### PR TITLE
chore: unify IR project wiring on ir-core

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -13,7 +13,6 @@
       "@tsgodown/config": ["packages/config/src/index.ts"],
       "@tsgodown/core": ["packages/core/src/index.ts"],
       "@tsgodown/analyzer": ["packages/analyzer/src/index.ts"],
-      "@tsgodown/ir": ["packages/ir/src/index.ts"],
       "@tsgodown/ir-core": ["packages/ir-core/src/index.ts"],
       "@tsgodown/emitter-go": ["packages/emitter-go/src/index.ts"],
       "@tsgodown/node-compat": ["packages/node-compat/src/index.ts"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
       "@tsgodown/config": ["packages/config/src/index.ts"],
       "@tsgodown/core": ["packages/core/src/index.ts"],
       "@tsgodown/analyzer": ["packages/analyzer/src/index.ts"],
-      "@tsgodown/ir": ["packages/ir/src/index.ts"],
+      "@tsgodown/ir-core": ["packages/ir-core/src/index.ts"],
       "@tsgodown/emitter-go": ["packages/emitter-go/src/index.ts"],
       "@tsgodown/tsdown-driver": ["packages/tsdown-driver/src/index.ts"],
       "@tsgodown/node-compat": ["packages/node-compat/src/index.ts"],
@@ -15,7 +15,7 @@
   },
   "references": [
     { "path": "packages/config" },
-    { "path": "packages/ir" },
+    { "path": "packages/ir-core" },
     { "path": "packages/analyzer" },
     { "path": "packages/emitter-go" },
     { "path": "packages/tsdown-driver" },


### PR DESCRIPTION
## Summary
- remove active TypeScript path aliases that pointed to `@tsgodown/ir`
- use `@tsgodown/ir-core` in root tsconfig path mapping
- switch root project references from `packages/ir` to `packages/ir-core`

## Validation
- pnpm install
- pnpm run lint
- pnpm run format:check
- pnpm run test:tdd
