### PR TITLE
ci: add merge_group trigger for merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   pull_request:
+  merge_group:
   push:
     branches: [main]
 


### PR DESCRIPTION
## Summary
- add `merge_group` trigger to CI workflow
- ensure required `test` check runs for merge queue batches

## Why
- merge queue validates temporary merge-group refs, not only pull_request refs
- without `merge_group`, required status checks can block queue merges

## Validation
- pnpm run lint
- pnpm run format:check
- pnpm run test:tdd
