### PR TITLE
fix: align package dist entries and cli runtime entrypoints

### DIFF
--- a/packages/analyzer/package.json
+++ b/packages/analyzer/package.json
@@ -10,5 +10,12 @@
   },
   "dependencies": {
     "@tsgodown/ir-core": "workspace:*"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
   }
 }

--- a/packages/analyzer/tsconfig.json
+++ b/packages/analyzer/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
-  "compilerOptions": { "baseUrl": "../../" },
+  "compilerOptions": {
+    "outDir": "dist",
+    "paths": {}
+  },
   "include": ["src"]
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -14,5 +14,12 @@
   },
   "dependencies": {
     "@tsgodown/core": "workspace:*"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
   }
 }

--- a/packages/cli/test/runtime-entry.test.js
+++ b/packages/cli/test/runtime-entry.test.js
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const repoRoot = path.resolve(import.meta.dirname, "../../..");
+const packagesDir = path.join(repoRoot, "packages");
+
+const packageExpectations = [
+  ["analyzer", ["main", "types", "exports"]],
+  ["cli", ["main", "types", "exports", "bin"]],
+  ["config", ["main", "types", "exports"]],
+  ["core", ["main", "types", "exports"]],
+  ["emitter-go", ["main", "types", "exports"]],
+  ["ir", ["main", "types", "exports"]],
+  ["ir-core", ["main", "types", "exports"]],
+  ["node-compat", ["main", "types", "exports"]],
+  ["pipeline", ["main", "types", "exports"]],
+  ["tsdown-driver", ["main", "types", "exports"]],
+];
+
+test("workspace package runtime entries point to emitted dist files", () => {
+  for (const [pkgName, fields] of packageExpectations) {
+    const packageRoot = path.join(packagesDir, pkgName);
+    const packageJson = JSON.parse(
+      fs.readFileSync(path.join(packageRoot, "package.json"), "utf8"),
+    );
+
+    for (const field of fields) {
+      if (field === "bin") {
+        const bins = Object.values(packageJson.bin ?? {});
+        assert.ok(
+          bins.length > 0,
+          `${pkgName} should declare at least one bin`,
+        );
+        for (const entry of bins) {
+          const target = path.join(packageRoot, entry);
+          assert.ok(
+            fs.existsSync(target),
+            `${pkgName} bin target missing: ${entry}`,
+          );
+        }
+        continue;
+      }
+
+      if (field === "exports") {
+        const exportsEntry = packageJson.exports?.["."];
+        assert.ok(exportsEntry, `${pkgName} exports["."] is required`);
+        assert.equal(
+          typeof exportsEntry.import,
+          "string",
+          `${pkgName} exports import must be a string`,
+        );
+        assert.equal(
+          typeof exportsEntry.types,
+          "string",
+          `${pkgName} exports types must be a string`,
+        );
+
+        for (const [kind, entry] of Object.entries({
+          import: exportsEntry.import,
+          types: exportsEntry.types,
+        })) {
+          const target = path.join(packageRoot, entry);
+          assert.ok(
+            fs.existsSync(target),
+            `${pkgName} exports ${kind} target missing: ${entry}`,
+          );
+        }
+        continue;
+      }
+
+      const entry = packageJson[field];
+      assert.equal(
+        typeof entry,
+        "string",
+        `${pkgName} ${field} must be a string`,
+      );
+      const target = path.join(packageRoot, entry);
+      assert.ok(
+        fs.existsSync(target),
+        `${pkgName} ${field} target missing: ${entry}`,
+      );
+    }
+  }
+});
+
+test("cli dist entry runs build/check/report/stages commands", () => {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "tsgodown-cli-runtime-"));
+
+  fs.mkdirSync(path.join(cwd, "src"), { recursive: true });
+  fs.writeFileSync(
+    path.join(cwd, "src", "index.ts"),
+    [
+      "const handler = () => ({ ok: true });",
+      "fastify.get('/health', handler);",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+
+  fs.writeFileSync(
+    path.join(cwd, "tsgodown.config.ts"),
+    [
+      "export default {",
+      "  entry: 'src/index.ts',",
+      "  outDir: 'dist-go'",
+      "};",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+
+  const cliEntry = path.join(repoRoot, "packages", "cli", "dist", "index.js");
+  for (const command of ["build", "check", "report", "stages"]) {
+    const result = spawnSync(process.execPath, [cliEntry, command, "--json"], {
+      cwd,
+      encoding: "utf8",
+    });
+
+    assert.equal(result.status, 0, `${command} failed: ${result.stderr}`);
+    const jsonStart = result.stdout.indexOf("{");
+    assert.ok(jsonStart >= 0, `${command} should print JSON output`);
+    const parsed = JSON.parse(result.stdout.slice(jsonStart));
+    assert.ok(parsed.cwd, `${command} should print result`);
+  }
+
+  assert.ok(
+    fs.existsSync(path.join(cwd, "dist-go", "main.go")),
+    "build command should emit dist-go/main.go",
+  );
+});

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
-  "compilerOptions": { "baseUrl": "../../" },
+  "compilerOptions": {
+    "outDir": "dist",
+    "paths": {}
+  },
   "include": ["src"]
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -7,5 +7,12 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "test": "node --test"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
   }
 }

--- a/packages/config/tsconfig.json
+++ b/packages/config/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
-  "compilerOptions": { "baseUrl": "../../" },
+  "compilerOptions": {
+    "outDir": "dist",
+    "paths": {}
+  },
   "include": ["src"]
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,6 +9,15 @@
     "test": "node --test"
   },
   "dependencies": {
+    "@tsgodown/analyzer": "workspace:*",
+    "@tsgodown/config": "workspace:*",
     "@tsgodown/pipeline": "workspace:*"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
   }
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
-  "compilerOptions": { "baseUrl": "../../" },
+  "compilerOptions": {
+    "outDir": "dist",
+    "paths": {}
+  },
   "include": ["src"]
 }

--- a/packages/emitter-go/package.json
+++ b/packages/emitter-go/package.json
@@ -10,5 +10,12 @@
   },
   "dependencies": {
     "@tsgodown/ir-core": "workspace:*"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
   }
 }

--- a/packages/emitter-go/tsconfig.json
+++ b/packages/emitter-go/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
-  "compilerOptions": { "baseUrl": "../../" },
+  "compilerOptions": {
+    "outDir": "dist",
+    "paths": {}
+  },
   "include": ["src"]
 }

--- a/packages/ir-core/package.json
+++ b/packages/ir-core/package.json
@@ -7,5 +7,12 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "test": "node --test"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
   }
 }

--- a/packages/ir-core/tsconfig.json
+++ b/packages/ir-core/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
-  "compilerOptions": { "baseUrl": "../../" },
+  "compilerOptions": {
+    "outDir": "dist",
+    "paths": {}
+  },
   "include": ["src"]
 }

--- a/packages/ir/package.json
+++ b/packages/ir/package.json
@@ -7,5 +7,12 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "test": "node --test"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
   }
 }

--- a/packages/ir/tsconfig.json
+++ b/packages/ir/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
-  "compilerOptions": { "baseUrl": "../../" },
+  "compilerOptions": {
+    "outDir": "dist",
+    "paths": {}
+  },
   "include": ["src"]
 }

--- a/packages/node-compat/package.json
+++ b/packages/node-compat/package.json
@@ -10,5 +10,12 @@
   },
   "dependencies": {
     "@tsgodown/ir-core": "workspace:*"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
   }
 }

--- a/packages/node-compat/src/index.ts
+++ b/packages/node-compat/src/index.ts
@@ -1,1 +1,1 @@
-export * from "./capability";
+export * from "./capability.js";

--- a/packages/node-compat/tsconfig.json
+++ b/packages/node-compat/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
-  "compilerOptions": { "baseUrl": "../../" },
+  "compilerOptions": {
+    "outDir": "dist",
+    "paths": {}
+  },
   "include": ["src"]
 }

--- a/packages/pipeline/package.json
+++ b/packages/pipeline/package.json
@@ -14,5 +14,12 @@
     "@tsgodown/node-compat": "workspace:*",
     "@tsgodown/emitter-go": "workspace:*",
     "@tsgodown/tsdown-driver": "workspace:*"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
   }
 }

--- a/packages/pipeline/tsconfig.json
+++ b/packages/pipeline/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
-  "compilerOptions": { "baseUrl": "../../" },
+  "compilerOptions": {
+    "outDir": "dist",
+    "paths": {}
+  },
   "include": ["src"]
 }

--- a/packages/tsdown-driver/package.json
+++ b/packages/tsdown-driver/package.json
@@ -11,5 +11,12 @@
   },
   "dependencies": {
     "tsdown": "^0.20.3"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
   }
 }

--- a/packages/tsdown-driver/tsconfig.json
+++ b/packages/tsdown-driver/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
-  "compilerOptions": { "baseUrl": "../../" },
+  "compilerOptions": {
+    "outDir": "dist",
+    "paths": {}
+  },
   "include": ["src"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,6 +37,12 @@ importers:
 
   packages/core:
     dependencies:
+      '@tsgodown/analyzer':
+        specifier: workspace:*
+        version: link:../analyzer
+      '@tsgodown/config':
+        specifier: workspace:*
+        version: link:../config
       '@tsgodown/pipeline':
         specifier: workspace:*
         version: link:../pipeline


### PR DESCRIPTION
## Summary
- align package runtime metadata (`main`, `types`, `exports`, `bin`) to the actual per-package dist output
- switch per-package TypeScript build output to local `dist/` directories and stop cross-package source path rewriting during build (`paths: {}` override)
- add missing direct runtime deps in `@tsgodown/core` for `@tsgodown/analyzer` and `@tsgodown/config`
- fix ESM runtime import in `@tsgodown/node-compat` (`./capability.js`)
- add CLI runtime integration tests to ensure:
  - package entry declarations point to real built files
  - CLI `build/check/report/stages` execute from `packages/cli/dist/index.js` without entrypoint errors

## Validation
- `pnpm install`
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run test:tdd`

All commands pass.

## Notes
This resolves entry/bin mismatches after build and verifies CLI runtime command flow from the compiled dist entrypoint.
