### PR TITLE
test: add pipeline/command e2e coverage

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "tsx src/index.ts",
-    "test": "node --test"
+    "test": "node --import tsx --test test/**/*.test.ts"
   },
   "dependencies": {
     "@tsgodown/core": "workspace:*"

--- a/packages/cli/test/commands.e2e.test.ts
+++ b/packages/cli/test/commands.e2e.test.ts
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { after, test } from "node:test";
+
+import { build, check, report, stages } from "../../core/src/index.ts";
+
+const tempDirs: string[] = [];
+
+after(() => {
+  for (const dir of tempDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function setupProject() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tsgodown-cli-e2e-"));
+  tempDirs.push(dir);
+
+  fs.mkdirSync(path.join(dir, "src"), { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, "src", "index.ts"),
+    [
+      "const fastify = {} as any;",
+      "const listUsers = () => {};",
+      "const getUser = () => {};",
+      "fastify.get('/users', listUsers);",
+      "fastify.get('/users/:id', getUser);",
+      "",
+    ].join("\n"),
+  );
+
+  fs.writeFileSync(
+    path.join(dir, "tsgodown.config.ts"),
+    `export default { entry: "src/index.ts", outDir: "dist-go" };\n`,
+  );
+
+  fs.mkdirSync(path.join(dir, "dist"), { recursive: true });
+  fs.writeFileSync(path.join(dir, "dist", "index.js"), "export {};\n");
+
+  return dir;
+}
+
+test("build/check/report/stages produce stable command payloads and deterministic Go output", async () => {
+  const cwd = setupProject();
+
+  const buildResult = await build(cwd);
+  assert.equal(buildResult.command, "build");
+  assert.deepEqual(buildResult.stages, [
+    "load-config",
+    "analyze",
+    "emit",
+    "onSuccess",
+  ]);
+  assert.equal(buildResult.targets.length, 1);
+  assert.equal(buildResult.targets[0].diagnostics.routes, 2);
+  assert.equal(buildResult.targets[0].emitted, true);
+
+  const goPath = path.join(cwd, "dist-go", "main.go");
+  assert.equal(fs.existsSync(goPath), true);
+  const go = fs.readFileSync(goPath, "utf8");
+  assert.ok(go.includes('http.HandleFunc("/users", route0)'));
+  assert.ok(go.includes('http.HandleFunc("/users/:id", route1)'));
+  assert.ok(go.includes('fmt.Fprintln(w, "TODO GET /users -> listUsers")'));
+  assert.ok(go.includes('fmt.Fprintln(w, "TODO GET /users/:id -> getUser")'));
+
+  const checkResult = await check(cwd);
+  assert.equal(checkResult.command, "check");
+  assert.equal(checkResult.targets[0].diagnostics.routes, 2);
+  assert.equal(checkResult.targets[0].emitted, true);
+
+  const reportResult = await report(cwd);
+  assert.equal(reportResult.command, "report");
+  assert.equal(reportResult.targets[0].diagnostics.routes, 2);
+
+  const stagesResult = await stages(cwd);
+  assert.deepEqual(stagesResult.stages, [
+    "load-config",
+    "analyze",
+    "emit",
+    "onSuccess",
+  ]);
+  assert.equal(stagesResult.targets[0].emitted, true);
+});

--- a/packages/pipeline/package.json
+++ b/packages/pipeline/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "test": "node --test"
+    "test": "node --import tsx --test test/**/*.test.ts"
   },
   "dependencies": {
     "@tsgodown/config": "workspace:*",

--- a/packages/pipeline/test/pipeline.e2e.test.ts
+++ b/packages/pipeline/test/pipeline.e2e.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { after, test } from "node:test";
+
+import { runPipeline } from "../src/index.ts";
+
+const tempDirs: string[] = [];
+
+after(() => {
+  for (const dir of tempDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function setupProject() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tsgodown-pipeline-e2e-"));
+  tempDirs.push(dir);
+
+  fs.mkdirSync(path.join(dir, "src"), { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, "src", "index.ts"),
+    [
+      "const fastify = {} as any;",
+      "const health = () => {};",
+      "const createUser = () => {};",
+      "fastify.get('/health', health);",
+      "fastify.post('/users', createUser);",
+      "",
+    ].join("\n"),
+  );
+
+  fs.writeFileSync(
+    path.join(dir, "tsgodown.config.ts"),
+    `export default { entry: "src/index.ts", outDir: "dist-go" };\n`,
+  );
+
+  fs.mkdirSync(path.join(dir, "dist"), { recursive: true });
+  fs.writeFileSync(path.join(dir, "dist", "index.js"), "export {};\n");
+
+  return dir;
+}
+
+test("runPipeline executes all stages and emits deterministic Go scaffold", async () => {
+  const cwd = setupProject();
+  const logs: string[] = [];
+
+  await runPipeline(cwd, {
+    log(message) {
+      logs.push(message);
+    },
+  });
+
+  assert.equal(logs.length, 4);
+  assert.match(logs[0], /\[BUILD_ARTIFACTS\]/);
+  assert.match(logs[1], /\[BUILD_IR\] analyzing entry: src\/index\.ts/);
+  assert.match(logs[2], /\[CAPABILITY_GATE\]/);
+  assert.match(logs[3], /\[EMIT_GO\] writing Go scaffold to dist-go/);
+
+  const goPath = path.join(cwd, "dist-go", "main.go");
+  assert.equal(fs.existsSync(goPath), true);
+
+  const emitted = fs.readFileSync(goPath, "utf8");
+  assert.ok(emitted.includes('http.HandleFunc("/health", route0)'));
+  assert.ok(emitted.includes('http.HandleFunc("/users", route1)'));
+  assert.ok(emitted.includes('fmt.Fprintln(w, "TODO GET /health -> health")'));
+  assert.ok(
+    emitted.includes('fmt.Fprintln(w, "TODO POST /users -> createUser")'),
+  );
+});


### PR DESCRIPTION
## Summary
- add pipeline integration/e2e test that verifies stage progression logs and scaffold emission
- add command-oriented integration test covering `build`, `check`, `report`, and `stages` flows
- assert deterministic Go output structure for discovered Fastify routes and handler mappings
- enable TS test execution in `cli` and `pipeline` packages using `node --import tsx --test`

## Validation
- `pnpm install`
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run test:tdd`

All checks passed.
