### PR TITLE
chore: deprecate legacy @tsgodown/ir from active usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,5 +33,9 @@ Generated output:
 - `pnpm run format:check`
 - `pnpm run test:tdd`
 
+## Migration Note
+- Legacy package `@tsgodown/ir` is deprecated and intentionally inactive.
+- Active IR model/package is `@tsgodown/ir-core`.
+
 ## License
 MIT

--- a/packages/cli/test/runtime-entry.test.js
+++ b/packages/cli/test/runtime-entry.test.js
@@ -14,7 +14,6 @@ const packageExpectations = [
   ["config", ["main", "types", "exports"]],
   ["core", ["main", "types", "exports"]],
   ["emitter-go", ["main", "types", "exports"]],
-  ["ir", ["main", "types", "exports"]],
   ["ir-core", ["main", "types", "exports"]],
   ["node-compat", ["main", "types", "exports"]],
   ["pipeline", ["main", "types", "exports"]],
@@ -85,6 +84,22 @@ test("workspace package runtime entries point to emitted dist files", () => {
       );
     }
   }
+});
+
+test("legacy @tsgodown/ir package is marked inactive", () => {
+  const packageRoot = path.join(packagesDir, "ir");
+  const packageJson = JSON.parse(
+    fs.readFileSync(path.join(packageRoot, "package.json"), "utf8"),
+  );
+
+  assert.equal(packageJson.private, true);
+  assert.equal(packageJson.main, undefined);
+  assert.equal(packageJson.types, undefined);
+  assert.equal(packageJson.exports, undefined);
+  assert.ok(
+    typeof packageJson.description === "string" &&
+      packageJson.description.includes("DEPRECATED"),
+  );
 });
 
 test("cli dist entry runs build/check/report/stages commands", () => {

--- a/packages/ir/README.md
+++ b/packages/ir/README.md
@@ -1,0 +1,7 @@
+# @tsgodown/ir (legacy)
+
+This package is deprecated and kept only as a placeholder during migration.
+
+- Do not add new imports from `@tsgodown/ir`.
+- Use `@tsgodown/ir-core` for all active IR types and semantics.
+- This package is marked `private` and has no active build/test/runtime entrypoints.

--- a/packages/ir/package.json
+++ b/packages/ir/package.json
@@ -1,18 +1,8 @@
 {
   "name": "@tsgodown/ir",
   "version": "0.0.1",
+  "private": true,
   "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "scripts": {
-    "build": "tsc -p tsconfig.json",
-    "test": "node --test"
-  },
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "default": "./dist/index.js"
-    }
-  }
+  "description": "DEPRECATED legacy IR package. Inactive in workspace builds; use @tsgodown/ir-core.",
+  "scripts": {}
 }


### PR DESCRIPTION
## Summary
- deprecate legacy `@tsgodown/ir` package and mark it inactive (`private`, no build/test/runtime entrypoints)
- remove active package runtime-entry expectations for `packages/ir` from CLI runtime contract tests
- add migration notes in docs (`README.md` and `packages/ir/README.md`) directing usage to `@tsgodown/ir-core`

## Why
`@tsgodown/ir` is legacy and should not be part of active code/config/build usage. The active IR surface is `@tsgodown/ir-core`.

## Validation
- `pnpm install`
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run test:tdd`

All passed.

## Migration note
If any downstream code still imports `@tsgodown/ir`, migrate imports to `@tsgodown/ir-core`.
