### PR TITLE
feat(node-compat): strengthen capability gate coverage and diagnostics

### DIFF
--- a/packages/node-compat/src/capability.ts
+++ b/packages/node-compat/src/capability.ts
@@ -46,6 +46,8 @@ export interface CapabilityDiagnostic {
   capability: CapabilityKey;
   status: CapabilityStatus;
   source?: CapabilitySource;
+  cause?: string;
+  guidance?: string;
 }
 
 export interface CapabilityCheckOptions {
@@ -127,6 +129,15 @@ export const CAPABILITY_MATRIX: Record<CapabilityKey, CapabilityRule> = {
 
 type ProgramIRLike = CoreProgramIR | Record<string, unknown>;
 
+const DIAGNOSTIC_CAPABILITY_MAP: Record<string, CapabilityKey> = {
+  NODE_FS_BASIC_REQUIRED: "node.fs.basic",
+  NODE_PATH_BASIC_REQUIRED: "node.path.basic",
+  NODE_URL_BASIC_REQUIRED: "node.url.basic",
+  NODE_PROCESS_ENV_REQUIRED: "node.process.env",
+  NODE_BUFFER_BASIC_REQUIRED: "node.buffer.basic",
+  RUNTIME_EVENT_LOOP_REQUIRED: "runtime.event_loop",
+};
+
 function sourceFromUnknown(value: unknown): CapabilitySource | undefined {
   if (!value || typeof value !== "object") return undefined;
   const v = value as Record<string, unknown>;
@@ -157,6 +168,7 @@ function pushUnique(
  * - routes -> route.basic
  * - modules.imports.kind(esm/cjs) -> module.esm/module.cjs
  * - handlers.async -> handler.async
+ * - diagnostics.code -> node/runtime feature requirements
  */
 export function collectRequiredCapabilities(
   ir: ProgramIRLike,
@@ -210,6 +222,23 @@ export function collectRequiredCapabilities(
     }
   }
 
+  const diagnostics = Array.isArray(rec.diagnostics) ? rec.diagnostics : [];
+  for (const d of diagnostics) {
+    const dr = d as Record<string, unknown>;
+    const code = typeof dr.code === "string" ? dr.code : "";
+    const mapped = DIAGNOSTIC_CAPABILITY_MAP[code];
+    if (!mapped) continue;
+    const detail =
+      typeof dr.message === "string" && dr.message.length > 0
+        ? ` (${dr.message})`
+        : "";
+    pushUnique(required, seen, {
+      capability: mapped,
+      reason: `Analyzer diagnostic ${code}${detail}`,
+      source: sourceFromUnknown(dr.source),
+    });
+  }
+
   return required;
 }
 
@@ -220,6 +249,18 @@ function isSupportedStatus(
   if (status === CapabilityStatus.DONE) return true;
   if (status === CapabilityStatus.WIP && allowWip) return true;
   return false;
+}
+
+function formatSource(source?: CapabilitySource): string {
+  if (!source) return "unknown";
+  const line = source.line ?? "?";
+  const column = source.column ?? "?";
+  const suffix = source.viaSourceMap ? " (via source map)" : "";
+  return `${source.file}:${line}:${column}${suffix}`;
+}
+
+function buildGuidance(rule: CapabilityRule): string {
+  return `Update source to avoid '${rule.key}' usage, or implement ${rule.scope} strategy '${rule.strategy}'. See docs/specs/CAPABILITY_MATRIX.md.`;
 }
 
 export function checkCapabilities(
@@ -236,13 +277,21 @@ export function checkCapabilities(
     const rule = CAPABILITY_MATRIX[req.capability];
     if (isSupportedStatus(rule.status, allowWip)) continue;
 
+    const cause = `Capability status is ${rule.status} for required '${req.capability}' (${req.reason}).`;
+    const guidance = buildGuidance(rule);
+    const sourceLocation = formatSource(req.source);
+
     diagnostics.push({
       level: "error",
       code: "CAPABILITY_UNMET",
-      message: `Capability '${req.capability}' is required (${req.reason}) but current status is ${rule.status}.`,
+      message:
+        `Capability '${req.capability}' is not supported (status=${rule.status}) at ${sourceLocation}. ` +
+        `Cause: ${cause} Guidance: ${guidance}`,
       capability: req.capability,
       status: rule.status,
       source: req.source,
+      cause,
+      guidance,
     });
 
     if (failFast) break;

--- a/packages/node-compat/test/capability.test.ts
+++ b/packages/node-compat/test/capability.test.ts
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { checkCapabilities } from "../src/capability.ts";
+import {
+  CapabilityStatus,
+  checkCapabilities,
+  collectRequiredCapabilities,
+} from "../src/capability.ts";
 
 test("passes when only WIP-supported capabilities are required", () => {
   const ir = {
@@ -23,9 +27,69 @@ test("passes when only WIP-supported capabilities are required", () => {
   assert.equal(result.diagnostics.length, 0);
 });
 
-test("fails fast with source-aware diagnostic for unmet capability", () => {
+test("collectRequiredCapabilities expands node/runtime feature detection from diagnostics", () => {
   const ir = {
-    routes: [{ method: "GET", path: "/x", handlerRef: "h1" }],
+    routes: [],
+    modules: [],
+    handlers: [],
+    diagnostics: [
+      {
+        level: "warn",
+        code: "NODE_FS_BASIC_REQUIRED",
+        message: "uses fs.readFileSync",
+        source: { file: "src/fs.ts", line: 2, column: 4 },
+      },
+      {
+        level: "warn",
+        code: "NODE_PATH_BASIC_REQUIRED",
+        message: "uses path.join",
+        source: { file: "src/path.ts", line: 3, column: 2 },
+      },
+      {
+        level: "warn",
+        code: "NODE_URL_BASIC_REQUIRED",
+        message: "uses URL",
+        source: { file: "src/url.ts", line: 5, column: 1 },
+      },
+      {
+        level: "warn",
+        code: "NODE_PROCESS_ENV_REQUIRED",
+        message: "uses process.env",
+        source: { file: "src/env.ts", line: 8, column: 7 },
+      },
+      {
+        level: "warn",
+        code: "NODE_BUFFER_BASIC_REQUIRED",
+        message: "uses Buffer.from",
+        source: { file: "src/buf.ts", line: 13, column: 9 },
+      },
+      {
+        level: "warn",
+        code: "RUNTIME_EVENT_LOOP_REQUIRED",
+        message: "uses setTimeout",
+        source: { file: "src/timers.ts", line: 21, column: 3 },
+      },
+    ],
+  };
+
+  const required = collectRequiredCapabilities(ir);
+  const capabilities = required.map((r) => r.capability);
+
+  assert.deepEqual(capabilities, [
+    "node.fs.basic",
+    "node.path.basic",
+    "node.url.basic",
+    "node.process.env",
+    "node.buffer.basic",
+    "runtime.event_loop",
+  ]);
+  assert.equal(required[0]?.source?.file, "src/fs.ts");
+  assert.equal(required[5]?.source?.line, 21);
+});
+
+test("fails fast with source-aware diagnostic including cause and guidance", () => {
+  const ir = {
+    routes: [],
     modules: [
       {
         id: "m1",
@@ -57,6 +121,44 @@ test("fails fast with source-aware diagnostic for unmet capability", () => {
 
   const [diag] = result.diagnostics;
   assert.equal(diag.code, "CAPABILITY_UNMET");
+  assert.equal(diag.capability, "handler.async");
+  assert.equal(diag.status, CapabilityStatus.TODO);
   assert.equal(diag.source?.file, "src/handlers.ts");
   assert.equal(diag.source?.line, 10);
+  assert.match(diag.message, /src\/handlers.ts:10:3/);
+  assert.match(diag.message, /Cause:/);
+  assert.match(diag.message, /Guidance:/);
+  assert.equal(typeof diag.cause, "string");
+  assert.equal(typeof diag.guidance, "string");
+});
+
+test("reports all unmet capabilities when failFast is disabled", () => {
+  const ir = {
+    routes: [],
+    modules: [
+      {
+        id: "m1",
+        sourcePath: "src/app.ts",
+        exports: [],
+        imports: [{ spec: "legacy-lib", kind: "cjs" }],
+      },
+    ],
+    handlers: [{ id: "h1", params: [], async: true }],
+    diagnostics: [
+      {
+        level: "warn",
+        code: "NODE_FS_BASIC_REQUIRED",
+        message: "uses fs.readFileSync",
+        source: { file: "src/fs.ts", line: 2, column: 4 },
+      },
+    ],
+  };
+
+  const result = checkCapabilities(ir, { failFast: false });
+  assert.equal(result.ok, false);
+  assert.equal(result.diagnostics.length, 3);
+  assert.deepEqual(
+    result.diagnostics.map((d) => d.capability),
+    ["handler.async", "module.cjs", "node.fs.basic"],
+  );
 });


### PR DESCRIPTION
## Summary
- expand capability requirement extraction to include analyzer diagnostics for node/runtime features:
  - `NODE_FS_BASIC_REQUIRED` -> `node.fs.basic`
  - `NODE_PATH_BASIC_REQUIRED` -> `node.path.basic`
  - `NODE_URL_BASIC_REQUIRED` -> `node.url.basic`
  - `NODE_PROCESS_ENV_REQUIRED` -> `node.process.env`
  - `NODE_BUFFER_BASIC_REQUIRED` -> `node.buffer.basic`
  - `RUNTIME_EVENT_LOOP_REQUIRED` -> `runtime.event_loop`
- improve capability gate diagnostics with fail-fast context:
  - source location formatting (`file:line:column`, source map marker)
  - explicit `cause`
  - actionable `guidance` with strategy + docs pointer
- add node-compat tests for expanded coverage and fail-fast/all-errors behavior

## Diagnostic examples
Example unmet capability message:

```text
Capability 'handler.async' is not supported (status=TODO) at src/handlers.ts:10:3 (via source map).
Cause: Capability status is TODO for required 'handler.async' (HandlerIR.async is true).
Guidance: Update source to avoid 'handler.async' usage, or implement control-flow strategy 'goroutine + await shim'. See docs/specs/CAPABILITY_MATRIX.md.
```

Example extraction from analyzer diagnostics:

```text
Analyzer diagnostic NODE_FS_BASIC_REQUIRED (uses fs.readFileSync)
-> requires capability node.fs.basic
```

## Validation
- `pnpm install`
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run test:tdd`
