### PR TITLE
feat(emitter-go): improve Go scaffold route structure and TODO stubs

### DIFF
--- a/packages/cli/test/commands.e2e.test.ts
+++ b/packages/cli/test/commands.e2e.test.ts
@@ -60,10 +60,19 @@ test("build/check/report/stages produce stable command payloads and deterministi
   const goPath = path.join(cwd, "dist-go", "main.go");
   assert.equal(fs.existsSync(goPath), true);
   const go = fs.readFileSync(goPath, "utf8");
-  assert.ok(go.includes('http.HandleFunc("/users", route0)'));
-  assert.ok(go.includes('http.HandleFunc("/users/:id", route1)'));
-  assert.ok(go.includes('fmt.Fprintln(w, "TODO GET /users -> listUsers")'));
-  assert.ok(go.includes('fmt.Fprintln(w, "TODO GET /users/:id -> getUser")'));
+  assert.ok(go.includes('mux.HandleFunc("/users", route0)'));
+  assert.ok(go.includes('mux.HandleFunc("/users/:id", route1)'));
+  assert.ok(go.includes("if req.Method != http.MethodGet {"));
+  assert.ok(
+    go.includes(
+      'fmt.Fprintln(w, "TODO implement handler listUsers for GET /users")',
+    ),
+  );
+  assert.ok(
+    go.includes(
+      'fmt.Fprintln(w, "TODO implement handler getUser for GET /users/:id")',
+    ),
+  );
 
   const checkResult = await check(cwd);
   assert.equal(checkResult.command, "check");

--- a/packages/emitter-go/package.json
+++ b/packages/emitter-go/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "test": "node --test"
+    "test": "node --import tsx --test test/**/*.test.ts"
   },
   "dependencies": {
     "@tsgodown/ir-core": "workspace:*"

--- a/packages/emitter-go/src/index.ts
+++ b/packages/emitter-go/src/index.ts
@@ -1,27 +1,83 @@
 import fs from "node:fs";
 import path from "node:path";
-import type { ProgramIR } from "@tsgodown/ir-core";
+import type { ProgramIR, RouteIR } from "@tsgodown/ir-core";
+
+function routeHandlerName(index: number): string {
+  return `route${index}`;
+}
+
+function toGoHttpMethod(method: RouteIR["method"]): string {
+  switch (method) {
+    case "GET":
+      return "http.MethodGet";
+    case "POST":
+      return "http.MethodPost";
+    case "PUT":
+      return "http.MethodPut";
+    case "DELETE":
+      return "http.MethodDelete";
+    case "PATCH":
+      return "http.MethodPatch";
+    default:
+      return JSON.stringify(method);
+  }
+}
+
+function quoteGo(value: string): string {
+  return JSON.stringify(value);
+}
+
+function emitRoute(route: RouteIR, index: number): string[] {
+  const methodRef = toGoHttpMethod(route.method);
+  const todoMessage = `TODO implement handler ${route.handlerRef} for ${route.method} ${route.path}`;
+
+  return [
+    `func ${routeHandlerName(index)}(w http.ResponseWriter, req *http.Request) {`,
+    `\tif req.Method != ${methodRef} {`,
+    `\t\tw.Header().Set("Allow", ${methodRef})`,
+    '\t\thttp.Error(w, "method not allowed", http.StatusMethodNotAllowed)',
+    "\t\treturn",
+    "\t}",
+    "",
+    `\t// TODO(tsgodown): Implement handler ${quoteGo(route.handlerRef)} for ${route.method} ${route.path}.`,
+    "\t//   1) Replace this scaffold with application logic.",
+    "\t//   2) Validate request input and map to domain arguments.",
+    "\t//   3) Write response status, headers, and body.",
+    '\tw.Header().Set("Content-Type", "text/plain; charset=utf-8")',
+    "\tw.WriteHeader(http.StatusNotImplemented)",
+    `\tfmt.Fprintln(w, ${quoteGo(todoMessage)})`,
+    "}",
+    "",
+  ];
+}
 
 export function emitGoProject(ir: ProgramIR, outDir: string) {
   fs.mkdirSync(outDir, { recursive: true });
   const lines: string[] = [];
-  lines.push("package main\n");
-  lines.push('import (\n\t"fmt"\n\t"net/http"\n)\n');
-  lines.push("func main() {");
-  for (const [idx, r] of ir.routes.entries()) {
-    lines.push(`\thttp.HandleFunc("${r.path}", route${idx})`);
-  }
-  lines.push('\tfmt.Println("tsgodown scaffold :18081")');
-  lines.push('\t_ = http.ListenAndServe(":18081", nil)');
-  lines.push("}\n");
 
-  for (const [idx, r] of ir.routes.entries()) {
-    lines.push(`func route${idx}(w http.ResponseWriter, req *http.Request) {`);
+  lines.push("package main", "");
+  lines.push("import (", '\t"fmt"', '\t"net/http"', ")", "");
+
+  lines.push("func registerRoutes(mux *http.ServeMux) {");
+  for (const [index, route] of ir.routes.entries()) {
     lines.push(
-      `\tfmt.Fprintln(w, "TODO ${r.method} ${r.path} -> ${r.handlerRef}")`,
+      `\tmux.HandleFunc(${quoteGo(route.path)}, ${routeHandlerName(index)})`,
     );
-    lines.push("}\n");
+  }
+  lines.push("}", "");
+
+  lines.push("func main() {");
+  lines.push("\tmux := http.NewServeMux()");
+  lines.push("\tregisterRoutes(mux)");
+  lines.push('\tfmt.Println("tsgodown scaffold listening on :18081")');
+  lines.push('\tif err := http.ListenAndServe(":18081", mux); err != nil {');
+  lines.push('\t\tfmt.Println("server exited:", err)');
+  lines.push("\t}");
+  lines.push("}", "");
+
+  for (const [index, route] of ir.routes.entries()) {
+    lines.push(...emitRoute(route, index));
   }
 
-  fs.writeFileSync(path.join(outDir, "main.go"), lines.join("\n"));
+  fs.writeFileSync(path.join(outDir, "main.go"), `${lines.join("\n")}`);
 }

--- a/packages/emitter-go/test/emit-go.test.ts
+++ b/packages/emitter-go/test/emit-go.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { after, test } from "node:test";
+import type { ProgramIR } from "@tsgodown/ir-core";
+
+import { emitGoProject } from "../src/index.ts";
+
+const tempDirs: string[] = [];
+
+after(() => {
+  for (const dir of tempDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function createOutDir() {
+  const dir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "tsgodown-emitter-go-test-"),
+  );
+  tempDirs.push(dir);
+  return dir;
+}
+
+const sampleIr: ProgramIR = {
+  modules: [],
+  handlers: [],
+  diagnostics: [],
+  routes: [
+    { method: "GET", path: "/health", handlerRef: "health" },
+    { method: "POST", path: "/users", handlerRef: "createUser" },
+  ],
+};
+
+test("emitGoProject emits deterministic main.go scaffold with route registration and actionable TODO stubs", () => {
+  const outDir = createOutDir();
+
+  emitGoProject(sampleIr, outDir);
+
+  const emitted = fs.readFileSync(path.join(outDir, "main.go"), "utf8");
+
+  assert.match(emitted, /func registerRoutes\(mux \*http\.ServeMux\) \{/);
+  assert.match(emitted, /mux\.HandleFunc\("\/health", route0\)/);
+  assert.match(emitted, /mux\.HandleFunc\("\/users", route1\)/);
+  assert.match(emitted, /if req\.Method != http\.MethodGet \{/);
+  assert.match(emitted, /if req\.Method != http\.MethodPost \{/);
+  assert.match(
+    emitted,
+    /TODO\(tsgodown\): Implement handler "health" for GET \/health\./,
+  );
+  assert.match(
+    emitted,
+    /TODO\(tsgodown\): Implement handler "createUser" for POST \/users\./,
+  );
+  assert.match(emitted, /w\.WriteHeader\(http\.StatusNotImplemented\)/);
+  assert.match(
+    emitted,
+    /fmt\.Fprintln\(w, "TODO implement handler health for GET \/health"\)/,
+  );
+  assert.match(
+    emitted,
+    /fmt\.Fprintln\(w, "TODO implement handler createUser for POST \/users"\)/,
+  );
+});
+
+test("emitGoProject output is byte-for-byte stable across repeated runs", () => {
+  const firstOutDir = createOutDir();
+  const secondOutDir = createOutDir();
+
+  emitGoProject(sampleIr, firstOutDir);
+  emitGoProject(sampleIr, secondOutDir);
+
+  const first = fs.readFileSync(path.join(firstOutDir, "main.go"), "utf8");
+  const second = fs.readFileSync(path.join(secondOutDir, "main.go"), "utf8");
+
+  assert.equal(first, second);
+});

--- a/packages/pipeline/test/pipeline.e2e.test.ts
+++ b/packages/pipeline/test/pipeline.e2e.test.ts
@@ -62,10 +62,18 @@ test("runPipeline executes all stages and emits deterministic Go scaffold", asyn
   assert.equal(fs.existsSync(goPath), true);
 
   const emitted = fs.readFileSync(goPath, "utf8");
-  assert.ok(emitted.includes('http.HandleFunc("/health", route0)'));
-  assert.ok(emitted.includes('http.HandleFunc("/users", route1)'));
-  assert.ok(emitted.includes('fmt.Fprintln(w, "TODO GET /health -> health")'));
+  assert.ok(emitted.includes('mux.HandleFunc("/health", route0)'));
+  assert.ok(emitted.includes('mux.HandleFunc("/users", route1)'));
+  assert.ok(emitted.includes("if req.Method != http.MethodGet {"));
+  assert.ok(emitted.includes("if req.Method != http.MethodPost {"));
   assert.ok(
-    emitted.includes('fmt.Fprintln(w, "TODO POST /users -> createUser")'),
+    emitted.includes(
+      'fmt.Fprintln(w, "TODO implement handler health for GET /health")',
+    ),
+  );
+  assert.ok(
+    emitted.includes(
+      'fmt.Fprintln(w, "TODO implement handler createUser for POST /users")',
+    ),
   );
 });


### PR DESCRIPTION
## Summary
- refactor Go scaffold generation to use a structured `registerRoutes(mux *http.ServeMux)` entrypoint
- switch startup flow to explicit `http.NewServeMux()` wiring and surfaced server-exit logging
- upgrade per-route stubs with method guards (`Allow` + 405) and actionable TODO guidance steps
- keep deterministic emission via stable route ordering and byte-for-byte deterministic output assertions
- add dedicated emitter-go structural tests and determinism test; update CLI/pipeline e2e expectations accordingly

## Before / After (generated `main.go`)
### Before
- registered handlers directly in `main()` with `http.HandleFunc`
- route stub response was a single opaque placeholder line:
  - `TODO METHOD /path -> handlerRef`
- no explicit method guard logic in generated handlers

### After
- routes are registered in `registerRoutes(mux)` and invoked from `main()` via `http.NewServeMux()`
- each generated route now includes:
  - method enforcement (`if req.Method != http.MethodX`) with `Allow` header + 405 response
  - explicit TODO comment checklist (implement logic, validate input, write response)
  - deterministic not-implemented scaffold response (`StatusNotImplemented` + stable TODO message)

## Validation
- `pnpm install`
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run test:tdd`

All checks passed.
