### PR TITLE
feat(analyzer): expand fastify route extraction and diagnostics

### DIFF
--- a/packages/analyzer/src/index.ts
+++ b/packages/analyzer/src/index.ts
@@ -1,21 +1,29 @@
 import fs from "node:fs";
 import type { DiagnosticIR, ProgramIR, RouteIR } from "@tsgodown/ir-core";
 
+type PluginDef = {
+  paramName: string;
+  body: string;
+};
+
+const HTTP_METHODS = ["GET", "POST", "PUT", "DELETE", "PATCH"] as const;
+
 export function analyzeFastifyEntry(entryFile: string): ProgramIR {
   const src = fs.readFileSync(entryFile, "utf-8");
-  const routeRe =
-    /fastify\.(get|post|put|delete|patch)\(\s*['\"]([^'\"]+)['\"]\s*,\s*([A-Za-z_][A-Za-z0-9_]*)/g;
-
-  const routes: RouteIR[] = [];
-  for (const m of src.matchAll(routeRe)) {
-    routes.push({
-      method: m[1].toUpperCase() as RouteIR["method"],
-      path: m[2],
-      handlerRef: m[3],
-    });
-  }
-
   const diagnostics: DiagnosticIR[] = [];
+  const routes: RouteIR[] = [];
+
+  const pluginDefs = collectPluginDefinitions(src);
+  analyzeScope({
+    src,
+    file: entryFile,
+    diagnostics,
+    routes,
+    pluginDefs,
+    instanceName: "fastify",
+    prefix: "",
+  });
+
   if (src.includes("import(")) {
     diagnostics.push({
       level: "warn",
@@ -31,4 +39,377 @@ export function analyzeFastifyEntry(entryFile: string): ProgramIR {
     handlers: [],
     diagnostics,
   };
+}
+
+function analyzeScope(params: {
+  src: string;
+  file: string;
+  diagnostics: DiagnosticIR[];
+  routes: RouteIR[];
+  pluginDefs: Map<string, PluginDef>;
+  instanceName: string;
+  prefix: string;
+}) {
+  const { src, file, diagnostics, routes, pluginDefs, instanceName, prefix } =
+    params;
+
+  const callRe = new RegExp(
+    String.raw`${escapeRe(instanceName)}\.(get|post|put|delete|patch)\s*\(\s*([^,\n]+?)\s*,\s*([^,\n\)]+)`,
+    "g",
+  );
+
+  for (const m of src.matchAll(callRe)) {
+    const method = m[1].toUpperCase() as RouteIR["method"];
+    const pathExpr = m[2].trim();
+    const handlerExpr = m[3].trim();
+
+    const path = extractQuoted(pathExpr);
+    if (!path) {
+      diagnostics.push({
+        level: "warn",
+        code: "ANALYZER_UNSUPPORTED_DYNAMIC_PATH",
+        message: `unsupported dynamic path in ${instanceName}.${m[1]}(...)`,
+        source: { file },
+      });
+      continue;
+    }
+
+    const handlerRef = extractHandlerRef(handlerExpr);
+    if (!handlerRef) {
+      diagnostics.push({
+        level: "warn",
+        code: "ANALYZER_UNSUPPORTED_INLINE_HANDLER",
+        message: `unsupported non-reference handler in ${instanceName}.${m[1]}('${path}', handler)`,
+        source: { file },
+      });
+      continue;
+    }
+
+    routes.push({ method, path: joinPath(prefix, path), handlerRef });
+  }
+
+  const routeObjRe = new RegExp(
+    String.raw`${escapeRe(instanceName)}\.route\s*\(\s*\{([\s\S]*?)\}\s*\)`,
+    "g",
+  );
+  for (const m of src.matchAll(routeObjRe)) {
+    const body = m[1];
+    const methodRaw = extractObjectStringProp(body, "method");
+    const method = methodRaw ? methodRaw.toUpperCase() : undefined;
+    const path =
+      extractObjectStringProp(body, "url") ??
+      extractObjectStringProp(body, "path");
+    const handlerRef = extractHandlerRef(
+      extractObjectValue(body, "handler") ?? "",
+    );
+
+    if (
+      !method ||
+      !HTTP_METHODS.includes(method as (typeof HTTP_METHODS)[number])
+    ) {
+      diagnostics.push({
+        level: "warn",
+        code: "ANALYZER_UNSUPPORTED_ROUTE_OBJECT",
+        message: `unsupported route object method in ${instanceName}.route({...})`,
+        source: { file },
+      });
+      continue;
+    }
+    if (!path) {
+      diagnostics.push({
+        level: "warn",
+        code: "ANALYZER_UNSUPPORTED_DYNAMIC_PATH",
+        message: `unsupported route object path in ${instanceName}.route({...})`,
+        source: { file },
+      });
+      continue;
+    }
+    if (!handlerRef) {
+      diagnostics.push({
+        level: "warn",
+        code: "ANALYZER_UNSUPPORTED_INLINE_HANDLER",
+        message: `unsupported route object handler in ${instanceName}.route({...})`,
+        source: { file },
+      });
+      continue;
+    }
+
+    routes.push({
+      method: method as RouteIR["method"],
+      path: joinPath(prefix, path),
+      handlerRef,
+    });
+  }
+
+  const registerNeedle = `${instanceName}.register`;
+  let searchIndex = 0;
+  while (true) {
+    const at = src.indexOf(registerNeedle, searchIndex);
+    if (at < 0) break;
+    const openParen = src.indexOf("(", at + registerNeedle.length);
+    if (openParen < 0) break;
+
+    const closeParen = findMatching(src, openParen, "(", ")");
+    if (closeParen < 0) break;
+
+    const args = splitTopLevel(src.slice(openParen + 1, closeParen));
+    const pluginExpr = (args[0] ?? "").trim();
+    const optionsExpr = (args[1] ?? "").trim();
+    const prefixFromRegister =
+      extractObjectStringProp(optionsExpr, "prefix") ?? "";
+    const nextPrefix = joinPath(prefix, prefixFromRegister);
+
+    const inlinePlugin = parsePluginExpression(pluginExpr);
+    if (inlinePlugin) {
+      analyzeScope({
+        src: inlinePlugin.body,
+        file,
+        diagnostics,
+        routes,
+        pluginDefs,
+        instanceName: inlinePlugin.paramName,
+        prefix: nextPrefix,
+      });
+      searchIndex = closeParen + 1;
+      continue;
+    }
+
+    const pluginRef = extractHandlerRef(pluginExpr);
+    if (pluginRef) {
+      const def = pluginDefs.get(pluginRef);
+      if (def) {
+        analyzeScope({
+          src: def.body,
+          file,
+          diagnostics,
+          routes,
+          pluginDefs,
+          instanceName: def.paramName,
+          prefix: nextPrefix,
+        });
+      } else {
+        diagnostics.push({
+          level: "warn",
+          code: "ANALYZER_UNRESOLVED_PLUGIN",
+          message: `register plugin '${pluginRef}' could not be resolved in current file`,
+          source: { file },
+        });
+      }
+      searchIndex = closeParen + 1;
+      continue;
+    }
+
+    diagnostics.push({
+      level: "warn",
+      code: "ANALYZER_UNSUPPORTED_REGISTER_CALLBACK",
+      message: `unsupported register callback pattern on ${instanceName}.register(...)`,
+      source: { file },
+    });
+
+    searchIndex = closeParen + 1;
+  }
+}
+
+function collectPluginDefinitions(src: string): Map<string, PluginDef> {
+  const map = new Map<string, PluginDef>();
+
+  const fnRe = /function\s+([A-Za-z_$][\w$]*)\s*\(([^)]*)\)\s*\{/g;
+  for (const m of src.matchAll(fnRe)) {
+    const name = m[1];
+    const params = m[2];
+    const openBrace = (m.index ?? 0) + m[0].length - 1;
+    const closeBrace = findMatching(src, openBrace, "{", "}");
+    if (closeBrace < 0) continue;
+    const body = src.slice(openBrace + 1, closeBrace);
+    const paramName = firstParam(params);
+    if (!paramName) continue;
+    map.set(name, { paramName, body });
+  }
+
+  const fnExprRe =
+    /(const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(?:async\s+)?function(?:\s+[A-Za-z_$][\w$]*)?\s*\(([^)]*)\)\s*\{/g;
+  for (const m of src.matchAll(fnExprRe)) {
+    const name = m[2];
+    const paramName = firstParam(m[3]);
+    if (!paramName) continue;
+
+    const openBrace = (m.index ?? 0) + m[0].length - 1;
+    const closeBrace = findMatching(src, openBrace, "{", "}");
+    if (closeBrace < 0) continue;
+    const body = src.slice(openBrace + 1, closeBrace);
+    map.set(name, { paramName, body });
+  }
+
+  const arrowExprRe =
+    /(const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(?:async\s+)?(?:\(([^)]*)\)|([A-Za-z_$][\w$]*))\s*=>\s*\{/g;
+  for (const m of src.matchAll(arrowExprRe)) {
+    const name = m[2];
+    const rawParams = m[3] ?? m[4] ?? "";
+    const paramName = firstParam(rawParams);
+    if (!paramName) continue;
+
+    const openBrace = (m.index ?? 0) + m[0].length - 1;
+    const closeBrace = findMatching(src, openBrace, "{", "}");
+    if (closeBrace < 0) continue;
+    const body = src.slice(openBrace + 1, closeBrace);
+    map.set(name, { paramName, body });
+  }
+
+  return map;
+}
+
+function parsePluginExpression(expr: string): PluginDef | null {
+  const fnRe =
+    /^(?:async\s+)?function(?:\s+[A-Za-z_$][\w$]*)?\s*\(([^)]*)\)\s*\{([\s\S]*)\}$/;
+  const fn = expr.match(fnRe);
+  if (fn) {
+    const paramName = firstParam(fn[1]);
+    if (!paramName) return null;
+    return { paramName, body: fn[2] };
+  }
+
+  const arrowBlockRe =
+    /^(?:async\s+)?(?:\(([^)]*)\)|([A-Za-z_$][\w$]*))\s*=>\s*\{([\s\S]*)\}$/;
+  const arrow = expr.match(arrowBlockRe);
+  if (arrow) {
+    const rawParams = arrow[1] ?? arrow[2] ?? "";
+    const paramName = firstParam(rawParams);
+    if (!paramName) return null;
+    return { paramName, body: arrow[3] };
+  }
+
+  return null;
+}
+
+function firstParam(params: string): string | null {
+  const first = params
+    .split(",")
+    .map((v) => v.trim())
+    .filter(Boolean)[0];
+  if (!first) return null;
+  const cleaned = first
+    .replace(/^\.\.\./, "")
+    .split(/[=:]/)[0]
+    .trim();
+  return /^[A-Za-z_$][\w$]*$/.test(cleaned) ? cleaned : null;
+}
+
+function findMatching(
+  src: string,
+  openIndex: number,
+  open: string,
+  close: string,
+): number {
+  let depth = 0;
+  let quote: string | null = null;
+  let escaped = false;
+
+  for (let i = openIndex; i < src.length; i++) {
+    const ch = src[i];
+    if (quote) {
+      if (!escaped && ch === quote) quote = null;
+      escaped = !escaped && ch === "\\";
+      continue;
+    }
+
+    if (ch === '"' || ch === "'" || ch === "`") {
+      quote = ch;
+      escaped = false;
+      continue;
+    }
+
+    if (ch === open) depth++;
+    if (ch === close) {
+      depth--;
+      if (depth === 0) return i;
+    }
+  }
+
+  return -1;
+}
+
+function splitTopLevel(src: string): string[] {
+  const out: string[] = [];
+  let start = 0;
+  let depthParen = 0;
+  let depthBrace = 0;
+  let depthBracket = 0;
+  let quote: string | null = null;
+  let escaped = false;
+
+  for (let i = 0; i < src.length; i++) {
+    const ch = src[i];
+    if (quote) {
+      if (!escaped && ch === quote) quote = null;
+      escaped = !escaped && ch === "\\";
+      continue;
+    }
+
+    if (ch === '"' || ch === "'" || ch === "`") {
+      quote = ch;
+      escaped = false;
+      continue;
+    }
+
+    if (ch === "(") depthParen++;
+    else if (ch === ")") depthParen--;
+    else if (ch === "{") depthBrace++;
+    else if (ch === "}") depthBrace--;
+    else if (ch === "[") depthBracket++;
+    else if (ch === "]") depthBracket--;
+
+    if (
+      ch === "," &&
+      depthParen === 0 &&
+      depthBrace === 0 &&
+      depthBracket === 0
+    ) {
+      out.push(src.slice(start, i).trim());
+      start = i + 1;
+    }
+  }
+
+  out.push(src.slice(start).trim());
+  return out;
+}
+
+function extractQuoted(value: string): string | null {
+  const m = value.trim().match(/^['"]([^'"]+)['"]$/);
+  return m ? m[1] : null;
+}
+
+function extractHandlerRef(value: string): string | null {
+  const v = value.trim();
+  if (/^[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*$/.test(v)) return v;
+  return null;
+}
+
+function extractObjectStringProp(src: string, key: string): string | null {
+  const re = new RegExp(`${escapeRe(key)}\\s*:\\s*['\"]([^'\"]+)['\"]`);
+  const m = src.match(re);
+  return m ? m[1] : null;
+}
+
+function extractObjectValue(src: string, key: string): string | null {
+  const re = new RegExp(`${escapeRe(key)}\\s*:\\s*([^,\\n}]+)`);
+  const m = src.match(re);
+  return m ? m[1].trim() : null;
+}
+
+function joinPath(prefix: string, path: string): string {
+  const prefixNorm = prefix.trim();
+  const pathNorm = path.trim();
+  if (!prefixNorm) return ensureSlash(pathNorm);
+  if (!pathNorm) return ensureSlash(prefixNorm);
+  const left = ensureSlash(prefixNorm).replace(/\/$/, "");
+  const right = ensureSlash(pathNorm);
+  return `${left}${right}`;
+}
+
+function ensureSlash(v: string): string {
+  return v.startsWith("/") ? v : `/${v}`;
+}
+
+function escapeRe(v: string): string {
+  return v.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/packages/analyzer/test/analyze-fastify.test.js
+++ b/packages/analyzer/test/analyze-fastify.test.js
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { analyzeFastifyEntry } from "../dist/index.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+function fixture(name) {
+  return path.join(__dirname, "fixtures", name);
+}
+
+test("extracts method/path/handler from shorthand and route object", () => {
+  const ir = analyzeFastifyEntry(fixture("basic-fastify.fixture.txt"));
+
+  assert.deepEqual(ir.routes, [
+    { method: "GET", path: "/users", handlerRef: "listUsers" },
+    { method: "POST", path: "/users", handlerRef: "createUser" },
+    { method: "PATCH", path: "/users/:id", handlerRef: "updateUser" },
+  ]);
+  assert.equal(ir.diagnostics.length, 0);
+});
+
+test("applies register prefix for inline and named plugin callbacks", () => {
+  const ir = analyzeFastifyEntry(
+    fixture("register-prefix-fastify.fixture.txt"),
+  );
+
+  assert.deepEqual(ir.routes, [
+    { method: "GET", path: "/v1/users", handlerRef: "listV1Users" },
+    { method: "GET", path: "/v1/users/:id", handlerRef: "showV1User" },
+    { method: "GET", path: "/v1/admin/accounts", handlerRef: "listAccounts" },
+  ]);
+  assert.equal(ir.diagnostics.length, 0);
+});
+
+test("emits explicit diagnostics for unsupported patterns", () => {
+  const ir = analyzeFastifyEntry(fixture("unsupported-fastify.fixture.txt"));
+
+  assert.deepEqual(ir.routes, []);
+  assert.deepEqual(ir.diagnostics.map((d) => d.code).sort(), [
+    "ANALYZER_UNRESOLVED_PLUGIN",
+    "ANALYZER_UNSUPPORTED_DYNAMIC_PATH",
+    "ANALYZER_UNSUPPORTED_INLINE_HANDLER",
+  ]);
+});

--- a/packages/analyzer/test/fixtures/basic-fastify.fixture.txt
+++ b/packages/analyzer/test/fixtures/basic-fastify.fixture.txt
@@ -1,0 +1,12 @@
+import Fastify from "fastify";
+
+const fastify = Fastify();
+
+const listUsers = async () => {};
+const createUser = async () => {};
+
+fastify.get("/users", listUsers);
+fastify.post('/users', createUser);
+fastify.route({ method: "PATCH", url: "/users/:id", handler: updateUser });
+
+function updateUser() {}

--- a/packages/analyzer/test/fixtures/register-prefix-fastify.fixture.txt
+++ b/packages/analyzer/test/fixtures/register-prefix-fastify.fixture.txt
@@ -1,0 +1,19 @@
+import Fastify from "fastify";
+
+const fastify = Fastify();
+
+function listV1Users() {}
+function showV1User() {}
+
+const accountPlugin = async (app) => {
+  app.get("/accounts", listAccounts);
+};
+
+function listAccounts() {}
+
+fastify.register(async function routes(instance) {
+  instance.get("/users", listV1Users);
+  instance.route({ method: "GET", path: "/users/:id", handler: showV1User });
+}, { prefix: "/v1" });
+
+fastify.register(accountPlugin, { prefix: "/v1/admin" });

--- a/packages/analyzer/test/fixtures/unsupported-fastify.fixture.txt
+++ b/packages/analyzer/test/fixtures/unsupported-fastify.fixture.txt
@@ -1,0 +1,11 @@
+import Fastify from "fastify";
+
+const fastify = Fastify();
+
+const dynamicPath = "/x";
+
+fastify.get(dynamicPath, handler);
+fastify.post("/inline", async () => {});
+fastify.register(externalPlugin, { prefix: "/v2" });
+
+function handler() {}


### PR DESCRIPTION
## Summary
- Expand Fastify analyzer route extraction beyond simple `fastify.METHOD(path, handler)` regex matching.
- Add support for:
  - shorthand routes (`fastify.get/post/put/delete/patch`)
  - `fastify.route({ method, url|path, handler })`
  - `register(..., { prefix })` prefix propagation
  - inline register callbacks (`async function (instance) { ... }` / arrow block)
  - same-file named plugin callbacks referenced via `register(pluginRef, { prefix })`
- Add explicit diagnostics for unsupported patterns to make capability boundaries visible.

## Supported vs Unsupported Matrix
- ✅ Supported:
  - `fastify.METHOD('/path', handlerRef)`
  - `instance.route({ method: 'GET', url|path: '/x', handler: handlerRef })`
  - `fastify.register(inlinePlugin, { prefix: '/v1' })`
  - `fastify.register(namedPluginInSameFile, { prefix: '/v1' })`
  - nested prefix composition through supported register patterns
- ⚠️ Explicitly diagnosed (unsupported for now):
  - dynamic/non-literal path expressions
  - inline/non-reference handlers
  - unresolved plugin references in `register(...)`
  - unsupported register callback shapes

## Tests
- Added analyzer fixtures and tests for:
  - direct shorthand + route object extraction
  - register/prefix expansion across inline and named plugins
  - explicit diagnostics on unsupported patterns

## Validation
- `pnpm install`
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run test:tdd`
