### PR TITLE
chore(node-compat): sync capability matrix keys with drift tests

### DIFF
--- a/packages/node-compat/src/capability.ts
+++ b/packages/node-compat/src/capability.ts
@@ -7,17 +7,20 @@ export enum CapabilityStatus {
   BLOCKED = "BLOCKED",
 }
 
-export type CapabilityKey =
-  | "route.basic"
-  | "handler.async"
-  | "module.esm"
-  | "module.cjs"
-  | "runtime.event_loop"
-  | "node.fs.basic"
-  | "node.path.basic"
-  | "node.url.basic"
-  | "node.process.env"
-  | "node.buffer.basic";
+export const CAPABILITY_KEYS = [
+  "route.basic",
+  "handler.async",
+  "module.esm",
+  "module.cjs",
+  "runtime.event_loop",
+  "node.fs.basic",
+  "node.path.basic",
+  "node.url.basic",
+  "node.process.env",
+  "node.buffer.basic",
+] as const;
+
+export type CapabilityKey = (typeof CAPABILITY_KEYS)[number];
 
 export interface CapabilityRule {
   key: CapabilityKey;

--- a/packages/node-compat/test/capability-matrix-sync.test.ts
+++ b/packages/node-compat/test/capability-matrix-sync.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import {
+  CAPABILITY_KEYS,
+  CAPABILITY_MATRIX,
+  type CapabilityStatus,
+} from "../src/capability.ts";
+
+interface MatrixRow {
+  key: string;
+  scope: string;
+  status: string;
+  strategy: string;
+}
+
+function parseCapabilityRows(markdown: string): MatrixRow[] {
+  const rows = markdown
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith("|"))
+    .map((line) =>
+      line
+        .split("|")
+        .slice(1, -1)
+        .map((cell) => cell.trim()),
+    )
+    .filter((cells) => cells.length === 4)
+    .filter((cells) => cells[0] !== "Capability Key")
+    .filter((cells) => !cells.every((cell) => /^-+$/.test(cell)));
+
+  return rows.map(([key, scope, status, strategy]) => ({
+    key,
+    scope,
+    status,
+    strategy,
+  }));
+}
+
+test("CAPABILITY_MATRIX keys are unique and internally consistent", () => {
+  const matrixEntries = Object.entries(CAPABILITY_MATRIX);
+  const matrixKeys = matrixEntries.map(([key]) => key);
+
+  assert.deepEqual(matrixKeys, CAPABILITY_KEYS);
+  assert.equal(new Set(matrixKeys).size, matrixKeys.length);
+
+  for (const [key, rule] of matrixEntries) {
+    assert.equal(rule.key, key);
+  }
+});
+
+test("docs/specs/CAPABILITY_MATRIX.md stays 1:1 with implemented capability keys", () => {
+  const docPath = new URL(
+    "../../../docs/specs/CAPABILITY_MATRIX.md",
+    import.meta.url,
+  );
+  const markdown = readFileSync(docPath, "utf8");
+  const rows = parseCapabilityRows(markdown);
+
+  const docKeys = rows.map((row) => row.key);
+  assert.equal(new Set(docKeys).size, docKeys.length);
+  assert.deepEqual(docKeys, CAPABILITY_KEYS);
+
+  for (const row of rows) {
+    const rule = CAPABILITY_MATRIX[row.key as keyof typeof CAPABILITY_MATRIX];
+    assert.ok(rule, `Missing code rule for ${row.key}`);
+    assert.equal(rule.scope, row.scope);
+    assert.equal(rule.status, row.status as CapabilityStatus);
+    assert.equal(rule.strategy, row.strategy);
+  }
+});


### PR DESCRIPTION
## Summary
- add a node-compat drift guard test that parses `docs/specs/CAPABILITY_MATRIX.md` and asserts 1:1 sync with implemented capabilities
- enforce duplicate/ambiguous key prevention by introducing `CAPABILITY_KEYS` as the canonical key list
- verify `CAPABILITY_MATRIX` internal consistency (`rule.key === object key`) and uniqueness

## Why
- prevents silent divergence between the capability matrix doc and runtime gating rules
- keeps capability keys unambiguous and reviewable as a single ordered source of truth

## Validation
- `pnpm install`
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run test:tdd`
