### PR TITLE
test(analyzer): add SSoT guard coverage for capability boundary

### DIFF
--- a/packages/analyzer/test/analyze-fastify.test.js
+++ b/packages/analyzer/test/analyze-fastify.test.js
@@ -46,3 +46,50 @@ test("emits explicit diagnostics for unsupported patterns", () => {
     "ANALYZER_UNSUPPORTED_INLINE_HANDLER",
   ]);
 });
+
+test("handles nested register + prefix + route-object variants without policy decisions", () => {
+  const ir = analyzeFastifyEntry(
+    fixture("nested-register-route-object-fastify.fixture.txt"),
+  );
+
+  assert.deepEqual(ir.routes, [
+    { method: "GET", path: "/api/users", handlerRef: "listApiUsers" },
+    {
+      method: "GET",
+      path: "/api/v2/users/:id",
+      handlerRef: "listApiUserById",
+    },
+    {
+      method: "GET",
+      path: "/private/devices",
+      handlerRef: "listPrivateDevices",
+    },
+    {
+      method: "POST",
+      path: "/private/devices",
+      handlerRef: "createPrivateDevice",
+    },
+    {
+      method: "GET",
+      path: "/internal/metrics",
+      handlerRef: "listInternalMetrics",
+    },
+  ]);
+  assert.equal(ir.diagnostics.length, 0);
+});
+
+test("keeps analyzer as semantic extractor/diagnostics only (SSoT boundary)", () => {
+  const ir = analyzeFastifyEntry(fixture("ssot-boundary-fastify.fixture.txt"));
+
+  assert.deepEqual(ir.routes, [
+    { method: "GET", path: "/policy/allow", handlerRef: "allowAdminOnly" },
+    { method: "POST", path: "/policy/deny", handlerRef: "denyGuest" },
+  ]);
+
+  const diagnosticCodes = ir.diagnostics.map((d) => d.code);
+  assert.equal(diagnosticCodes.includes("CAPABILITY_UNMET"), false);
+  assert.equal(
+    diagnosticCodes.some((code) => code.startsWith("CAPABILITY_")),
+    false,
+  );
+});

--- a/packages/analyzer/test/fixtures/nested-register-route-object-fastify.fixture.txt
+++ b/packages/analyzer/test/fixtures/nested-register-route-object-fastify.fixture.txt
@@ -1,0 +1,28 @@
+import Fastify from "fastify";
+
+const fastify = Fastify();
+
+function listApiUsers() {}
+function listApiUserById() {}
+function listPrivateDevices() {}
+function createPrivateDevice() {}
+function listInternalMetrics() {}
+
+fastify.register(async function apiRoutes(api) {
+  api.route({ method: "GET", path: "/users", handler: listApiUsers });
+
+  api.register(function nestedV2(v2) {
+    v2.route({ method: "GET", url: "/users/:id", handler: listApiUserById });
+  }, { prefix: "/v2" });
+}, { prefix: "/api" });
+
+const privatePlugin = (app) => {
+  app.get("/devices", listPrivateDevices);
+  app.route({ method: "POST", url: "/devices", handler: createPrivateDevice });
+};
+
+fastify.register(privatePlugin, { prefix: "/private" });
+
+fastify.register(async (scope) => {
+  scope.route({ method: "GET", path: "/metrics", handler: listInternalMetrics });
+}, { prefix: "/internal" });

--- a/packages/analyzer/test/fixtures/ssot-boundary-fastify.fixture.txt
+++ b/packages/analyzer/test/fixtures/ssot-boundary-fastify.fixture.txt
@@ -1,0 +1,9 @@
+import Fastify from "fastify";
+
+const fastify = Fastify();
+
+function allowAdminOnly() {}
+function denyGuest() {}
+
+fastify.get("/policy/allow", allowAdminOnly);
+fastify.route({ method: "POST", path: "/policy/deny", handler: denyGuest });


### PR DESCRIPTION
## Summary
- Add analyzer SSoT boundary guard tests to ensure analyzer remains responsible only for semantic route extraction and analyzer diagnostics.
- Add fixture coverage for nested `register` + `prefix` + `route({...})` combinations (including `url` and `path` variants across inline and named plugins).
- Add explicit boundary test asserting analyzer does **not** emit capability policy decisions (`CAPABILITY_*`), keeping final allow/deny ownership in the capability gate path.

## What changed
- `packages/analyzer/test/analyze-fastify.test.js`
  - Added nested register/prefix/route-object extraction test.
  - Added SSoT boundary test for analyzer-vs-capability responsibilities.
- Added fixtures:
  - `packages/analyzer/test/fixtures/nested-register-route-object-fastify.fixture.txt`
  - `packages/analyzer/test/fixtures/ssot-boundary-fastify.fixture.txt`

## Validation
- `pnpm install`
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run test:tdd`

All green.