### PR TITLE
test: expand e2e contract fixtures and cli output assertions

### DIFF
--- a/packages/cli/test/commands.e2e.test.ts
+++ b/packages/cli/test/commands.e2e.test.ts
@@ -1,12 +1,13 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { after, test } from "node:test";
 
-import { build, check, report, stages } from "../../core/src/index.ts";
-
 const tempDirs: string[] = [];
+const fixturesDir = path.join(import.meta.dirname, "fixtures");
+const cliEntry = path.resolve(import.meta.dirname, "..", "dist", "index.js");
 
 after(() => {
   for (const dir of tempDirs) {
@@ -14,27 +15,19 @@ after(() => {
   }
 });
 
-function setupProject() {
+function setupProject(
+  sourceLines: string[],
+  config = 'export default { entry: "src/index.ts", outDir: "dist-go" };\n',
+) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tsgodown-cli-e2e-"));
   tempDirs.push(dir);
 
   fs.mkdirSync(path.join(dir, "src"), { recursive: true });
   fs.writeFileSync(
     path.join(dir, "src", "index.ts"),
-    [
-      "const fastify = {} as any;",
-      "const listUsers = () => {};",
-      "const getUser = () => {};",
-      "fastify.get('/users', listUsers);",
-      "fastify.get('/users/:id', getUser);",
-      "",
-    ].join("\n"),
+    `${sourceLines.join("\n")}\n`,
   );
-
-  fs.writeFileSync(
-    path.join(dir, "tsgodown.config.ts"),
-    `export default { entry: "src/index.ts", outDir: "dist-go" };\n`,
-  );
+  fs.writeFileSync(path.join(dir, "tsgodown.config.ts"), config);
 
   fs.mkdirSync(path.join(dir, "dist"), { recursive: true });
   fs.writeFileSync(path.join(dir, "dist", "index.js"), "export {};\n");
@@ -42,20 +35,104 @@ function setupProject() {
   return dir;
 }
 
-test("build/check/report/stages produce stable command payloads and deterministic Go output", async () => {
-  const cwd = setupProject();
+function runCli(cwd: string, command: "build" | "check" | "report" | "stages") {
+  const result = spawnSync(process.execPath, [cliEntry, command, "--json"], {
+    cwd,
+    encoding: "utf8",
+  });
+  return result;
+}
 
-  const buildResult = await build(cwd);
-  assert.equal(buildResult.command, "build");
-  assert.deepEqual(buildResult.stages, [
-    "load-config",
-    "analyze",
-    "emit",
-    "onSuccess",
+function parseJsonStdout(stdout: string) {
+  const jsonStart = stdout.indexOf("{");
+  assert.ok(jsonStart >= 0, "expected JSON output");
+  return JSON.parse(stdout.slice(jsonStart)) as Record<string, unknown>;
+}
+
+function normalizeResult(cwd: string, value: unknown): unknown {
+  const roots = [cwd];
+  try {
+    roots.push(fs.realpathSync(cwd));
+  } catch {
+    // noop
+  }
+
+  function walk(current: unknown): unknown {
+    if (Array.isArray(current)) {
+      return current.map((entry) => walk(entry));
+    }
+    if (current && typeof current === "object") {
+      const rec = current as Record<string, unknown>;
+      const out: Record<string, unknown> = {};
+      for (const [key, raw] of Object.entries(rec)) {
+        if (typeof raw === "string") {
+          const root = roots.find(
+            (candidate) =>
+              raw === candidate || raw.startsWith(`${candidate}${path.sep}`),
+          );
+          if (root) {
+            out[key] = raw === root ? "." : raw.slice(root.length + 1);
+            continue;
+          }
+        }
+        out[key] = walk(raw);
+      }
+      return out;
+    }
+    return current;
+  }
+
+  return walk(value);
+}
+
+function assertSubset(actual: unknown, expected: unknown, scope = "root") {
+  if (Array.isArray(expected)) {
+    assert.ok(Array.isArray(actual), `${scope} should be an array`);
+    assert.equal(actual.length, expected.length, `${scope} length mismatch`);
+    for (let i = 0; i < expected.length; i++) {
+      assertSubset(actual[i], expected[i], `${scope}[${i}]`);
+    }
+    return;
+  }
+
+  if (expected && typeof expected === "object") {
+    assert.ok(
+      actual && typeof actual === "object",
+      `${scope} should be an object`,
+    );
+    const actualRec = actual as Record<string, unknown>;
+    const expectedRec = expected as Record<string, unknown>;
+    for (const [key, value] of Object.entries(expectedRec)) {
+      assert.ok(key in actualRec, `${scope}.${key} should exist`);
+      assertSubset(actualRec[key], value, `${scope}.${key}`);
+    }
+    return;
+  }
+
+  assert.equal(actual, expected, `${scope} mismatch`);
+}
+
+test("CLI JSON contract fixtures: success path", () => {
+  const cwd = setupProject([
+    "const fastify = {} as any;",
+    "const listUsers = () => {};",
+    "const getUser = () => {};",
+    "fastify.get('/users', listUsers);",
+    "fastify.get('/users/:id', getUser);",
   ]);
-  assert.equal(buildResult.targets.length, 1);
-  assert.equal(buildResult.targets[0].diagnostics.routes, 2);
-  assert.equal(buildResult.targets[0].emitted, true);
+
+  const fixture = JSON.parse(
+    fs.readFileSync(path.join(fixturesDir, "contract-success.json"), "utf8"),
+  ) as Record<string, unknown>;
+
+  for (const command of ["build", "check", "report", "stages"] as const) {
+    const result = runCli(cwd, command);
+    assert.equal(result.status, 0, `${command} failed: ${result.stderr}`);
+
+    const parsed = parseJsonStdout(result.stdout);
+    const normalized = normalizeResult(cwd, parsed);
+    assertSubset(normalized, fixture[command], command);
+  }
 
   const goPath = path.join(cwd, "dist-go", "main.go");
   assert.equal(fs.existsSync(goPath), true);
@@ -77,22 +154,46 @@ test("build/check/report/stages produce stable command payloads and deterministi
       'fmt.Fprintln(w, "TODO implement handler getUser for GET /users/:id")',
     ),
   );
+});
 
-  const checkResult = await check(cwd);
-  assert.equal(checkResult.command, "check");
-  assert.equal(checkResult.targets[0].diagnostics.routes, 2);
-  assert.equal(checkResult.targets[0].emitted, true);
-
-  const reportResult = await report(cwd);
-  assert.equal(reportResult.command, "report");
-  assert.equal(reportResult.targets[0].diagnostics.routes, 2);
-
-  const stagesResult = await stages(cwd);
-  assert.deepEqual(stagesResult.stages, [
-    "load-config",
-    "analyze",
-    "emit",
-    "onSuccess",
+test("CLI JSON contract fixtures: warn path", () => {
+  const cwd = setupProject([
+    "const fastify = {} as any;",
+    "const health = () => {};",
+    "fastify.get('/health', health);",
+    "await import('node:fs');",
   ]);
-  assert.equal(stagesResult.targets[0].emitted, true);
+
+  const fixture = JSON.parse(
+    fs.readFileSync(path.join(fixturesDir, "contract-warn.json"), "utf8"),
+  ) as Record<string, unknown>;
+
+  for (const command of ["check", "report"] as const) {
+    const result = runCli(cwd, command);
+    assert.equal(result.status, 0, `${command} failed: ${result.stderr}`);
+    const parsed = parseJsonStdout(result.stdout);
+    const normalized = normalizeResult(cwd, parsed);
+    assertSubset(normalized, fixture[command], command);
+  }
+});
+
+test("CLI fail diagnostics include source/cause/guidance contract", () => {
+  const cwd = setupProject(
+    ["const fastify = {} as any;", "fastify.get('/health', () => {});"],
+    'export default { entry: "src/missing.ts", outDir: "dist-go" };\n',
+  );
+
+  const fixture = JSON.parse(
+    fs.readFileSync(path.join(fixturesDir, "contract-fail.json"), "utf8"),
+  ) as { stderrIncludes: string[] };
+
+  const result = runCli(cwd, "build");
+  assert.notEqual(result.status, 0, "build should fail for missing entry");
+
+  for (const token of fixture.stderrIncludes) {
+    assert.match(
+      result.stderr,
+      new RegExp(token.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")),
+    );
+  }
 });

--- a/packages/cli/test/fixtures/contract-fail.json
+++ b/packages/cli/test/fixtures/contract-fail.json
@@ -1,0 +1,9 @@
+{
+  "stderrIncludes": [
+    "[tsgodown] command failed:",
+    "source:",
+    "cause:",
+    "guidance:",
+    "tsgodown.config.ts"
+  ]
+}

--- a/packages/cli/test/fixtures/contract-success.json
+++ b/packages/cli/test/fixtures/contract-success.json
@@ -1,0 +1,67 @@
+{
+  "build": {
+    "command": "build",
+    "ok": true,
+    "stages": ["load-config", "analyze", "emit", "onSuccess"],
+    "targets": [
+      {
+        "configIndex": 0,
+        "entry": "src/index.ts",
+        "outDir": "dist-go",
+        "artifact": "dist-go/main.go",
+        "emitted": true,
+        "diagnostics": {
+          "routes": 2,
+          "warnings": []
+        }
+      }
+    ]
+  },
+  "check": {
+    "command": "check",
+    "ok": true,
+    "stages": ["load-config", "analyze", "emit", "onSuccess"],
+    "targets": [
+      {
+        "configIndex": 0,
+        "entry": "src/index.ts",
+        "outDir": "dist-go",
+        "artifact": "dist-go/main.go",
+        "emitted": true,
+        "diagnostics": {
+          "routes": 2,
+          "warnings": []
+        }
+      }
+    ]
+  },
+  "report": {
+    "command": "report",
+    "ok": true,
+    "stages": ["load-config", "analyze", "emit", "onSuccess"],
+    "targets": [
+      {
+        "configIndex": 0,
+        "entry": "src/index.ts",
+        "outDir": "dist-go",
+        "artifact": "dist-go/main.go",
+        "diagnostics": {
+          "routes": 2,
+          "warnings": []
+        }
+      }
+    ]
+  },
+  "stages": {
+    "stages": ["load-config", "analyze", "emit", "onSuccess"],
+    "targets": [
+      {
+        "configIndex": 0,
+        "entry": "src/index.ts",
+        "outDir": "dist-go",
+        "artifact": "dist-go/main.go",
+        "emitted": true
+      }
+    ]
+  }
+}

--- a/packages/cli/test/fixtures/contract-warn.json
+++ b/packages/cli/test/fixtures/contract-warn.json
@@ -1,0 +1,26 @@
+{
+  "check": {
+    "command": "check",
+    "ok": true,
+    "targets": [
+      {
+        "diagnostics": {
+          "routes": 1,
+          "warnings": ["dynamic import detected"]
+        }
+      }
+    ]
+  },
+  "report": {
+    "command": "report",
+    "ok": true,
+    "targets": [
+      {
+        "diagnostics": {
+          "routes": 1,
+          "warnings": ["dynamic import detected"]
+        }
+      }
+    ]
+  }
+}

--- a/packages/pipeline/src/index.ts
+++ b/packages/pipeline/src/index.ts
@@ -31,8 +31,13 @@ export async function runPipeline(cwd: string, options: PipelineOptions = {}) {
       });
       if (!gate.ok) {
         const details = gate.diagnostics
-          .map((d) => `${d.capability}=${d.status}`)
-          .join(", ");
+          .map((d) => {
+            const source = d.source
+              ? `${d.source.file}:${d.source.line ?? "?"}:${d.source.column ?? "?"}`
+              : "unknown";
+            return `${d.capability}=${d.status} source:${source} cause:${d.cause ?? "n/a"} guidance:${d.guidance ?? "n/a"}`;
+          })
+          .join(" | ");
         throw new Error(
           `unsupported capabilities: ${details}. Check docs/specs/CAPABILITY_MATRIX.md or simplify source features.`,
         );
@@ -44,7 +49,12 @@ export async function runPipeline(cwd: string, options: PipelineOptions = {}) {
     } catch (cause) {
       const msg = cause instanceof Error ? cause.message : String(cause);
       throw new Error(
-        `[pipeline] failed for entry "${entry}" -> outDir "${outDir}": ${msg}. Verify tsgodown.config.ts entry/outDir and input source syntax.`,
+        [
+          `[pipeline] failed for entry "${entry}" -> outDir "${outDir}"`,
+          `source: ${entry}`,
+          `cause: ${msg}`,
+          "guidance: Verify tsgodown.config.ts entry/outDir and input source syntax.",
+        ].join("; "),
       );
     }
   }


### PR DESCRIPTION
## Summary
- add CLI e2e contract fixtures for success/warn/fail scenarios
- harden command assertions for build/check/report/stages JSON payloads
- validate fail-path diagnostics include `source`, `cause`, and `guidance`
- normalize temp absolute paths in tests for stable assertions across macOS tmp path variants

## Details
- introduced fixture files:
  - `packages/cli/test/fixtures/contract-success.json`
  - `packages/cli/test/fixtures/contract-warn.json`
  - `packages/cli/test/fixtures/contract-fail.json`
- rewrote `packages/cli/test/commands.e2e.test.ts` to:
  - execute CLI dist entry with `--json`
  - compare normalized outputs against fixtures via subset contract checks
  - keep deterministic Go scaffold assertions for build output
  - verify warning contract for dynamic import detection
  - verify fail contract tokens in stderr
- updated `packages/pipeline/src/index.ts` fail messages to consistently expose:
  - `source: ...`
  - `cause: ...`
  - `guidance: ...`

## Validation
- `pnpm install`
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run test:tdd`
