### PR TITLE
feat(node-compat): advance path/url capability support for v1

### DIFF
--- a/docs/specs/CAPABILITY_MATRIX.md
+++ b/docs/specs/CAPABILITY_MATRIX.md
@@ -10,8 +10,8 @@ IR 의미를 Go로 내릴 수 있는지 판정하는 단일 테이블.
 | module.cjs | module | TODO | cjs bridge |
 | runtime.event_loop | runtime | TODO | scheduler shim |
 | node.fs.basic | node api | TODO | os/io adapter |
-| node.path.basic | node api | TODO | filepath adapter |
-| node.url.basic | node api | TODO | net/url adapter |
+| node.path.basic | node api | WIP | filepath adapter (join/resolve/dirname/basename) |
+| node.url.basic | node api | WIP | net/url adapter (URL + URLSearchParams) |
 | node.process.env | node api | TODO | runtime env map |
 | node.buffer.basic | node api | TODO | []byte wrapper |
 

--- a/packages/node-compat/src/capability.ts
+++ b/packages/node-compat/src/capability.ts
@@ -107,14 +107,14 @@ export const CAPABILITY_MATRIX: Record<CapabilityKey, CapabilityRule> = {
   "node.path.basic": {
     key: "node.path.basic",
     scope: "node api",
-    status: CapabilityStatus.TODO,
-    strategy: "filepath adapter",
+    status: CapabilityStatus.WIP,
+    strategy: "filepath adapter (join/resolve/dirname/basename)",
   },
   "node.url.basic": {
     key: "node.url.basic",
     scope: "node api",
-    status: CapabilityStatus.TODO,
-    strategy: "net/url adapter",
+    status: CapabilityStatus.WIP,
+    strategy: "net/url adapter (URL + URLSearchParams)",
   },
   "node.process.env": {
     key: "node.process.env",

--- a/packages/node-compat/test/capability.test.ts
+++ b/packages/node-compat/test/capability.test.ts
@@ -132,6 +132,36 @@ test("fails fast with source-aware diagnostic including cause and guidance", () 
   assert.equal(typeof diag.guidance, "string");
 });
 
+test("treats path/url diagnostics as supported in node-compat v1", () => {
+  const ir = {
+    routes: [],
+    modules: [],
+    handlers: [],
+    diagnostics: [
+      {
+        level: "warn",
+        code: "NODE_PATH_BASIC_REQUIRED",
+        message: "uses path.join",
+        source: { file: "src/path.ts", line: 3, column: 2 },
+      },
+      {
+        level: "warn",
+        code: "NODE_URL_BASIC_REQUIRED",
+        message: "uses new URL",
+        source: { file: "src/url.ts", line: 5, column: 1 },
+      },
+    ],
+  };
+
+  const result = checkCapabilities(ir, { failFast: false });
+  assert.equal(result.ok, true);
+  assert.equal(result.diagnostics.length, 0);
+  assert.deepEqual(
+    result.required.map((req) => req.capability),
+    ["node.path.basic", "node.url.basic"],
+  );
+});
+
 test("reports all unmet capabilities when failFast is disabled", () => {
   const ir = {
     routes: [],
@@ -150,6 +180,18 @@ test("reports all unmet capabilities when failFast is disabled", () => {
         code: "NODE_FS_BASIC_REQUIRED",
         message: "uses fs.readFileSync",
         source: { file: "src/fs.ts", line: 2, column: 4 },
+      },
+      {
+        level: "warn",
+        code: "NODE_PATH_BASIC_REQUIRED",
+        message: "uses path.join",
+        source: { file: "src/path.ts", line: 3, column: 2 },
+      },
+      {
+        level: "warn",
+        code: "NODE_URL_BASIC_REQUIRED",
+        message: "uses new URL",
+        source: { file: "src/url.ts", line: 5, column: 1 },
       },
     ],
   };


### PR DESCRIPTION
## Summary
- Advance `node-compat` capability support for practical v1 Node APIs by promoting:
  - `node.path.basic` from `TODO` -> `WIP`
  - `node.url.basic` from `TODO` -> `WIP`
- Refine matrix strategy text to reflect realistic v1 subsets:
  - path: `join/resolve/dirname/basename`
  - url: `URL + URLSearchParams`
- Add tests that lock in behavior:
  - path/url diagnostics are collected as requirements
  - path/url are now considered supported under default `allowWip=true`
  - fail-fast=false still reports unmet capabilities correctly (excluding supported path/url)

## Why
This moves small, high-impact Node compatibility keys forward without weakening existing fail-fast diagnostics quality.

## Validation
- `pnpm install`
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run test:tdd`

All green.

## Notes
- No merge performed (per instruction).
