### PR TITLE
feat(emitter-go): improve v1 route logic generation

### DIFF
--- a/packages/cli/test/commands.e2e.test.ts
+++ b/packages/cli/test/commands.e2e.test.ts
@@ -137,9 +137,9 @@ test("CLI JSON contract fixtures: success path", () => {
   const goPath = path.join(cwd, "dist-go", "main.go");
   assert.equal(fs.existsSync(goPath), true);
   const go = fs.readFileSync(goPath, "utf8");
-  assert.ok(go.includes('mux.HandleFunc("/users", route0)'));
-  assert.ok(go.includes('mux.HandleFunc("/users/:id", route1)'));
-  assert.ok(go.includes("if req.Method != http.MethodGet {"));
+  assert.ok(go.includes('mux.HandleFunc("GET /users", route0)'));
+  assert.ok(go.includes('mux.HandleFunc("GET /users/{id}", route1)'));
+  assert.ok(!go.includes("if req.Method != http.MethodGet {"));
   assert.ok(go.includes("// Route metadata:"));
   assert.ok(go.includes("//   Method: GET"));
   assert.ok(go.includes('//   Path: "/users"'));

--- a/packages/emitter-go/src/index.ts
+++ b/packages/emitter-go/src/index.ts
@@ -6,53 +6,81 @@ function routeHandlerName(index: number): string {
   return `route${index}`;
 }
 
-function toGoHttpMethod(method: RouteIR["method"]): string {
-  switch (method) {
-    case "GET":
-      return "http.MethodGet";
-    case "POST":
-      return "http.MethodPost";
-    case "PUT":
-      return "http.MethodPut";
-    case "DELETE":
-      return "http.MethodDelete";
-    case "PATCH":
-      return "http.MethodPatch";
-    default:
-      return JSON.stringify(method);
-  }
-}
-
 function quoteGo(value: string): string {
   return JSON.stringify(value);
 }
 
+function toServeMuxPath(pathname: string): string {
+  return pathname.replaceAll(/:([A-Za-z_][A-Za-z0-9_]*)/g, "{$1}");
+}
+
+function toServeMuxPattern(route: RouteIR): string {
+  return `${route.method} ${toServeMuxPath(route.path)}`;
+}
+
+function extractPathParamNames(pathname: string): string[] {
+  const names: string[] = [];
+  const seen = new Set<string>();
+
+  for (const match of pathname.matchAll(/:([A-Za-z_][A-Za-z0-9_]*)/g)) {
+    const name = match[1];
+    if (!seen.has(name)) {
+      seen.add(name);
+      names.push(name);
+    }
+  }
+
+  return names;
+}
+
+function emitPathParams(route: RouteIR): string[] {
+  const names = extractPathParamNames(route.path);
+  if (names.length === 0) {
+    return [];
+  }
+
+  const lines = ["\t// Extracted path params:"];
+  for (const name of names) {
+    lines.push(`\t${name} := req.PathValue(${quoteGo(name)})`);
+    lines.push(`\t_ = ${name}`);
+  }
+  lines.push("");
+
+  return lines;
+}
+
 function emitRoute(route: RouteIR, index: number): string[] {
-  const methodRef = toGoHttpMethod(route.method);
   const todoMessage = `TODO implement handler ${route.handlerRef} for ${route.method} ${route.path}`;
 
-  return [
+  const lines: string[] = [
     `func ${routeHandlerName(index)}(w http.ResponseWriter, req *http.Request) {`,
-    `\tif req.Method != ${methodRef} {`,
-    `\t\tw.Header().Set("Allow", ${methodRef})`,
-    '\t\thttp.Error(w, "method not allowed", http.StatusMethodNotAllowed)',
-    "\t\treturn",
-    "\t}",
     "",
     "\t// Route metadata:",
     `\t//   Method: ${route.method}`,
     `\t//   Path: ${quoteGo(route.path)}`,
+    `\t//   Pattern: ${quoteGo(toServeMuxPattern(route))}`,
     `\t//   Handler: ${quoteGo(route.handlerRef)}`,
+  ];
+
+  if ((route.middlewareRefs?.length ?? 0) > 0) {
+    lines.push(`\t//   Middleware: ${JSON.stringify(route.middlewareRefs)}`);
+  }
+
+  lines.push(
     `\t// TODO(tsgodown): Implement handler ${quoteGo(route.handlerRef)} for ${route.method} ${route.path}.`,
     "\t//   - Replace this scaffold with application logic.",
     "\t//   - Validate request input and map to domain arguments.",
     "\t//   - Write response status, headers, and body.",
+    "",
+    ...emitPathParams(route),
     '\tw.Header().Set("Content-Type", "text/plain; charset=utf-8")',
     "\tw.WriteHeader(http.StatusNotImplemented)",
     `\tfmt.Fprintln(w, ${quoteGo(todoMessage)})`,
     "}",
     "",
-  ];
+  );
+
+  return lines;
 }
 
 export function emitGoProject(ir: ProgramIR, outDir: string) {
@@ -65,7 +93,7 @@ export function emitGoProject(ir: ProgramIR, outDir: string) {
   lines.push("func registerRoutes(mux *http.ServeMux) {");
   for (const [index, route] of ir.routes.entries()) {
     lines.push(
-      `\tmux.HandleFunc(${quoteGo(route.path)}, ${routeHandlerName(index)})`,
+      `\tmux.HandleFunc(${quoteGo(toServeMuxPattern(route))}, ${routeHandlerName(index)})`,
     );
   }
   lines.push("}", "");

--- a/packages/emitter-go/test/emit-go.test.ts
+++ b/packages/emitter-go/test/emit-go.test.ts
@@ -28,12 +28,17 @@ const sampleIr: ProgramIR = {
   handlers: [],
   diagnostics: [],
   routes: [
-    { method: "GET", path: "/health", handlerRef: "health" },
-    { method: "POST", path: "/users", handlerRef: "createUser" },
+    {
+      method: "GET",
+      path: "/health",
+      handlerRef: "health",
+      middlewareRefs: ["auth"],
+    },
+    { method: "POST", path: "/users/:id", handlerRef: "createUser" },
   ],
 };
 
-test("emitGoProject emits deterministic main.go scaffold with route registration and actionable TODO stubs", () => {
+test("emitGoProject emits deterministic main.go scaffold with method-aware route registration and actionable TODO stubs", () => {
   const outDir = createOutDir();
 
   emitGoProject(sampleIr, outDir);
@@ -41,24 +46,26 @@ test("emitGoProject emits deterministic main.go scaffold with route registration
   const emitted = fs.readFileSync(path.join(outDir, "main.go"), "utf8");
 
   assert.match(emitted, /func registerRoutes\(mux \*http\.ServeMux\) \{/);
-  assert.match(emitted, /mux\.HandleFunc\("\/health", route0\)/);
-  assert.match(emitted, /mux\.HandleFunc\("\/users", route1\)/);
-  assert.match(emitted, /if req\.Method != http\.MethodGet \{/);
-  assert.match(emitted, /if req\.Method != http\.MethodPost \{/);
+  assert.match(emitted, /mux\.HandleFunc\("GET \/health", route0\)/);
+  assert.match(emitted, /mux\.HandleFunc\("POST \/users\/\{id\}", route1\)/);
+  assert.doesNotMatch(emitted, /if req\.Method != http\.MethodGet \{/);
+  assert.doesNotMatch(emitted, /if req\.Method != http\.MethodPost \{/);
   assert.match(emitted, /\/\/ Route metadata:/);
   assert.match(emitted, /\/\/\s+Method:\s+GET/);
   assert.match(emitted, /\/\/\s+Path:\s+"\/health"/);
   assert.match(emitted, /\/\/\s+Handler:\s+"health"/);
+  assert.match(emitted, /\/\/\s+Middleware:\s+\["auth"\]/);
   assert.match(emitted, /\/\/\s+Method:\s+POST/);
-  assert.match(emitted, /\/\/\s+Path:\s+"\/users"/);
+  assert.match(emitted, /\/\/\s+Path:\s+"\/users\/:id"/);
   assert.match(emitted, /\/\/\s+Handler:\s+"createUser"/);
+  assert.match(emitted, /id := req\.PathValue\("id"\)/);
   assert.match(
     emitted,
     /TODO\(tsgodown\): Implement handler "health" for GET \/health\./,
   );
   assert.match(
     emitted,
-    /TODO\(tsgodown\): Implement handler "createUser" for POST \/users\./,
+    /TODO\(tsgodown\): Implement handler "createUser" for POST \/users\/:id\./,
   );
   assert.match(emitted, /w\.WriteHeader\(http\.StatusNotImplemented\)/);
   assert.match(
@@ -67,7 +74,7 @@ test("emitGoProject emits deterministic main.go scaffold with route registration
   );
   assert.match(
     emitted,
-    /fmt\.Fprintln\(w, "TODO implement handler createUser for POST \/users"\)/,
+    /fmt\.Fprintln\(w, "TODO implement handler createUser for POST \/users\/:id"\)/,
   );
 });
 

--- a/packages/pipeline/test/pipeline.e2e.test.ts
+++ b/packages/pipeline/test/pipeline.e2e.test.ts
@@ -62,10 +62,10 @@ test("runPipeline executes all stages and emits deterministic Go scaffold", asyn
   assert.equal(fs.existsSync(goPath), true);
 
   const emitted = fs.readFileSync(goPath, "utf8");
-  assert.ok(emitted.includes('mux.HandleFunc("/health", route0)'));
-  assert.ok(emitted.includes('mux.HandleFunc("/users", route1)'));
-  assert.ok(emitted.includes("if req.Method != http.MethodGet {"));
-  assert.ok(emitted.includes("if req.Method != http.MethodPost {"));
+  assert.ok(emitted.includes('mux.HandleFunc("GET /health", route0)'));
+  assert.ok(emitted.includes('mux.HandleFunc("POST /users", route1)'));
+  assert.ok(!emitted.includes("if req.Method != http.MethodGet {"));
+  assert.ok(!emitted.includes("if req.Method != http.MethodPost {"));
   assert.ok(emitted.includes("// Route metadata:"));
   assert.ok(emitted.includes("//   Method: GET"));
   assert.ok(emitted.includes('//   Path: "/health"'));


### PR DESCRIPTION
## Summary
- upgrade Go emitter route registration from path-only stubs to method-aware ServeMux patterns (`"METHOD /path"`)
- translate Fastify/Express-style `:param` segments into Go ServeMux placeholders (`{param}`)
- emit per-route path parameter extraction scaffold via `req.PathValue(...)`
- include middleware metadata comments when present in IR
- keep deterministic output and update e2e/golden-oriented assertions accordingly

## Why
The previous baseline emitted only path registration and method checks inside handlers. This v1 route-logic step moves method matching and route pattern handling into registration, improves compatibility with latest analyzer IR (including paramized paths and middleware refs), and produces more actionable deterministic scaffolds.

## Validation
- `pnpm install`
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run test:tdd`
