### PR TITLE
feat(ir): extend handler semantics (pragmatic v1)

### DIFF
--- a/docs/specs/IR_SPEC.md
+++ b/docs/specs/IR_SPEC.md
@@ -41,11 +41,17 @@ interface RouteIR {
 
 ### HandlerIR
 ```ts
+type HandlerResponseMode = 'return' | 'response-object' | 'next-callback' | 'unknown'
+
 interface HandlerIR {
   id: string
   params: Array<{ name: string; role: 'request' | 'response' | 'next' | 'custom' }>
   bodyRef?: string
   async: boolean
+  semantics?: {
+    // pragmatic v1: response handling strategy hint for emitters
+    responseMode: HandlerResponseMode
+  }
 }
 ```
 

--- a/packages/analyzer/src/index.ts
+++ b/packages/analyzer/src/index.ts
@@ -1,10 +1,22 @@
 import fs from "node:fs";
-import type { DiagnosticIR, ProgramIR, RouteIR } from "@tsgodown/ir-core";
+import type {
+  DiagnosticIR,
+  HandlerIR,
+  HandlerResponseMode,
+  ProgramIR,
+  RouteIR,
+} from "@tsgodown/ir-core";
 import ts from "typescript";
 
 type PluginDef = {
   paramName: string;
   statements: readonly ts.Statement[];
+};
+
+type HandlerDef = {
+  params: string[];
+  async: boolean;
+  body: string;
 };
 
 const HTTP_METHODS = new Set(["GET", "POST", "PUT", "DELETE", "PATCH"]);
@@ -21,14 +33,18 @@ export function analyzeFastifyEntry(entryFile: string): ProgramIR {
 
   const diagnostics: DiagnosticIR[] = [];
   const routes: RouteIR[] = [];
+  const handlers: HandlerIR[] = [];
   const pluginDefs = collectPluginDefinitions(sourceFile);
+  const handlerDefs = collectHandlerDefinitions(sourceFile);
 
   analyzeScope({
     statements: sourceFile.statements,
     file: entryFile,
     diagnostics,
     routes,
+    handlers,
     pluginDefs,
+    handlerDefs,
     instanceName: detectRootInstanceName(sourceFile) ?? "fastify",
     prefix: "",
   });
@@ -45,7 +61,7 @@ export function analyzeFastifyEntry(entryFile: string): ProgramIR {
   return {
     modules: [],
     routes,
-    handlers: [],
+    handlers,
     diagnostics,
   };
 }
@@ -55,7 +71,9 @@ function analyzeScope(params: {
   file: string;
   diagnostics: DiagnosticIR[];
   routes: RouteIR[];
+  handlers: HandlerIR[];
   pluginDefs: Map<string, PluginDef>;
+  handlerDefs: Map<string, HandlerDef>;
   instanceName: string;
   prefix: string;
 }) {
@@ -64,7 +82,9 @@ function analyzeScope(params: {
     file,
     diagnostics,
     routes,
+    handlers,
     pluginDefs,
+    handlerDefs,
     instanceName,
     prefix,
   } = params;
@@ -83,6 +103,8 @@ function analyzeScope(params: {
           file,
           diagnostics,
           routes,
+          handlers,
+          handlerDefs,
           method: member.toUpperCase() as RouteIR["method"],
           prefix,
           instanceName,
@@ -96,6 +118,8 @@ function analyzeScope(params: {
           file,
           diagnostics,
           routes,
+          handlers,
+          handlerDefs,
           prefix,
           instanceName,
         });
@@ -108,7 +132,9 @@ function analyzeScope(params: {
           file,
           diagnostics,
           routes,
+          handlers,
           pluginDefs,
+          handlerDefs,
           prefix,
           instanceName,
         });
@@ -122,12 +148,23 @@ function extractShorthandRoute(params: {
   file: string;
   diagnostics: DiagnosticIR[];
   routes: RouteIR[];
+  handlers: HandlerIR[];
+  handlerDefs: Map<string, HandlerDef>;
   method: RouteIR["method"];
   prefix: string;
   instanceName: string;
 }) {
-  const { call, file, diagnostics, routes, method, prefix, instanceName } =
-    params;
+  const {
+    call,
+    file,
+    diagnostics,
+    routes,
+    handlers,
+    handlerDefs,
+    method,
+    prefix,
+    instanceName,
+  } = params;
   const pathExpr = call.arguments[0];
   const handlerExpr = call.arguments[1];
 
@@ -154,6 +191,7 @@ function extractShorthandRoute(params: {
   }
 
   routes.push({ method, path: joinPath(prefix, path), handlerRef });
+  upsertHandler(handlers, handlerDefs, handlerRef);
 }
 
 function extractRouteObject(params: {
@@ -161,10 +199,21 @@ function extractRouteObject(params: {
   file: string;
   diagnostics: DiagnosticIR[];
   routes: RouteIR[];
+  handlers: HandlerIR[];
+  handlerDefs: Map<string, HandlerDef>;
   prefix: string;
   instanceName: string;
 }) {
-  const { call, file, diagnostics, routes, prefix, instanceName } = params;
+  const {
+    call,
+    file,
+    diagnostics,
+    routes,
+    handlers,
+    handlerDefs,
+    prefix,
+    instanceName,
+  } = params;
   const firstArg = call.arguments[0];
   if (!firstArg || !ts.isObjectLiteralExpression(firstArg)) {
     diagnostics.push({
@@ -218,6 +267,7 @@ function extractRouteObject(params: {
     path: joinPath(prefix, path),
     handlerRef,
   });
+  upsertHandler(handlers, handlerDefs, handlerRef);
 }
 
 function analyzeRegisterCall(params: {
@@ -225,12 +275,23 @@ function analyzeRegisterCall(params: {
   file: string;
   diagnostics: DiagnosticIR[];
   routes: RouteIR[];
+  handlers: HandlerIR[];
   pluginDefs: Map<string, PluginDef>;
+  handlerDefs: Map<string, HandlerDef>;
   prefix: string;
   instanceName: string;
 }) {
-  const { call, file, diagnostics, routes, pluginDefs, prefix, instanceName } =
-    params;
+  const {
+    call,
+    file,
+    diagnostics,
+    routes,
+    handlers,
+    pluginDefs,
+    handlerDefs,
+    prefix,
+    instanceName,
+  } = params;
 
   const pluginExpr = call.arguments[0];
   const optionsExpr = call.arguments[1];
@@ -247,7 +308,9 @@ function analyzeRegisterCall(params: {
       file,
       diagnostics,
       routes,
+      handlers,
       pluginDefs,
+      handlerDefs,
       instanceName: inlinePlugin.paramName,
       prefix: nextPrefix,
     });
@@ -263,7 +326,9 @@ function analyzeRegisterCall(params: {
         file,
         diagnostics,
         routes,
+        handlers,
         pluginDefs,
+        handlerDefs,
         instanceName: def.paramName,
         prefix: nextPrefix,
       });
@@ -285,6 +350,59 @@ function analyzeRegisterCall(params: {
     message: `unsupported register callback pattern on ${instanceName}.register(...)`,
     source: { file },
   });
+}
+
+function upsertHandler(
+  handlers: HandlerIR[],
+  handlerDefs: Map<string, HandlerDef>,
+  handlerRef: string,
+) {
+  if (!/^[A-Za-z_$][\w$]*$/.test(handlerRef)) return;
+  if (handlers.some((h) => h.id === handlerRef)) return;
+
+  const def = handlerDefs.get(handlerRef);
+  if (!def) return;
+
+  handlers.push({
+    id: handlerRef,
+    params: def.params.map((name) => ({ name, role: inferParamRole(name) })),
+    async: def.async,
+    semantics: {
+      responseMode: inferResponseMode(def.body, def.params),
+    },
+  });
+}
+
+function inferParamRole(name: string): HandlerIR["params"][number]["role"] {
+  const n = name.toLowerCase();
+  if (n === "req" || n === "request") return "request";
+  if (n === "res" || n === "reply" || n === "response") return "response";
+  if (n === "next") return "next";
+  return "custom";
+}
+
+function inferResponseMode(
+  body: string,
+  params: string[],
+): HandlerResponseMode {
+  const responseParam = params.find((p) => {
+    const n = p.toLowerCase();
+    return n === "res" || n === "reply" || n === "response";
+  });
+  if (
+    responseParam &&
+    new RegExp(`\\b${escapeRe(responseParam)}\\s*\\.`).test(body)
+  ) {
+    return "response-object";
+  }
+
+  const nextParam = params.find((p) => p.toLowerCase() === "next");
+  if (nextParam && new RegExp(`\\b${escapeRe(nextParam)}\\s*\\(`).test(body)) {
+    return "next-callback";
+  }
+
+  if (/\breturn\b/i.test(body)) return "return";
+  return "unknown";
 }
 
 function collectPluginDefinitions(
@@ -320,6 +438,47 @@ function collectPluginDefinitions(
   return map;
 }
 
+function collectHandlerDefinitions(
+  sourceFile: ts.SourceFile,
+): Map<string, HandlerDef> {
+  const map = new Map<string, HandlerDef>();
+
+  for (const statement of sourceFile.statements) {
+    if (
+      ts.isFunctionDeclaration(statement) &&
+      statement.name &&
+      statement.body
+    ) {
+      map.set(statement.name.text, {
+        params: parseParamNames(statement.parameters),
+        async: hasAsyncModifier(statement),
+        body: statement.body.getText(sourceFile),
+      });
+      continue;
+    }
+
+    if (!ts.isVariableStatement(statement)) continue;
+    for (const declaration of statement.declarationList.declarations) {
+      if (!ts.isIdentifier(declaration.name) || !declaration.initializer)
+        continue;
+
+      const init = declaration.initializer;
+      if (
+        (ts.isFunctionExpression(init) || ts.isArrowFunction(init)) &&
+        ts.isBlock(init.body)
+      ) {
+        map.set(declaration.name.text, {
+          params: parseParamNames(init.parameters),
+          async: hasAsyncModifier(init),
+          body: init.body.getText(sourceFile),
+        });
+      }
+    }
+  }
+
+  return map;
+}
+
 function parsePluginExpression(expr: ts.Expression): PluginDef | null {
   if (
     (ts.isFunctionExpression(expr) || ts.isArrowFunction(expr)) &&
@@ -331,6 +490,23 @@ function parsePluginExpression(expr: ts.Expression): PluginDef | null {
   }
 
   return null;
+}
+
+function parseParamNames(params: readonly ts.ParameterDeclaration[]): string[] {
+  return params
+    .map((p) => {
+      if (!ts.isIdentifier(p.name)) return null;
+      return p.name.text;
+    })
+    .filter((v): v is string => typeof v === "string");
+}
+
+function hasAsyncModifier(node: ts.Node): boolean {
+  return Boolean(
+    (node as { modifiers?: ts.NodeArray<ts.ModifierLike> }).modifiers?.some(
+      (m) => m.kind === ts.SyntaxKind.AsyncKeyword,
+    ),
+  );
 }
 
 function firstParam(params: readonly ts.ParameterDeclaration[]): string | null {
@@ -443,4 +619,8 @@ function joinPath(prefix: string, path: string): string {
 
 function ensureSlash(v: string): string {
   return v.startsWith("/") ? v : `/${v}`;
+}
+
+function escapeRe(v: string): string {
+  return v.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/packages/analyzer/test/analyze-fastify.test.js
+++ b/packages/analyzer/test/analyze-fastify.test.js
@@ -20,6 +20,26 @@ test("extracts method/path/handler from shorthand and route object", () => {
     { method: "POST", path: "/users", handlerRef: "createUser" },
     { method: "PATCH", path: "/users/:id", handlerRef: "updateUser" },
   ]);
+  assert.deepEqual(ir.handlers, [
+    {
+      id: "listUsers",
+      params: [],
+      async: true,
+      semantics: { responseMode: "unknown" },
+    },
+    {
+      id: "createUser",
+      params: [],
+      async: true,
+      semantics: { responseMode: "unknown" },
+    },
+    {
+      id: "updateUser",
+      params: [],
+      async: false,
+      semantics: { responseMode: "unknown" },
+    },
+  ]);
   assert.equal(ir.diagnostics.length, 0);
 });
 

--- a/packages/emitter-go/src/index.ts
+++ b/packages/emitter-go/src/index.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import type { ProgramIR, RouteIR } from "@tsgodown/ir-core";
+import type { HandlerIR, ProgramIR, RouteIR } from "@tsgodown/ir-core";
 
 function routeHandlerName(index: number): string {
   return `route${index}`;
@@ -49,7 +49,16 @@ function emitPathParams(route: RouteIR): string[] {
   return lines;
 }
 
-function emitRoute(route: RouteIR, index: number): string[] {
+function formatHandlerParams(handler: HandlerIR | undefined): string {
+  if (!handler || handler.params.length === 0) return "none";
+  return handler.params.map((p) => `${p.role}:${p.name}`).join(", ");
+}
+
+function emitRoute(
+  route: RouteIR,
+  index: number,
+  handler: HandlerIR | undefined,
+): string[] {
   const todoMessage = `TODO implement handler ${route.handlerRef} for ${route.method} ${route.path}`;
 
   const lines: string[] = [
@@ -60,6 +69,9 @@ function emitRoute(route: RouteIR, index: number): string[] {
     `\t//   Path: ${quoteGo(route.path)}`,
     `\t//   Pattern: ${quoteGo(toServeMuxPattern(route))}`,
     `\t//   Handler: ${quoteGo(route.handlerRef)}`,
+    `\t//   Handler params: ${formatHandlerParams(handler)}`,
+    `\t//   Handler async: ${handler?.async ?? "unknown"}`,
+    `\t//   Handler response mode: ${handler?.semantics?.responseMode ?? "unknown"}`,
   ];
 
   if ((route.middlewareRefs?.length ?? 0) > 0) {
@@ -107,8 +119,12 @@ export function emitGoProject(ir: ProgramIR, outDir: string) {
   lines.push("\t}");
   lines.push("}", "");
 
+  const handlerById = new Map(
+    ir.handlers.map((handler) => [handler.id, handler]),
+  );
+
   for (const [index, route] of ir.routes.entries()) {
-    lines.push(...emitRoute(route, index));
+    lines.push(...emitRoute(route, index, handlerById.get(route.handlerRef)));
   }
 
   fs.writeFileSync(path.join(outDir, "main.go"), `${lines.join("\n")}`);

--- a/packages/emitter-go/test/emit-go.test.ts
+++ b/packages/emitter-go/test/emit-go.test.ts
@@ -25,7 +25,23 @@ function createOutDir() {
 
 const sampleIr: ProgramIR = {
   modules: [],
-  handlers: [],
+  handlers: [
+    {
+      id: "health",
+      params: [
+        { name: "req", role: "request" },
+        { name: "reply", role: "response" },
+      ],
+      async: false,
+      semantics: { responseMode: "response-object" },
+    },
+    {
+      id: "createUser",
+      params: [{ name: "req", role: "request" }],
+      async: true,
+      semantics: { responseMode: "return" },
+    },
+  ],
   diagnostics: [],
   routes: [
     {
@@ -54,10 +70,16 @@ test("emitGoProject emits deterministic main.go scaffold with method-aware route
   assert.match(emitted, /\/\/\s+Method:\s+GET/);
   assert.match(emitted, /\/\/\s+Path:\s+"\/health"/);
   assert.match(emitted, /\/\/\s+Handler:\s+"health"/);
+  assert.match(emitted, /\/\/\s+Handler params:\s+request:req, response:reply/);
+  assert.match(emitted, /\/\/\s+Handler async:\s+false/);
+  assert.match(emitted, /\/\/\s+Handler response mode:\s+response-object/);
   assert.match(emitted, /\/\/\s+Middleware:\s+\["auth"\]/);
   assert.match(emitted, /\/\/\s+Method:\s+POST/);
   assert.match(emitted, /\/\/\s+Path:\s+"\/users\/:id"/);
   assert.match(emitted, /\/\/\s+Handler:\s+"createUser"/);
+  assert.match(emitted, /\/\/\s+Handler params:\s+request:req/);
+  assert.match(emitted, /\/\/\s+Handler async:\s+true/);
+  assert.match(emitted, /\/\/\s+Handler response mode:\s+return/);
   assert.match(emitted, /id := req\.PathValue\("id"\)/);
   assert.match(
     emitted,

--- a/packages/ir-core/src/index.ts
+++ b/packages/ir-core/src/index.ts
@@ -14,6 +14,12 @@ export interface RouteIR {
   middlewareRefs?: string[];
 }
 
+export type HandlerResponseMode =
+  | "return"
+  | "response-object"
+  | "next-callback"
+  | "unknown";
+
 export interface HandlerIR {
   id: string;
   params: Array<{
@@ -22,6 +28,9 @@ export interface HandlerIR {
   }>;
   bodyRef?: string;
   async: boolean;
+  semantics?: {
+    responseMode: HandlerResponseMode;
+  };
 }
 
 export interface DiagnosticIR {


### PR DESCRIPTION
## Summary
- Extend IR handler semantics with pragmatic v1 metadata:
  - Added `HandlerResponseMode` and optional `HandlerIR.semantics.responseMode` in `@tsgodown/ir-core`.
- Update analyzer to infer and emit handler semantics for referenced named handlers:
  - infer handler param roles (`request`/`response`/`next`/`custom`)
  - infer `async` from declaration
  - infer response mode (`response-object`/`next-callback`/`return`/`unknown`)
- Update Go emitter to consume handler semantics and include them in route TODO metadata comments.
- Sync IR spec documentation with the new handler semantics fields.

## Why
Downstream emitter needs minimal-but-structured handler semantics to generate more actionable scaffolding without introducing framework policy into IR.

## Backward compatibility
- Existing IR fields are unchanged.
- `HandlerIR.semantics` is optional.
- Existing routes-only flows continue to work when handler semantics are absent.

## Validation
- `pnpm install`
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run test:tdd`

All checks passed.
