### PR TITLE
feat: route TS build flow via Rust engine adapter stub

### DIFF
--- a/.pr-body-ts-wrapper-rust-engine-v1.md
+++ b/.pr-body-ts-wrapper-rust-engine-v1.md
@@ -1,0 +1,27 @@
+## Summary
+- keep the TS CLI/config UX unchanged, but route build execution through a new TS `runBuild` Rust-engine adapter layer
+- add a JSON IO contract for TS -> Rust engine invocation:
+  - request: `{ action: "build", cwd, configPath? }`
+  - response success: `{ ok: true, manifest, diagnostics? }`
+  - response failure: `{ ok: false, error: { source, cause, guidance } }`
+- support external binary invocation via `TSGODOWN_RUST_ENGINE_BIN` (stdin/stdout JSON transport)
+- keep a default in-process stub engine (`rust-engine-stub`) that currently delegates to `tsdown.build` while honoring the adapter contract
+- standardize failure messages from adapter path in `source=... cause=... guidance=...` form
+
+## Tests
+- `packages/tsdown-driver/test/driver.test.ts`
+  - verifies adapter request contract invocation
+  - verifies adapter error propagation format
+- `packages/cli/test/commands.e2e.test.ts`
+  - integration test proving CLI/pipeline invoke the adapter binary path with JSON request capture
+  - integration test proving adapter error fields surface in CLI stderr contract
+
+## Gate
+- pnpm install ✅
+- pnpm run lint ✅
+- pnpm run format:check ✅
+- pnpm run test:tdd ✅
+- cargo test: not applicable (no Rust crate/binary compiled or tested in-repo in this change)
+
+## Notes
+- no merge performed (per instruction)

--- a/packages/cli/test/commands.e2e.test.ts
+++ b/packages/cli/test/commands.e2e.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
+import crypto from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -35,10 +36,15 @@ function setupProject(
   return dir;
 }
 
-function runCli(cwd: string, command: "build" | "check" | "report" | "stages") {
+function runCli(
+  cwd: string,
+  command: "build" | "check" | "report" | "stages",
+  env?: NodeJS.ProcessEnv,
+) {
   const result = spawnSync(process.execPath, [cliEntry, command, "--json"], {
     cwd,
     encoding: "utf8",
+    env,
   });
   return result;
 }
@@ -196,4 +202,111 @@ test("CLI fail diagnostics include source/cause/guidance contract", () => {
       new RegExp(token.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")),
     );
   }
+});
+
+test("CLI build routes through rust adapter binary with JSON contract", () => {
+  const cwd = setupProject([
+    "const fastify = {} as any;",
+    "const health = () => {};",
+    "fastify.get('/health', health);",
+  ]);
+
+  const capturePath = path.join(cwd, `request-${crypto.randomUUID()}.json`);
+  const stubPath = path.join(cwd, `rust-stub-${crypto.randomUUID()}.mjs`);
+
+  fs.writeFileSync(
+    stubPath,
+    [
+      "import fs from 'node:fs';",
+      "const chunks = [];",
+      "for await (const chunk of process.stdin) chunks.push(chunk);",
+      "const request = JSON.parse(Buffer.concat(chunks).toString('utf8'));",
+      `fs.writeFileSync(${JSON.stringify(capturePath)}, JSON.stringify(request, null, 2));`,
+      "const response = {",
+      "  ok: true,",
+      "  diagnostics: ['engine=rust-binary-stub'],",
+      "  manifest: {",
+      "    buildId: '1122334455667788',",
+      "    entries: ['src/index.ts'],",
+      "    bundles: [{ file: 'dist/index.mjs', map: 'dist/index.mjs.map', format: 'esm', exports: [] }],",
+      "    types: ['dist/index.d.ts'],",
+      "    tsconfigPath: 'tsconfig.json'",
+      "  }",
+      "};",
+      "process.stdout.write(JSON.stringify(response));",
+    ].join("\n"),
+  );
+
+  const launcherPath = path.join(
+    cwd,
+    `rust-launcher-${crypto.randomUUID()}.sh`,
+  );
+  fs.writeFileSync(
+    launcherPath,
+    `#!/usr/bin/env bash\nexec ${JSON.stringify(process.execPath)} ${JSON.stringify(stubPath)}\n`,
+  );
+  fs.chmodSync(launcherPath, 0o755);
+
+  const result = runCli(cwd, "build", {
+    ...process.env,
+    TSGODOWN_RUST_ENGINE_BIN: launcherPath,
+  });
+
+  assert.equal(result.status, 0, `build failed: ${result.stderr}`);
+  const captured = JSON.parse(fs.readFileSync(capturePath, "utf8")) as {
+    action: string;
+    cwd: string;
+  };
+  assert.equal(captured.action, "build");
+  const realCwd = fs.realpathSync(cwd);
+  assert.ok(captured.cwd === cwd || captured.cwd === realCwd);
+});
+
+test("CLI surfaces rust adapter error propagation format", () => {
+  const cwd = setupProject([
+    "const fastify = {} as any;",
+    "const health = () => {};",
+    "fastify.get('/health', health);",
+  ]);
+
+  const stubPath = path.join(cwd, `rust-stub-error-${crypto.randomUUID()}.mjs`);
+
+  fs.writeFileSync(
+    stubPath,
+    [
+      "for await (const _ of process.stdin) { /* drain */ }",
+      "const response = {",
+      "  ok: false,",
+      "  error: {",
+      "    source: 'rust-engine-adapter',",
+      "    cause: 'invalid build graph',",
+      "    guidance: 'Check Rust engine JSON contract and retry.'",
+      "  }",
+      "};",
+      "process.stdout.write(JSON.stringify(response));",
+    ].join("\n"),
+  );
+
+  const launcherPath = path.join(
+    cwd,
+    `rust-launcher-error-${crypto.randomUUID()}.sh`,
+  );
+  fs.writeFileSync(
+    launcherPath,
+    `#!/usr/bin/env bash\nexec ${JSON.stringify(process.execPath)} ${JSON.stringify(stubPath)}\n`,
+  );
+  fs.chmodSync(launcherPath, 0o755);
+
+  const result = runCli(cwd, "build", {
+    ...process.env,
+    TSGODOWN_RUST_ENGINE_BIN: launcherPath,
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /source=rust-engine-adapter/);
+  assert.match(result.stderr, /cause=invalid build graph/);
+  assert.match(
+    result.stderr,
+    /guidance=Check Rust engine JSON contract and retry\./,
+  );
 });

--- a/packages/tsdown-driver/src/index.ts
+++ b/packages/tsdown-driver/src/index.ts
@@ -1,3 +1,4 @@
+import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
 import { promises as fs } from "node:fs";
 import path from "node:path";
@@ -21,7 +22,7 @@ export interface ArtifactManifest {
 }
 
 export interface RunBuildResult {
-  mode: "tsdown-programmatic";
+  mode: "rust-engine-adapter";
   manifestPath: string;
   manifest: ArtifactManifest;
   diagnostics: string[];
@@ -39,8 +40,32 @@ export interface TsdownBundleLike {
   };
 }
 
+export interface RustEngineRequest {
+  action: "build";
+  cwd: string;
+  configPath?: string;
+}
+
+export type RustEngineResponse =
+  | {
+      ok: true;
+      manifest: ArtifactManifest;
+      diagnostics?: string[];
+    }
+  | {
+      ok: false;
+      error: {
+        source: string;
+        cause: string;
+        guidance: string;
+      };
+    };
+
 interface RunBuildOptions {
   executeBuild?: (inlineConfig: InlineConfig) => Promise<TsdownBundleLike[]>;
+  executeRustEngine?: (
+    request: RustEngineRequest,
+  ) => Promise<RustEngineResponse>;
 }
 
 export async function runBuild(
@@ -48,9 +73,61 @@ export async function runBuild(
   configPath?: string,
   options: RunBuildOptions = {},
 ): Promise<RunBuildResult> {
-  const inlineConfig: InlineConfig = {
+  const request: RustEngineRequest = {
+    action: "build",
     cwd,
-    ...(configPath ? { config: configPath } : {}),
+    ...(configPath ? { configPath } : {}),
+  };
+
+  const executeRustEngine =
+    options.executeRustEngine ?? ((req) => invokeRustEngine(req, options));
+  const response = await executeRustEngine(request);
+
+  if (!response.ok) {
+    throw new Error(
+      `[tsdown-driver] rust engine failed source=${response.error.source} cause=${response.error.cause} guidance=${response.error.guidance}`,
+    );
+  }
+
+  const manifestPath = await writeManifest(cwd, response.manifest);
+  return {
+    mode: "rust-engine-adapter",
+    manifestPath,
+    manifest: response.manifest,
+    diagnostics: response.diagnostics ?? [],
+  };
+}
+
+async function invokeRustEngine(
+  request: RustEngineRequest,
+  options: Pick<RunBuildOptions, "executeBuild">,
+): Promise<RustEngineResponse> {
+  const rustBin = process.env.TSGODOWN_RUST_ENGINE_BIN;
+  if (rustBin) {
+    return invokeRustBinary(rustBin, request);
+  }
+
+  return runRustEngineStub(request, options);
+}
+
+async function runRustEngineStub(
+  request: RustEngineRequest,
+  options: Pick<RunBuildOptions, "executeBuild">,
+): Promise<RustEngineResponse> {
+  if (request.action !== "build") {
+    return {
+      ok: false,
+      error: {
+        source: "rust-engine-stub",
+        cause: `unsupported action: ${request.action}`,
+        guidance: "Use action=build.",
+      },
+    };
+  }
+
+  const inlineConfig: InlineConfig = {
+    cwd: request.cwd,
+    ...(request.configPath ? { config: request.configPath } : {}),
   };
 
   let bundles: TsdownBundleLike[];
@@ -60,21 +137,95 @@ export async function runBuild(
       ((config) => build(config) as Promise<TsdownBundle[]>);
     bundles = await executeBuild(inlineConfig);
   } catch (error) {
-    throw new Error(
-      `[tsdown-driver] build failed (source=tsdown.build cwd=${toPosix(cwd)} config=${toPosix(configPath ?? "auto")}): ${formatErrorWithCause(error)}`,
-      { cause: error },
-    );
+    return {
+      ok: false,
+      error: {
+        source: "rust-engine-stub(tsdown.build)",
+        cause: formatErrorWithCause(error),
+        guidance:
+          "Verify tsgodown.config.ts and entry paths, then retry build.",
+      },
+    };
   }
 
-  const manifest = buildManifestFromBundles(cwd, bundles, configPath);
-  const manifestPath = await writeManifest(cwd, manifest);
-
   return {
-    mode: "tsdown-programmatic",
-    manifestPath,
-    manifest,
-    diagnostics: [],
+    ok: true,
+    manifest: buildManifestFromBundles(
+      request.cwd,
+      bundles,
+      request.configPath,
+    ),
+    diagnostics: ["engine=rust-stub", "transport=json-io"],
   };
+}
+
+async function invokeRustBinary(
+  commandPath: string,
+  request: RustEngineRequest,
+): Promise<RustEngineResponse> {
+  return new Promise((resolve) => {
+    const child = spawn(commandPath, [], {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+
+    child.on("error", (error) => {
+      resolve({
+        ok: false,
+        error: {
+          source: "rust-engine-binary-spawn",
+          cause: formatErrorWithCause(error),
+          guidance:
+            "Check TSGODOWN_RUST_ENGINE_BIN points to an executable binary.",
+        },
+      });
+    });
+
+    child.on("close", (code) => {
+      const out = stdout.trim();
+      if (code !== 0) {
+        resolve({
+          ok: false,
+          error: {
+            source: "rust-engine-binary",
+            cause: `exit=${code ?? "null"} stderr=${stderr.trim() || "n/a"}`,
+            guidance: "Inspect rust engine logs and JSON response contract.",
+          },
+        });
+        return;
+      }
+
+      try {
+        const parsed = JSON.parse(out) as RustEngineResponse;
+        resolve(parsed);
+      } catch (error) {
+        resolve({
+          ok: false,
+          error: {
+            source: "rust-engine-binary-json",
+            cause: `${formatErrorWithCause(error)} stdout=${out || "<empty>"}`,
+            guidance:
+              "Ensure rust engine prints a valid JSON object to stdout.",
+          },
+        });
+      }
+    });
+
+    child.stdin.write(`${JSON.stringify(request)}\n`);
+    child.stdin.end();
+  });
 }
 
 export function buildManifestFromBundles(

--- a/packages/tsdown-driver/test/driver.test.ts
+++ b/packages/tsdown-driver/test/driver.test.ts
@@ -1,7 +1,14 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 
-import { buildManifestFromBundles, runBuild } from "../src/index.ts";
+import {
+  type RustEngineRequest,
+  buildManifestFromBundles,
+  runBuild,
+} from "../src/index.ts";
 
 test("buildManifestFromBundles maps real bundle, sourcemap and d.ts outputs", () => {
   const cwd = "/repo";
@@ -40,26 +47,71 @@ test("buildManifestFromBundles maps real bundle, sourcemap and d.ts outputs", ()
   assert.match(manifest.buildId, /^[a-f0-9]{16}$/);
 });
 
-test("runBuild reports source and exact cause chain on tsdown failure", async () => {
-  const rootCause = new Error("ENOENT: missing entry src/index.ts");
-  const tsdownError = new Error("config resolution failed", {
-    cause: rootCause,
-  });
+test("runBuild invokes rust adapter with JSON request contract", async () => {
+  let seenRequest: RustEngineRequest | undefined;
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "tsgodown-driver-test-"));
 
+  try {
+    const result = await runBuild(cwd, "tsdown.config.ts", {
+      executeRustEngine: async (request) => {
+        seenRequest = request;
+        return {
+          ok: true,
+          manifest: {
+            buildId: "aabbccddeeff0011",
+            entries: ["src/index.ts"],
+            bundles: [
+              {
+                file: "dist/index.mjs",
+                map: "dist/index.mjs.map",
+                format: "esm",
+                exports: [],
+              },
+            ],
+            types: ["dist/index.d.ts"],
+            tsconfigPath: "tsconfig.json",
+          },
+          diagnostics: ["adapter=stub"],
+        };
+      },
+    });
+
+    assert.deepEqual(seenRequest, {
+      action: "build",
+      cwd,
+      configPath: "tsdown.config.ts",
+    });
+    assert.equal(result.mode, "rust-engine-adapter");
+    assert.equal(
+      result.manifestPath,
+      path.join(cwd, "artifacts", "manifests", "manifest.json"),
+    );
+    assert.equal(result.manifest.buildId, "aabbccddeeff0011");
+    assert.deepEqual(result.diagnostics, ["adapter=stub"]);
+  } finally {
+    fs.rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test("runBuild reports rust engine error in source/cause/guidance format", async () => {
   await assert.rejects(
     runBuild("/repo", "tsdown.config.ts", {
-      executeBuild: async () => {
-        throw tsdownError;
-      },
+      executeRustEngine: async () => ({
+        ok: false,
+        error: {
+          source: "rust-engine-adapter",
+          cause: "ENOENT: missing entry src/index.ts",
+          guidance: "Verify tsgodown.config.ts entry path and file existence.",
+        },
+      }),
     }),
     (error: unknown) => {
       assert.ok(error instanceof Error);
-      assert.match(error.message, /source=tsdown\.build/);
-      assert.match(error.message, /config=tsdown\.config\.ts/);
-      assert.match(error.message, /Error: config resolution failed/);
+      assert.match(error.message, /source=rust-engine-adapter/);
+      assert.match(error.message, /cause=ENOENT: missing entry src\/index\.ts/);
       assert.match(
         error.message,
-        /cause: Error: ENOENT: missing entry src\/index\.ts/,
+        /guidance=Verify tsgodown\.config\.ts entry path and file existence\./,
       );
       return true;
     },


### PR DESCRIPTION
## Summary
- keep the TS CLI/config UX unchanged, but route build execution through a new TS `runBuild` Rust-engine adapter layer
- add a JSON IO contract for TS -> Rust engine invocation:
  - request: `{ action: "build", cwd, configPath? }`
  - response success: `{ ok: true, manifest, diagnostics? }`
  - response failure: `{ ok: false, error: { source, cause, guidance } }`
- support external binary invocation via `TSGODOWN_RUST_ENGINE_BIN` (stdin/stdout JSON transport)
- keep a default in-process stub engine (`rust-engine-stub`) that currently delegates to `tsdown.build` while honoring the adapter contract
- standardize failure messages from adapter path in `source=... cause=... guidance=...` form

## Tests
- `packages/tsdown-driver/test/driver.test.ts`
  - verifies adapter request contract invocation
  - verifies adapter error propagation format
- `packages/cli/test/commands.e2e.test.ts`
  - integration test proving CLI/pipeline invoke the adapter binary path with JSON request capture
  - integration test proving adapter error fields surface in CLI stderr contract

## Gate
- pnpm install ✅
- pnpm run lint ✅
- pnpm run format:check ✅
- pnpm run test:tdd ✅
- cargo test: not applicable (no Rust crate/binary compiled or tested in-repo in this change)

## Notes
- no merge performed (per instruction)
