### PR TITLE
test: freeze Rust contract drift protections v2

### DIFF
--- a/packages/analyzer-rust/tests/contract_parity_regression.rs
+++ b/packages/analyzer-rust/tests/contract_parity_regression.rs
@@ -118,7 +118,17 @@ fn rust_contract_parity_routes_and_diagnostics_are_stable() {
             let mut actual_diag_details = ir
                 .diagnostics
                 .iter()
-                .map(|d| (d.code.as_str(), d.message.as_str(), d.level.as_str()))
+                .map(|d| {
+                    (
+                        d.code.as_str(),
+                        d.message.as_str(),
+                        d.level.as_str(),
+                        d.source
+                            .as_ref()
+                            .map(|source| source.file.as_str())
+                            .unwrap_or("<missing-source-file>"),
+                    )
+                })
                 .collect::<Vec<_>>();
             actual_diag_details.sort();
 
@@ -127,23 +137,26 @@ fn rust_contract_parity_routes_and_diagnostics_are_stable() {
                     "ANALYZER_UNRESOLVED_PLUGIN",
                     "register plugin 'externalPlugin' could not be resolved in current file. Ensure plugin is declared in the same file or use an inline callback.",
                     "warn",
+                    file.as_str(),
                 ),
                 (
                     "ANALYZER_UNSUPPORTED_DYNAMIC_PATH",
                     "unsupported dynamic path in fastify.get(...). Use string literal path (e.g. '/users/:id') for IR extraction.",
                     "warn",
+                    file.as_str(),
                 ),
                 (
                     "ANALYZER_UNSUPPORTED_INLINE_HANDLER",
                     "unsupported non-reference handler in fastify.post('/inline', handler). Extract handler to a named function and pass its identifier.",
                     "warn",
+                    file.as_str(),
                 ),
             ];
             expected_diag_details.sort();
 
             assert_eq!(
                 actual_diag_details, expected_diag_details,
-                "diagnostic message/level contract drifted for fixture: {}",
+                "diagnostic code/message/level/source.file contract drifted for fixture: {}",
                 case.name
             );
         }

--- a/packages/tsdown-driver/test/driver.test.ts
+++ b/packages/tsdown-driver/test/driver.test.ts
@@ -149,78 +149,174 @@ test("runBuild reports rust engine error in source/cause/guidance format", async
   );
 });
 
-test("runBuild accepts status-envelope success payload and normalizes diagnostics", async () => {
-  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "tsgodown-driver-test-"));
+test("runBuild accepts status-envelope success variants and normalizes diagnostics", async () => {
+  const fixtures: Array<{
+    name: string;
+    status: "ok" | "success";
+    buildId: string;
+  }> = [
+    { name: "status=ok", status: "ok", buildId: "0011223344556677" },
+    {
+      name: "status=success",
+      status: "success",
+      buildId: "8899aabbccddeeff",
+    },
+  ];
 
-  try {
-    const result = await runBuild(cwd, "tsdown.config.ts", {
-      executeRustEngine: async () => ({
-        status: "success",
-        manifest: {
-          buildId: "0011223344556677",
-          entries: ["src/index.ts"],
-          bundles: [
-            {
-              file: "dist/index.mjs",
-              map: "dist/index.mjs.map",
-              format: "esm",
-              exports: [],
-            },
-          ],
-          types: ["dist/index.d.ts"],
-          tsconfigPath: "tsconfig.json",
-        },
-        diagnostics: ["  keep-me  ", "", 42],
-      }),
-    });
+  for (const fixture of fixtures) {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "tsgodown-driver-test-"));
 
-    assert.equal(result.manifest.buildId, "0011223344556677");
-    assert.deepEqual(result.diagnostics, ["keep-me"]);
-  } finally {
-    fs.rmSync(cwd, { recursive: true, force: true });
+    try {
+      const result = await runBuild(cwd, "tsdown.config.ts", {
+        executeRustEngine: async () => ({
+          status: fixture.status,
+          manifest: {
+            buildId: fixture.buildId,
+            entries: ["src/index.ts"],
+            bundles: [
+              {
+                file: "dist/index.mjs",
+                map: "dist/index.mjs.map",
+                format: "esm",
+                exports: [],
+              },
+            ],
+            types: ["dist/index.d.ts"],
+            tsconfigPath: "tsconfig.json",
+          },
+          diagnostics: ["  keep-me  ", "", 42],
+        }),
+      });
+
+      assert.equal(
+        result.manifest.buildId,
+        fixture.buildId,
+        `manifest.buildId drifted for fixture: ${fixture.name}`,
+      );
+      assert.deepEqual(
+        result.diagnostics,
+        ["keep-me"],
+        `diagnostics normalization drifted for fixture: ${fixture.name}`,
+      );
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true });
+    }
   }
 });
 
-test("runBuild maps invalid status envelope to deterministic contract error", async () => {
-  await assert.rejects(
-    runBuild("/repo", "tsdown.config.ts", {
-      executeRustEngine: async () =>
-        ({ status: "maybe" }) as unknown as RustEngineResponse,
-    }),
-    (error: unknown) => {
-      assert.ok(error instanceof Error);
-      assert.match(error.message, /source=rust-engine-binary-contract/);
-      assert.match(error.message, /cause=missing or invalid status envelope/);
-      assert.match(
-        error.message,
-        /guidance=Ensure rust engine returns deterministic status or ok envelope\./,
-      );
-      return true;
+test("runBuild maps malformed responses to deterministic contract errors", async () => {
+  const fixtures: Array<{
+    name: string;
+    response: unknown;
+    expectedCause: RegExp;
+  }> = [
+    {
+      name: "invalid status value",
+      response: { status: "maybe" },
+      expectedCause: /cause=missing or invalid status envelope/,
     },
-  );
+    {
+      name: "non-object payload",
+      response: "not-json-object",
+      expectedCause: /cause=missing or invalid status envelope/,
+    },
+    {
+      name: "ok envelope missing manifest",
+      response: { status: "ok" },
+      expectedCause: /cause=ok envelope missing valid manifest payload/,
+    },
+  ];
+
+  for (const fixture of fixtures) {
+    await assert.rejects(
+      runBuild("/repo", "tsdown.config.ts", {
+        executeRustEngine: async () => fixture.response as RustEngineResponse,
+      }),
+      (error: unknown) => {
+        assert.ok(error instanceof Error);
+        assert.match(
+          error.message,
+          /source=rust-engine-binary-contract/,
+          `source drifted for fixture: ${fixture.name}`,
+        );
+        assert.match(
+          error.message,
+          fixture.expectedCause,
+          `cause drifted for fixture: ${fixture.name}`,
+        );
+        assert.match(
+          error.message,
+          /guidance=Ensure rust engine returns deterministic status or ok envelope\./,
+          `guidance drifted for fixture: ${fixture.name}`,
+        );
+        return true;
+      },
+      `fixture should fail: ${fixture.name}`,
+    );
+  }
 });
 
-test("runBuild maps failed status-envelope to deterministic source/cause/guidance", async () => {
-  await assert.rejects(
-    runBuild("/repo", "tsdown.config.ts", {
-      executeRustEngine: async () => ({
+test("runBuild maps failed status-envelope variants to deterministic source/cause/guidance", async () => {
+  const fixtures: Array<{
+    name: string;
+    response: RustEngineResponse;
+    source: RegExp;
+    cause: RegExp;
+    guidance: RegExp;
+  }> = [
+    {
+      name: "status=failed top-level fallbacks",
+      response: {
         status: "failed",
         source: "  ",
         cause: "",
-      }),
-    }),
-    (error: unknown) => {
-      assert.ok(error instanceof Error);
-      assert.match(error.message, /source=rust-engine-binary/);
-      assert.match(
-        error.message,
-        /cause=rust engine returned error without cause/,
-      );
-      assert.match(
-        error.message,
+      },
+      source: /source=rust-engine-binary/,
+      cause: /cause=rust engine returned error without cause/,
+      guidance:
         /guidance=Inspect rust engine logs and JSON response contract\./,
-      );
-      return true;
     },
-  );
+    {
+      name: "status=error nested error object",
+      response: {
+        status: "error",
+        error: {
+          source: "rust-engine-adapter",
+          cause: "invalid graph",
+          guidance: "Retry with fixed config.",
+        },
+      },
+      source: /source=rust-engine-adapter/,
+      cause: /cause=invalid graph/,
+      guidance: /guidance=Retry with fixed config\./,
+    },
+  ];
+
+  for (const fixture of fixtures) {
+    await assert.rejects(
+      runBuild("/repo", "tsdown.config.ts", {
+        executeRustEngine: async () => fixture.response,
+      }),
+      (error: unknown) => {
+        assert.ok(error instanceof Error);
+        assert.match(
+          error.message,
+          fixture.source,
+          `source drifted for fixture: ${fixture.name}`,
+        );
+        assert.match(
+          error.message,
+          fixture.cause,
+          `cause drifted for fixture: ${fixture.name}`,
+        );
+        assert.match(
+          error.message,
+          fixture.guidance,
+          `guidance drifted for fixture: ${fixture.name}`,
+        );
+        return true;
+      },
+      `fixture should fail: ${fixture.name}`,
+    );
+  }
 });


### PR DESCRIPTION
## Summary
- strengthen Rust contract drift protection tests in `tsdown-driver` with fixture-scoped checks for:
  - status-envelope success variants (`ok`/`success`)
  - malformed response mapping (`invalid status`, `non-object payload`, `ok without manifest`)
  - failed envelope variants (`failed`/`error`) with deterministic `source/cause/guidance`
- tighten analyzer regression checks in `analyzer-rust` to snapshot full diagnostic tuples for unsupported fixture:
  - `code/message/level/source.file`

## Why
This freezes high-risk Rust contract surfaces so drift is detected early and failures clearly point to a specific fixture.

## Validation
- package tests first:
  - `pnpm --filter @tsgodown/tsdown-driver test`
  - `cargo test -p analyzer-rust --test contract_parity_regression`
- full CI-equivalent gate executed in order:
  1. `pnpm install --frozen-lockfile`
  2. `pnpm run lint`
  3. `pnpm run format:check`
  4. `pnpm run guard:runtime`
  5. `pnpm run build`
  6. `pnpm run test`
  7. `cargo fmt --all --check`
  8. `cargo clippy --workspace --all-targets -- -D warnings`
- additional rust validation:
  - `cargo test --workspace --all-targets`
