### PR TITLE
refactor(cli): abstraction-first command modules with barrel exports

### DIFF
--- a/packages/cli/src/argv.ts
+++ b/packages/cli/src/argv.ts
@@ -1,0 +1,20 @@
+import type { Command } from "./types.js";
+
+export function parseArgv(argv: string[]): {
+  command: Command | string;
+  json: boolean;
+} {
+  const command = (argv[0] || "build") as Command | string;
+  const flags = new Set(argv.slice(1));
+  const json = flags.has("--json") || flags.has("-j");
+  return { command, json };
+}
+
+export function isCommand(value: string): value is Command {
+  return (
+    value === "build" ||
+    value === "check" ||
+    value === "report" ||
+    value === "stages"
+  );
+}

--- a/packages/cli/src/command-executor.ts
+++ b/packages/cli/src/command-executor.ts
@@ -1,0 +1,25 @@
+import { runBuild, runCheck, runReport, runStages } from "./commands/index.js";
+import type { Command } from "./types.js";
+
+export async function executeCommand(
+  command: Command,
+  cwd: string,
+  json: boolean,
+) {
+  switch (command) {
+    case "build":
+      await runBuild(cwd, json);
+      return;
+    case "check":
+      await runCheck(cwd, json);
+      return;
+    case "report":
+      await runReport(cwd, json);
+      return;
+    case "stages":
+      await runStages(cwd, json);
+      return;
+    default:
+      throw new Error(`unsupported command: ${String(command)}`);
+  }
+}

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -1,0 +1,12 @@
+import { build } from "@tsgodown/core";
+import { humanPrintSummary } from "../output/human.js";
+import { printJson } from "../output/json.js";
+
+export async function runBuild(cwd: string, json: boolean) {
+  const result = await build(cwd);
+  if (json) {
+    printJson(result);
+    return;
+  }
+  humanPrintSummary("build completed", result);
+}

--- a/packages/cli/src/commands/check.ts
+++ b/packages/cli/src/commands/check.ts
@@ -1,0 +1,12 @@
+import { check } from "@tsgodown/core";
+import { humanPrintSummary } from "../output/human.js";
+import { printJson } from "../output/json.js";
+
+export async function runCheck(cwd: string, json: boolean) {
+  const result = await check(cwd);
+  if (json) {
+    printJson(result);
+    return;
+  }
+  humanPrintSummary("check completed (no emit)", result);
+}

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -1,0 +1,4 @@
+export { runBuild } from "./build.js";
+export { runCheck } from "./check.js";
+export { runReport } from "./report.js";
+export { runStages } from "./stages.js";

--- a/packages/cli/src/commands/report.ts
+++ b/packages/cli/src/commands/report.ts
@@ -1,0 +1,12 @@
+import { report } from "@tsgodown/core";
+import { humanPrintSummary } from "../output/human.js";
+import { printJson } from "../output/json.js";
+
+export async function runReport(cwd: string, json: boolean) {
+  const result = await report(cwd);
+  if (json) {
+    printJson(result);
+    return;
+  }
+  humanPrintSummary("report", result);
+}

--- a/packages/cli/src/commands/stages.ts
+++ b/packages/cli/src/commands/stages.ts
@@ -1,0 +1,12 @@
+import { stages } from "@tsgodown/core";
+import { humanPrintStages } from "../output/human.js";
+import { printJson } from "../output/json.js";
+
+export async function runStages(cwd: string, json: boolean) {
+  const result = await stages(cwd);
+  if (json) {
+    printJson(result);
+    return;
+  }
+  humanPrintStages(result);
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,94 +1,16 @@
 #!/usr/bin/env node
-import { build, check, report, stages } from "@tsgodown/core";
-
-type Command = "build" | "check" | "report" | "stages";
-
-const argv = process.argv.slice(2);
-const command = (argv[0] || "build") as Command;
-const flags = new Set(argv.slice(1));
-const json = flags.has("--json") || flags.has("-j");
-
-function humanPrintSummary(
-  kind: string,
-  result: {
-    cwd: string;
-    stages?: readonly string[];
-    targets: Array<{
-      configIndex: number;
-      entry: string;
-      outDir: string;
-      artifact: string;
-      emitted: boolean;
-      diagnostics: { routes: number; warnings: string[] };
-    }>;
-  },
-) {
-  console.log(`[tsgodown] ${kind}`);
-  console.log(`cwd: ${result.cwd}`);
-  if (result.stages) {
-    console.log(`stages: ${result.stages.join(" -> ")}`);
-  }
-  for (const target of result.targets) {
-    console.log(`\n- config #${target.configIndex}`);
-    console.log(`  entry: ${target.entry}`);
-    console.log(`  outDir: ${target.outDir}`);
-    console.log(
-      `  artifact: ${target.artifact} ${target.emitted ? "(present)" : "(missing)"}`,
-    );
-    console.log(`  routes: ${target.diagnostics.routes}`);
-    if (target.diagnostics.warnings.length > 0) {
-      console.log("  warnings:");
-      for (const warning of target.diagnostics.warnings) {
-        console.log(`    - ${warning}`);
-      }
-    }
-  }
-}
+import { isCommand, parseArgv } from "./argv.js";
+import { executeCommand } from "./command-executor.js";
 
 async function main() {
-  switch (command) {
-    case "build": {
-      const result = await build(process.cwd());
-      if (json) console.log(JSON.stringify(result, null, 2));
-      else {
-        humanPrintSummary("build completed", result);
-      }
-      break;
-    }
-    case "check": {
-      const result = await check(process.cwd());
-      if (json) console.log(JSON.stringify(result, null, 2));
-      else humanPrintSummary("check completed (no emit)", result);
-      break;
-    }
-    case "report": {
-      const result = await report(process.cwd());
-      if (json) console.log(JSON.stringify(result, null, 2));
-      else humanPrintSummary("report", result);
-      break;
-    }
-    case "stages": {
-      const result = await stages(process.cwd());
-      if (json) console.log(JSON.stringify(result, null, 2));
-      else {
-        console.log("[tsgodown] active stages + paths");
-        console.log(`cwd: ${result.cwd}`);
-        console.log(`stages: ${result.stages.join(" -> ")}`);
-        for (const target of result.targets) {
-          console.log(`\n- config #${target.configIndex}`);
-          console.log(`  entry: ${target.entry}`);
-          console.log(`  outDir: ${target.outDir}`);
-          console.log(
-            `  artifact: ${target.artifact} ${target.emitted ? "(present)" : "(missing)"}`,
-          );
-        }
-      }
-      break;
-    }
-    default:
-      console.error(`[tsgodown] unsupported command: ${command}`);
-      process.exit(1);
+  const { command, json } = parseArgv(process.argv.slice(2));
+
+  if (!isCommand(command)) {
+    console.error(`[tsgodown] unsupported command: ${command}`);
+    process.exit(1);
   }
+
+  await executeCommand(command, process.cwd(), json);
 }
 
 try {

--- a/packages/cli/src/output/human.ts
+++ b/packages/cli/src/output/human.ts
@@ -1,0 +1,38 @@
+import type { CommandResult, StagesResult } from "../types.js";
+
+export function humanPrintSummary(kind: string, result: CommandResult) {
+  console.log(`[tsgodown] ${kind}`);
+  console.log(`cwd: ${result.cwd}`);
+  if (result.stages) {
+    console.log(`stages: ${result.stages.join(" -> ")}`);
+  }
+  for (const target of result.targets) {
+    console.log(`\n- config #${target.configIndex}`);
+    console.log(`  entry: ${target.entry}`);
+    console.log(`  outDir: ${target.outDir}`);
+    console.log(
+      `  artifact: ${target.artifact} ${target.emitted ? "(present)" : "(missing)"}`,
+    );
+    console.log(`  routes: ${target.diagnostics.routes}`);
+    if (target.diagnostics.warnings.length > 0) {
+      console.log("  warnings:");
+      for (const warning of target.diagnostics.warnings) {
+        console.log(`    - ${warning}`);
+      }
+    }
+  }
+}
+
+export function humanPrintStages(result: StagesResult) {
+  console.log("[tsgodown] active stages + paths");
+  console.log(`cwd: ${result.cwd}`);
+  console.log(`stages: ${result.stages.join(" -> ")}`);
+  for (const target of result.targets) {
+    console.log(`\n- config #${target.configIndex}`);
+    console.log(`  entry: ${target.entry}`);
+    console.log(`  outDir: ${target.outDir}`);
+    console.log(
+      `  artifact: ${target.artifact} ${target.emitted ? "(present)" : "(missing)"}`,
+    );
+  }
+}

--- a/packages/cli/src/output/index.ts
+++ b/packages/cli/src/output/index.ts
@@ -1,0 +1,2 @@
+export { humanPrintSummary, humanPrintStages } from "./human.js";
+export { printJson } from "./json.js";

--- a/packages/cli/src/output/json.ts
+++ b/packages/cli/src/output/json.ts
@@ -1,0 +1,3 @@
+export function printJson(result: unknown) {
+  console.log(JSON.stringify(result, null, 2));
+}

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -1,0 +1,33 @@
+export type Command = "build" | "check" | "report" | "stages";
+
+export type TargetDiagnostics = {
+  routes: number;
+  warnings: string[];
+};
+
+export type TargetSummary = {
+  configIndex: number;
+  entry: string;
+  outDir: string;
+  artifact: string;
+  emitted: boolean;
+  diagnostics: TargetDiagnostics;
+};
+
+export type CommandResult = {
+  cwd: string;
+  stages?: readonly string[];
+  targets: TargetSummary[];
+};
+
+export type StagesResult = {
+  cwd: string;
+  stages: readonly string[];
+  targets: Array<{
+    configIndex: number;
+    entry: string;
+    outDir: string;
+    artifact: string;
+    emitted: boolean;
+  }>;
+};


### PR DESCRIPTION
## Summary
- refactor `@tsgodown/cli` entrypoint into command-responsibility modules
- split argv parsing, command execution dispatch, human report formatting, and JSON output into dedicated helpers
- add barrel exports for command-layer (`src/commands/index.ts`) and output-layer (`src/output/index.ts`)
- keep runtime behavior and output contract unchanged (same messages, same JSON payloads)

## Refactor details
- `src/index.ts`: reduced to parse + validation + orchestration + existing error contract
- `src/argv.ts`: command/flag parsing and command type guard
- `src/command-executor.ts`: command dispatch unit
- `src/commands/*`: per-command execution modules (`build`, `check`, `report`, `stages`)
- `src/output/*`: human summary/stages formatting and JSON output helper
- `src/types.ts`: shared command/result shape aliases for report helpers

## Verification (full gate)
Executed in exact required order:
1. `pnpm install`
2. `pnpm run lint`
3. `pnpm run format:check`
4. `pnpm run build`
5. `pnpm run test`
6. `cargo fmt --all --check`
7. `cargo clippy --workspace --all-targets -- -D warnings`
8. `cargo test --workspace --all-targets`

All passed.
