### PR TITLE
refactor(engine-core): modularize contracts/analyze/cli glue

### DIFF
--- a/.pr-body-rust-engine-core-modularization-v1.md
+++ b/.pr-body-rust-engine-core-modularization-v1.md
@@ -1,0 +1,26 @@
+## Summary
+- Refactor `crates/engine-core` into clear modules while preserving behavior and API shape:
+  - `contract.rs`: all request/response/IR/diagnostic contract types
+  - `analyze.rs`: core `analyze` flow
+  - `normalize.rs`: internal normalization helper(s)
+  - `cli.rs`: binary command execution flow
+  - `error.rs`: CLI error-to-exit mapping
+- Keep `lib.rs` and `main.rs` as crate-local glue/re-export boundaries only.
+- No functional changes to analyze output, CLI usage string, or exit code behavior.
+
+## TDD
+- Kept existing tests intact; no test logic changes.
+- Verified existing contract round-trip and analyze mapping tests continue to pass unchanged.
+
+## Validation
+- Full gate run passed in CI order:
+  1. `pnpm run lint`
+  2. `pnpm run format:check`
+  3. `pnpm run build`
+  4. `pnpm run test`
+  5. `cargo fmt --all --check`
+  6. `cargo clippy --workspace --all-targets -- -D warnings`
+  7. `cargo test --workspace --all-targets`
+
+## Notes
+- `guard:runtime` script is not present on current `main`; validation follows current `.github/workflows/ci.yml` order exactly.

--- a/crates/engine-core/src/analyze.rs
+++ b/crates/engine-core/src/analyze.rs
@@ -1,0 +1,19 @@
+use crate::contract::{AnalyzeRequest, AnalyzeResponse, Diagnostic, DiagnosticLevel, IrDocument};
+use crate::normalize::framework_label;
+
+pub fn analyze(request: AnalyzeRequest) -> AnalyzeResponse {
+    let framework = framework_label(request.manifest.framework.as_deref());
+
+    AnalyzeResponse {
+        ir: IrDocument {
+            version: "0.1".to_string(),
+            entry: request.manifest.entry,
+            routes: vec![],
+        },
+        diagnostics: vec![Diagnostic {
+            level: DiagnosticLevel::Info,
+            code: "ENGINE_CORE_BOOTSTRAP".to_string(),
+            message: format!("engine-core analyze bootstrap executed (framework={framework})"),
+        }],
+    }
+}

--- a/crates/engine-core/src/cli.rs
+++ b/crates/engine-core/src/cli.rs
@@ -1,0 +1,28 @@
+use std::io::{self, Read};
+
+use engine_core::{analyze, AnalyzeRequest};
+
+use crate::error::CliError;
+
+pub fn run() -> Result<(), CliError> {
+    let mut args = std::env::args();
+    let _bin = args.next();
+
+    match args.next().as_deref() {
+        Some("analyze") => {
+            let mut input = String::new();
+            io::stdin()
+                .read_to_string(&mut input)
+                .expect("failed to read stdin");
+
+            let request: AnalyzeRequest =
+                serde_json::from_str(&input).expect("failed to parse AnalyzeRequest JSON");
+            let response = analyze(request);
+            let output =
+                serde_json::to_string_pretty(&response).expect("failed to encode response");
+            println!("{output}");
+            Ok(())
+        }
+        _ => Err(CliError::Usage),
+    }
+}

--- a/crates/engine-core/src/contract.rs
+++ b/crates/engine-core/src/contract.rs
@@ -1,0 +1,57 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct InputManifest {
+    pub entry: String,
+    #[serde(default)]
+    pub framework: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct AnalyzeConfig {
+    #[serde(default)]
+    pub profile: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AnalyzeRequest {
+    pub manifest: InputManifest,
+    #[serde(default)]
+    pub config: AnalyzeConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct IrDocument {
+    pub version: String,
+    pub entry: String,
+    #[serde(default)]
+    pub routes: Vec<Route>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Route {
+    pub method: String,
+    pub path: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Diagnostic {
+    pub level: DiagnosticLevel,
+    pub code: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum DiagnosticLevel {
+    Info,
+    Warning,
+    Error,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AnalyzeResponse {
+    pub ir: IrDocument,
+    #[serde(default)]
+    pub diagnostics: Vec<Diagnostic>,
+}

--- a/crates/engine-core/src/error.rs
+++ b/crates/engine-core/src/error.rs
@@ -1,0 +1,12 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CliError {
+    Usage,
+}
+
+impl CliError {
+    pub fn exit_code(self) -> i32 {
+        match self {
+            Self::Usage => 2,
+        }
+    }
+}

--- a/crates/engine-core/src/lib.rs
+++ b/crates/engine-core/src/lib.rs
@@ -1,81 +1,12 @@
-use serde::{Deserialize, Serialize};
+mod analyze;
+mod contract;
+mod normalize;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct InputManifest {
-    pub entry: String,
-    #[serde(default)]
-    pub framework: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
-pub struct AnalyzeConfig {
-    #[serde(default)]
-    pub profile: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct AnalyzeRequest {
-    pub manifest: InputManifest,
-    #[serde(default)]
-    pub config: AnalyzeConfig,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct IrDocument {
-    pub version: String,
-    pub entry: String,
-    #[serde(default)]
-    pub routes: Vec<Route>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct Route {
-    pub method: String,
-    pub path: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct Diagnostic {
-    pub level: DiagnosticLevel,
-    pub code: String,
-    pub message: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "lowercase")]
-pub enum DiagnosticLevel {
-    Info,
-    Warning,
-    Error,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct AnalyzeResponse {
-    pub ir: IrDocument,
-    #[serde(default)]
-    pub diagnostics: Vec<Diagnostic>,
-}
-
-pub fn analyze(request: AnalyzeRequest) -> AnalyzeResponse {
-    let framework = request
-        .manifest
-        .framework
-        .clone()
-        .unwrap_or_else(|| "unknown".to_string());
-
-    AnalyzeResponse {
-        ir: IrDocument {
-            version: "0.1".to_string(),
-            entry: request.manifest.entry,
-            routes: vec![],
-        },
-        diagnostics: vec![Diagnostic {
-            level: DiagnosticLevel::Info,
-            code: "ENGINE_CORE_BOOTSTRAP".to_string(),
-            message: format!("engine-core analyze bootstrap executed (framework={framework})"),
-        }],
-    }
-}
+pub use analyze::analyze;
+pub use contract::{
+    AnalyzeConfig, AnalyzeRequest, AnalyzeResponse, Diagnostic, DiagnosticLevel, InputManifest,
+    IrDocument, Route,
+};
 
 #[cfg(test)]
 mod tests {

--- a/crates/engine-core/src/main.rs
+++ b/crates/engine-core/src/main.rs
@@ -1,28 +1,13 @@
-use std::io::{self, Read};
-
-use engine_core::{analyze, AnalyzeRequest};
+mod cli;
+mod error;
 
 fn main() {
-    let mut args = std::env::args();
-    let _bin = args.next();
-
-    match args.next().as_deref() {
-        Some("analyze") => {
-            let mut input = String::new();
-            io::stdin()
-                .read_to_string(&mut input)
-                .expect("failed to read stdin");
-
-            let request: AnalyzeRequest =
-                serde_json::from_str(&input).expect("failed to parse AnalyzeRequest JSON");
-            let response = analyze(request);
-            let output =
-                serde_json::to_string_pretty(&response).expect("failed to encode response");
-            println!("{output}");
+    if let Err(error) = cli::run() {
+        match error {
+            error::CliError::Usage => {
+                eprintln!("usage: engine-core analyze");
+            }
         }
-        _ => {
-            eprintln!("usage: engine-core analyze");
-            std::process::exit(2);
-        }
+        std::process::exit(error.exit_code());
     }
 }

--- a/crates/engine-core/src/normalize.rs
+++ b/crates/engine-core/src/normalize.rs
@@ -1,0 +1,5 @@
+pub(crate) fn framework_label(framework: Option<&str>) -> String {
+    framework
+        .map(str::to_string)
+        .unwrap_or_else(|| "unknown".to_string())
+}


### PR DESCRIPTION
## Summary
- Refactor `crates/engine-core` into clear modules while preserving behavior and API shape:
  - `contract.rs`: all request/response/IR/diagnostic contract types
  - `analyze.rs`: core `analyze` flow
  - `normalize.rs`: internal normalization helper(s)
  - `cli.rs`: binary command execution flow
  - `error.rs`: CLI error-to-exit mapping
- Keep `lib.rs` and `main.rs` as crate-local glue/re-export boundaries only.
- No functional changes to analyze output, CLI usage string, or exit code behavior.

## TDD
- Kept existing tests intact; no test logic changes.
- Verified existing contract round-trip and analyze mapping tests continue to pass unchanged.

## Validation
- Full gate run passed in CI order:
  1. `pnpm run lint`
  2. `pnpm run format:check`
  3. `pnpm run build`
  4. `pnpm run test`
  5. `cargo fmt --all --check`
  6. `cargo clippy --workspace --all-targets -- -D warnings`
  7. `cargo test --workspace --all-targets`

## Notes
- `guard:runtime` script is not present on current `main`; validation follows current `.github/workflows/ci.yml` order exactly.
