### PR TITLE
refactor(pipeline): abstraction-first split for orchestration/adapter/normalization

### DIFF
--- a/packages/pipeline/src/index.ts
+++ b/packages/pipeline/src/index.ts
@@ -1,5 +1,6 @@
 import { loadUserConfig } from "@tsgodown/config";
-import { runBuild } from "@tsgodown/tsdown-driver";
+
+import { orchestratePipelineStages } from "./internal/index.js";
 
 export interface PipelineOptions {
   log?: (message: string) => void;
@@ -7,31 +8,11 @@ export interface PipelineOptions {
 
 export async function runPipeline(cwd: string, options: PipelineOptions = {}) {
   const log = options.log ?? ((msg: string) => console.log(msg));
-
   const configs = await loadUserConfig(cwd);
-  for (const conf of configs) {
-    const entry = typeof conf.entry === "string" ? conf.entry : "src/index.ts";
 
-    try {
-      log("[BUILD_ARTIFACTS] collecting build outputs");
-      await runBuild(cwd);
-
-      log(`[BUILD_IR] analyzing entry: ${entry} (delegated to rust engine)`);
-      log(
-        "[CAPABILITY_GATE] validating required capabilities (delegated to rust engine)",
-      );
-      log("[EMIT_GO] writing Go scaffold (delegated to rust engine)");
-      await conf.onSuccess?.();
-    } catch (cause) {
-      const msg = cause instanceof Error ? cause.message : String(cause);
-      throw new Error(
-        [
-          `[pipeline] failed for entry \"${entry}\"`,
-          `source: ${entry}`,
-          `cause: ${msg}`,
-          "guidance: Verify rust engine build/analyze contract and tsgodown.config.ts settings.",
-        ].join("; "),
-      );
-    }
-  }
+  await orchestratePipelineStages({
+    cwd,
+    configs,
+    log,
+  });
 }

--- a/packages/pipeline/src/internal/index.ts
+++ b/packages/pipeline/src/internal/index.ts
@@ -1,0 +1,3 @@
+export * from "./stage-orchestration.js";
+export * from "./rust-adapter-boundary.js";
+export * from "./result-normalization.js";

--- a/packages/pipeline/src/internal/result-normalization.ts
+++ b/packages/pipeline/src/internal/result-normalization.ts
@@ -1,0 +1,23 @@
+import type { UserConfig } from "@tsgodown/config";
+
+const DEFAULT_ENTRY = "src/index.ts";
+
+export function resolveEntry(config: UserConfig): string {
+  return typeof config.entry === "string" ? config.entry : DEFAULT_ENTRY;
+}
+
+export function normalizePipelineCause(cause: unknown): string {
+  return cause instanceof Error ? cause.message : String(cause);
+}
+
+export function formatPipelineFailure(entry: string, cause: unknown): Error {
+  const message = normalizePipelineCause(cause);
+  return new Error(
+    [
+      `[pipeline] failed for entry \"${entry}\"`,
+      `source: ${entry}`,
+      `cause: ${message}`,
+      "guidance: Verify rust engine build/analyze contract and tsgodown.config.ts settings.",
+    ].join("; "),
+  );
+}

--- a/packages/pipeline/src/internal/rust-adapter-boundary.ts
+++ b/packages/pipeline/src/internal/rust-adapter-boundary.ts
@@ -1,0 +1,7 @@
+import { runBuild } from "@tsgodown/tsdown-driver";
+
+export async function runBuildArtifactsViaRustAdapter(
+  cwd: string,
+): Promise<void> {
+  await runBuild(cwd);
+}

--- a/packages/pipeline/src/internal/stage-orchestration.ts
+++ b/packages/pipeline/src/internal/stage-orchestration.ts
@@ -1,0 +1,34 @@
+import type { UserConfig } from "@tsgodown/config";
+
+import { formatPipelineFailure, resolveEntry } from "./result-normalization.js";
+import { runBuildArtifactsViaRustAdapter } from "./rust-adapter-boundary.js";
+
+export interface StageOrchestrationOptions {
+  cwd: string;
+  configs: UserConfig[];
+  log: (message: string) => void;
+}
+
+export async function orchestratePipelineStages({
+  cwd,
+  configs,
+  log,
+}: StageOrchestrationOptions): Promise<void> {
+  for (const config of configs) {
+    const entry = resolveEntry(config);
+
+    try {
+      log("[BUILD_ARTIFACTS] collecting build outputs");
+      await runBuildArtifactsViaRustAdapter(cwd);
+
+      log(`[BUILD_IR] analyzing entry: ${entry} (delegated to rust engine)`);
+      log(
+        "[CAPABILITY_GATE] validating required capabilities (delegated to rust engine)",
+      );
+      log("[EMIT_GO] writing Go scaffold (delegated to rust engine)");
+      await config.onSuccess?.();
+    } catch (cause) {
+      throw formatPipelineFailure(entry, cause);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- split `packages/pipeline` runtime flow into abstraction-first internals:
  - stage orchestration (`stage-orchestration.ts`)
  - rust adapter boundary (`rust-adapter-boundary.ts`)
  - result normalization (`result-normalization.ts`)
- keep `runPipeline` as thin entrypoint delegating orchestration
- add internal barrel export (`internal/index.ts`) to improve module boundaries

## Behavior / Contract
- no behavior drift intended
- preserved runtime logging sequence and error contract formatting
- `runBuild` still invoked via rust adapter boundary

## Validation (CI order)
1. `pnpm run lint`
2. `pnpm run format:check`
3. `pnpm run build`
4. `pnpm run test`
5. `cargo fmt --all --check`
6. `cargo clippy --workspace --all-targets -- -D warnings`
7. `cargo test --workspace --all-targets`

All passed.