### PR TITLE
refactor(emitter-go): abstraction-first split for rendering pipeline

### DIFF
--- a/packages/emitter-go/src/index.ts
+++ b/packages/emitter-go/src/index.ts
@@ -1,235 +1,33 @@
 import fs from "node:fs";
 import path from "node:path";
-import type {
-  DiagnosticIR,
-  HandlerIR,
-  ProgramIR,
-  RouteIR,
-} from "@tsgodown/ir-core";
+import type { ProgramIR } from "@tsgodown/ir-core";
 
-function routeHandlerName(index: number): string {
-  return `route${index}`;
-}
-
-function quoteGo(value: string): string {
-  return JSON.stringify(value);
-}
-
-function normalizeHttpMethod(method: string): string {
-  return method.trim().toUpperCase();
-}
-
-function normalizeRoutePath(pathname: string): string {
-  const trimmed = pathname.trim();
-  if (trimmed.length === 0) {
-    return "/";
-  }
-  return trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
-}
-
-function toServeMuxPath(pathname: string): string {
-  return normalizeRoutePath(pathname).replaceAll(
-    /:([A-Za-z_][A-Za-z0-9_]*)/g,
-    "{$1}",
-  );
-}
-
-function toServeMuxPattern(route: RouteIR): string {
-  return `${normalizeHttpMethod(route.method)} ${toServeMuxPath(route.path)}`;
-}
-
-function extractPathParamNames(pathname: string): string[] {
-  const names: string[] = [];
-  const seen = new Set<string>();
-  const normalized = normalizeRoutePath(pathname);
-
-  for (const match of normalized.matchAll(/:([A-Za-z_][A-Za-z0-9_]*)/g)) {
-    const name = match[1];
-    if (!seen.has(name)) {
-      seen.add(name);
-      names.push(name);
-    }
-  }
-
-  for (const match of normalized.matchAll(
-    /\{([A-Za-z_][A-Za-z0-9_]*)(?:\.\.\.)?\}/g,
-  )) {
-    const name = match[1];
-    if (!seen.has(name)) {
-      seen.add(name);
-      names.push(name);
-    }
-  }
-
-  return names;
-}
-
-function emitPathParams(route: RouteIR): string[] {
-  const names = extractPathParamNames(route.path);
-  if (names.length === 0) {
-    return [];
-  }
-
-  const lines = ["\t// Extracted path params:"];
-  for (const name of names) {
-    lines.push(`\t${name} := req.PathValue(${quoteGo(name)})`);
-    lines.push(`\t_ = ${name}`);
-  }
-  lines.push("");
-
-  return lines;
-}
-
-function formatHandlerParams(handler: HandlerIR | undefined): string {
-  if (!handler || handler.params.length === 0) return "none";
-  return handler.params.map((p) => `${p.role}:${p.name}`).join(", ");
-}
-
-function formatDiagnosticSource(diagnostic: DiagnosticIR): string | undefined {
-  const source = diagnostic.source;
-  if (!source) return undefined;
-
-  const line = source.line ?? "?";
-  const column = source.column ?? "?";
-  return `${source.file}:${line}:${column}`;
-}
-
-function emitDiagnosticsComments(diagnostics: DiagnosticIR[]): string[] {
-  if (diagnostics.length === 0) {
-    return [];
-  }
-
-  const lines = [
-    "// IR diagnostics carried from rust analyzer (SSoT):",
-    "// Generated Go may be scaffold-only until these diagnostics are resolved.",
-  ];
-
-  for (const diagnostic of diagnostics) {
-    lines.push(
-      `// [${diagnostic.level}] ${diagnostic.code}: ${diagnostic.message}`,
-    );
-
-    const source = formatDiagnosticSource(diagnostic);
-    if (source) {
-      lines.push(`//   at ${source}`);
-    }
-  }
-
-  lines.push(
-    "// Action: fix diagnostics in source and regenerate. Emitter does not own policy decisions.",
-    "",
-  );
-
-  return lines;
-}
-
-function emitRoute(
-  route: RouteIR,
-  index: number,
-  handler: HandlerIR | undefined,
-): string[] {
-  const normalizedMethod = normalizeHttpMethod(route.method);
-  const normalizedPath = normalizeRoutePath(route.path);
-  const todoMessage = `TODO implement handler ${route.handlerRef} for ${normalizedMethod} ${normalizedPath}`;
-
-  const lines: string[] = [
-    `func ${routeHandlerName(index)}(w http.ResponseWriter, req *http.Request) {`,
-    "",
-    "\t// Route metadata:",
-    `\t//   Method: ${normalizedMethod}`,
-    `\t//   Path: ${quoteGo(normalizedPath)}`,
-    `\t//   Pattern: ${quoteGo(toServeMuxPattern(route))}`,
-    `\t//   Handler: ${quoteGo(route.handlerRef)}`,
-    `\t//   Handler params: ${formatHandlerParams(handler)}`,
-    `\t//   Handler async: ${handler?.async ?? "unknown"}`,
-    `\t//   Handler response mode: ${handler?.semantics?.responseMode ?? "unknown"}`,
-  ];
-
-  if ((route.middlewareRefs?.length ?? 0) > 0) {
-    lines.push(`\t//   Middleware: ${JSON.stringify(route.middlewareRefs)}`);
-  }
-
-  lines.push(
-    `\t// TODO(tsgodown): Implement handler ${quoteGo(route.handlerRef)} for ${normalizedMethod} ${normalizedPath}.`,
-    "\t//   - Replace this scaffold with application logic.",
-    "\t//   - Validate request input and map to domain arguments.",
-    "\t//   - Write response status, headers, and body.",
-    "",
-    ...emitPathParams(route),
-    '\tw.Header().Set("Content-Type", "text/plain; charset=utf-8")',
-    "\tw.WriteHeader(http.StatusNotImplemented)",
-    `\tfmt.Fprintln(w, ${quoteGo(todoMessage)})`,
-    "}",
-    "",
-  );
-
-  return lines;
-}
+import {
+  renderDiagnosticsComments,
+  renderGoImports,
+  renderMainFunction,
+  renderResolveListenAddr,
+  renderRoute,
+  renderRouteRegistry,
+} from "./render/index";
 
 export function emitGoProject(ir: ProgramIR, outDir: string) {
   fs.mkdirSync(outDir, { recursive: true });
   const lines: string[] = [];
 
   lines.push("package main", "");
-  lines.push(
-    "import (",
-    '\t"fmt"',
-    '\t"net/http"',
-    '\t"os"',
-    '\t"strings"',
-    '\t"time"',
-    ")",
-    "",
-  );
-
-  lines.push(...emitDiagnosticsComments(ir.diagnostics));
-
-  lines.push("func registerRoutes(mux *http.ServeMux) {");
-  for (const [index, route] of ir.routes.entries()) {
-    lines.push(
-      `\tmux.HandleFunc(${quoteGo(toServeMuxPattern(route))}, ${routeHandlerName(index)})`,
-    );
-  }
-  lines.push("}", "");
-
-  lines.push("func resolveListenAddr() string {");
-  lines.push(
-    '\tif addr := strings.TrimSpace(os.Getenv("TSGODOWN_ADDR")); addr != "" {',
-  );
-  lines.push("\t\treturn addr");
-  lines.push("\t}");
-  lines.push('\tif port := strings.TrimSpace(os.Getenv("PORT")); port != "" {');
-  lines.push('\t\tif strings.Contains(port, ":") {');
-  lines.push("\t\t\treturn port");
-  lines.push("\t\t}");
-  lines.push('\t\treturn ":" + port');
-  lines.push("\t}");
-  lines.push('\treturn ":18081"');
-  lines.push("}", "");
-
-  lines.push("func main() {");
-  lines.push("\tmux := http.NewServeMux()");
-  lines.push("\tregisterRoutes(mux)");
-  lines.push("\taddr := resolveListenAddr()");
-  lines.push('\tfmt.Println("tsgodown scaffold listening on", addr)');
-  lines.push("\tserver := &http.Server{");
-  lines.push("\t\tAddr:              addr,");
-  lines.push("\t\tHandler:           mux,");
-  lines.push("\t\tReadHeaderTimeout: 5 * time.Second,");
-  lines.push("\t}");
-  lines.push(
-    "\tif err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {",
-  );
-  lines.push('\t\tfmt.Println("server exited:", err)');
-  lines.push("\t}");
-  lines.push("}", "");
+  lines.push(...renderGoImports());
+  lines.push(...renderDiagnosticsComments(ir.diagnostics));
+  lines.push(...renderRouteRegistry(ir.routes));
+  lines.push(...renderResolveListenAddr());
+  lines.push(...renderMainFunction());
 
   const handlerById = new Map(
     ir.handlers.map((handler) => [handler.id, handler]),
   );
 
   for (const [index, route] of ir.routes.entries()) {
-    lines.push(...emitRoute(route, index, handlerById.get(route.handlerRef)));
+    lines.push(...renderRoute(route, index, handlerById.get(route.handlerRef)));
   }
 
   fs.writeFileSync(path.join(outDir, "main.go"), `${lines.join("\n")}`);

--- a/packages/emitter-go/src/render/diagnostics-comment-rendering.ts
+++ b/packages/emitter-go/src/render/diagnostics-comment-rendering.ts
@@ -1,0 +1,41 @@
+import type { DiagnosticIR } from "@tsgodown/ir-core";
+
+function formatDiagnosticSource(diagnostic: DiagnosticIR): string | undefined {
+  const source = diagnostic.source;
+  if (!source) return undefined;
+
+  const line = source.line ?? "?";
+  const column = source.column ?? "?";
+  return `${source.file}:${line}:${column}`;
+}
+
+export function renderDiagnosticsComments(
+  diagnostics: DiagnosticIR[],
+): string[] {
+  if (diagnostics.length === 0) {
+    return [];
+  }
+
+  const lines = [
+    "// IR diagnostics carried from rust analyzer (SSoT):",
+    "// Generated Go may be scaffold-only until these diagnostics are resolved.",
+  ];
+
+  for (const diagnostic of diagnostics) {
+    lines.push(
+      `// [${diagnostic.level}] ${diagnostic.code}: ${diagnostic.message}`,
+    );
+
+    const source = formatDiagnosticSource(diagnostic);
+    if (source) {
+      lines.push(`//   at ${source}`);
+    }
+  }
+
+  lines.push(
+    "// Action: fix diagnostics in source and regenerate. Emitter does not own policy decisions.",
+    "",
+  );
+
+  return lines;
+}

--- a/packages/emitter-go/src/render/index.ts
+++ b/packages/emitter-go/src/render/index.ts
@@ -1,0 +1,8 @@
+export { renderDiagnosticsComments } from "./diagnostics-comment-rendering";
+export {
+  renderGoImports,
+  renderMainFunction,
+  renderResolveListenAddr,
+  renderRouteRegistry,
+} from "./server-bootstrap-rendering";
+export { renderRoute } from "./template-rendering";

--- a/packages/emitter-go/src/render/route-normalization.ts
+++ b/packages/emitter-go/src/render/route-normalization.ts
@@ -1,0 +1,50 @@
+import type { RouteIR } from "@tsgodown/ir-core";
+
+export function normalizeHttpMethod(method: string): string {
+  return method.trim().toUpperCase();
+}
+
+export function normalizeRoutePath(pathname: string): string {
+  const trimmed = pathname.trim();
+  if (trimmed.length === 0) {
+    return "/";
+  }
+  return trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+}
+
+function toServeMuxPath(pathname: string): string {
+  return normalizeRoutePath(pathname).replaceAll(
+    /:([A-Za-z_][A-Za-z0-9_]*)/g,
+    "{$1}",
+  );
+}
+
+export function toServeMuxPattern(route: RouteIR): string {
+  return `${normalizeHttpMethod(route.method)} ${toServeMuxPath(route.path)}`;
+}
+
+export function extractPathParamNames(pathname: string): string[] {
+  const names: string[] = [];
+  const seen = new Set<string>();
+  const normalized = normalizeRoutePath(pathname);
+
+  for (const match of normalized.matchAll(/:([A-Za-z_][A-Za-z0-9_]*)/g)) {
+    const name = match[1];
+    if (!seen.has(name)) {
+      seen.add(name);
+      names.push(name);
+    }
+  }
+
+  for (const match of normalized.matchAll(
+    /\{([A-Za-z_][A-Za-z0-9_]*)(?:\.\.\.)?\}/g,
+  )) {
+    const name = match[1];
+    if (!seen.has(name)) {
+      seen.add(name);
+      names.push(name);
+    }
+  }
+
+  return names;
+}

--- a/packages/emitter-go/src/render/server-bootstrap-rendering.ts
+++ b/packages/emitter-go/src/render/server-bootstrap-rendering.ts
@@ -1,0 +1,63 @@
+import type { RouteIR } from "@tsgodown/ir-core";
+
+import { renderRouteRegistration } from "./template-rendering";
+
+export function renderGoImports(): string[] {
+  return [
+    "import (",
+    '\t"fmt"',
+    '\t"net/http"',
+    '\t"os"',
+    '\t"strings"',
+    '\t"time"',
+    ")",
+    "",
+  ];
+}
+
+export function renderRouteRegistry(routes: RouteIR[]): string[] {
+  const lines = ["func registerRoutes(mux *http.ServeMux) {"];
+  for (const [index, route] of routes.entries()) {
+    lines.push(renderRouteRegistration(route, index));
+  }
+  lines.push("}", "");
+  return lines;
+}
+
+export function renderResolveListenAddr(): string[] {
+  return [
+    "func resolveListenAddr() string {",
+    '\tif addr := strings.TrimSpace(os.Getenv("TSGODOWN_ADDR")); addr != "" {',
+    "\t\treturn addr",
+    "\t}",
+    '\tif port := strings.TrimSpace(os.Getenv("PORT")); port != "" {',
+    '\t\tif strings.Contains(port, ":") {',
+    "\t\t\treturn port",
+    "\t\t}",
+    '\t\treturn ":" + port',
+    "\t}",
+    '\treturn ":18081"',
+    "}",
+    "",
+  ];
+}
+
+export function renderMainFunction(): string[] {
+  return [
+    "func main() {",
+    "\tmux := http.NewServeMux()",
+    "\tregisterRoutes(mux)",
+    "\taddr := resolveListenAddr()",
+    '\tfmt.Println("tsgodown scaffold listening on", addr)',
+    "\tserver := &http.Server{",
+    "\t\tAddr:              addr,",
+    "\t\tHandler:           mux,",
+    "\t\tReadHeaderTimeout: 5 * time.Second,",
+    "\t}",
+    "\tif err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {",
+    '\t\tfmt.Println("server exited:", err)',
+    "\t}",
+    "}",
+    "",
+  ];
+}

--- a/packages/emitter-go/src/render/template-rendering.ts
+++ b/packages/emitter-go/src/render/template-rendering.ts
@@ -1,0 +1,84 @@
+import type { HandlerIR, RouteIR } from "@tsgodown/ir-core";
+
+import {
+  extractPathParamNames,
+  normalizeHttpMethod,
+  normalizeRoutePath,
+  toServeMuxPattern,
+} from "./route-normalization";
+
+function routeHandlerName(index: number): string {
+  return `route${index}`;
+}
+
+function quoteGo(value: string): string {
+  return JSON.stringify(value);
+}
+
+function emitPathParams(route: RouteIR): string[] {
+  const names = extractPathParamNames(route.path);
+  if (names.length === 0) {
+    return [];
+  }
+
+  const lines = ["\t// Extracted path params:"];
+  for (const name of names) {
+    lines.push(`\t${name} := req.PathValue(${quoteGo(name)})`);
+    lines.push(`\t_ = ${name}`);
+  }
+  lines.push("");
+
+  return lines;
+}
+
+function formatHandlerParams(handler: HandlerIR | undefined): string {
+  if (!handler || handler.params.length === 0) return "none";
+  return handler.params.map((p) => `${p.role}:${p.name}`).join(", ");
+}
+
+export function renderRoute(
+  route: RouteIR,
+  index: number,
+  handler: HandlerIR | undefined,
+): string[] {
+  const normalizedMethod = normalizeHttpMethod(route.method);
+  const normalizedPath = normalizeRoutePath(route.path);
+  const todoMessage = `TODO implement handler ${route.handlerRef} for ${normalizedMethod} ${normalizedPath}`;
+
+  const lines: string[] = [
+    `func ${routeHandlerName(index)}(w http.ResponseWriter, req *http.Request) {`,
+    "",
+    "\t// Route metadata:",
+    `\t//   Method: ${normalizedMethod}`,
+    `\t//   Path: ${quoteGo(normalizedPath)}`,
+    `\t//   Pattern: ${quoteGo(toServeMuxPattern(route))}`,
+    `\t//   Handler: ${quoteGo(route.handlerRef)}`,
+    `\t//   Handler params: ${formatHandlerParams(handler)}`,
+    `\t//   Handler async: ${handler?.async ?? "unknown"}`,
+    `\t//   Handler response mode: ${handler?.semantics?.responseMode ?? "unknown"}`,
+  ];
+
+  if ((route.middlewareRefs?.length ?? 0) > 0) {
+    lines.push(`\t//   Middleware: ${JSON.stringify(route.middlewareRefs)}`);
+  }
+
+  lines.push(
+    `\t// TODO(tsgodown): Implement handler ${quoteGo(route.handlerRef)} for ${normalizedMethod} ${normalizedPath}.`,
+    "\t//   - Replace this scaffold with application logic.",
+    "\t//   - Validate request input and map to domain arguments.",
+    "\t//   - Write response status, headers, and body.",
+    "",
+    ...emitPathParams(route),
+    '\tw.Header().Set("Content-Type", "text/plain; charset=utf-8")',
+    "\tw.WriteHeader(http.StatusNotImplemented)",
+    `\tfmt.Fprintln(w, ${quoteGo(todoMessage)})`,
+    "}",
+    "",
+  );
+
+  return lines;
+}
+
+export function renderRouteRegistration(route: RouteIR, index: number): string {
+  return `\tmux.HandleFunc(${quoteGo(toServeMuxPattern(route))}, ${routeHandlerName(index)})`;
+}


### PR DESCRIPTION
## Summary
- Refactor `packages/emitter-go` with an abstraction-first split while preserving public API (`emitGoProject`) and emitted behavior.
- Separate concerns into dedicated renderer modules:
  - template rendering (`render/template-rendering.ts`)
  - route normalization (`render/route-normalization.ts`)
  - diagnostics-comment rendering (`render/diagnostics-comment-rendering.ts`)
  - server bootstrap rendering (`render/server-bootstrap-rendering.ts`)
- Add a local barrel export (`render/index.ts`) and keep `src/index.ts` as the stable package entrypoint.

## Why
- Improve maintainability and readability without changing runtime contract/output.
- Make emitter responsibilities explicit and easier to evolve independently.

## Behavioral Contract
- No runtime contract drift intended.
- `emitGoProject(ir, outDir)` signature and export path remain unchanged.
- Emitted `main.go` output remains behaviorally and byte-order stable under existing tests.

## Validation (CI order)
1. `pnpm install --frozen-lockfile`
2. `pnpm run lint`
3. `pnpm run format:check`
4. `pnpm run build`
5. `pnpm run test`
6. `cargo fmt --all --check`
7. `cargo clippy --workspace --all-targets -- -D warnings`
8. `cargo test --workspace --all-targets`

All passed.
