### PR TITLE
refactor(config,core): split config loading and core target shaping

### DIFF
--- a/.pr-body-config-core-abstraction-v1.md
+++ b/.pr-body-config-core-abstraction-v1.md
@@ -1,0 +1,42 @@
+## Summary
+- refactored `@tsgodown/config` internals to separate config module loading and config export normalization while keeping `defineConfig`/`loadUserConfig` contracts unchanged
+- refactored `@tsgodown/core` internals to isolate target plan/result shaping behind small internal helpers
+- added focused unit tests in both packages to strengthen coverage around normalization and target planning/result defaults
+
+## What changed
+### packages/config
+- added `src/config-loader.ts`
+  - `resolveConfigModuleUrl(cwd)`
+  - `importConfigExport(cwd)`
+- added `src/config-normalize.ts`
+  - `normalizeUserConfigExport(exported)`
+- simplified `src/load-config.ts` to orchestrate load + normalize only
+
+### packages/core
+- added `src/internal/target-plan.ts`
+  - `resolveTargetPlan(cwd, conf, configIndex)`
+- added `src/internal/target-result.ts`
+  - `buildTargetResult(plan, emitted)`
+- added `src/internal/index.ts` for internal boundary clarity
+- simplified `src/index.ts` by delegating plan/result construction
+
+## Contract & behavior safety
+- no public API changes
+  - `defineConfig` untouched
+  - `loadUserConfig(cwd): Promise<UserConfig[]>` unchanged
+- command behavior unchanged (`build`/`check`/`report`/`stages` outputs preserved)
+
+## Tests
+- new: `packages/config/test/config-loader.test.ts`
+- new: `packages/config/test/config-normalize.test.ts`
+- new: `packages/core/test/target-plan.test.ts`
+- new: `packages/core/test/target-result.test.ts`
+
+## Full gate (CI order)
+1. `pnpm run lint` ✅
+2. `pnpm run format:check` ✅
+3. `pnpm run build` ✅
+4. `pnpm run test` ✅
+5. `cargo fmt --all --check` ✅
+6. `cargo clippy --workspace --all-targets -- -D warnings` ✅
+7. `cargo test --workspace --all-targets` ✅

--- a/packages/config/src/config-loader.ts
+++ b/packages/config/src/config-loader.ts
@@ -1,0 +1,17 @@
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import type { UserConfigExport } from "./types.js";
+
+const DEFAULT_CONFIG_FILE = "tsgodown.config.ts";
+
+export function resolveConfigModuleUrl(cwd: string): string {
+  const configPath = path.resolve(cwd, DEFAULT_CONFIG_FILE);
+  return pathToFileURL(configPath).href;
+}
+
+export async function importConfigExport(
+  cwd: string,
+): Promise<UserConfigExport> {
+  const mod = await import(resolveConfigModuleUrl(cwd));
+  return (mod.default ?? mod.config) as UserConfigExport;
+}

--- a/packages/config/src/config-normalize.ts
+++ b/packages/config/src/config-normalize.ts
@@ -1,0 +1,14 @@
+import type { UserConfig, UserConfigExport } from "./types.js";
+
+export async function normalizeUserConfigExport(
+  exported: UserConfigExport,
+): Promise<UserConfig[]> {
+  if (typeof exported === "function") {
+    const resolved = await exported({
+      mode: process.env.NODE_ENV || "development",
+    });
+    return [resolved];
+  }
+
+  return Array.isArray(exported) ? exported : [exported];
+}

--- a/packages/config/src/load-config.ts
+++ b/packages/config/src/load-config.ts
@@ -1,17 +1,8 @@
-import path from "node:path";
-import { pathToFileURL } from "node:url";
-import type { UserConfig, UserConfigExport } from "./types.js";
+import { importConfigExport } from "./config-loader.js";
+import { normalizeUserConfigExport } from "./config-normalize.js";
+import type { UserConfig } from "./types.js";
 
 export async function loadUserConfig(cwd: string): Promise<UserConfig[]> {
-  const configPath = path.resolve(cwd, "tsgodown.config.ts");
-  const mod = await import(pathToFileURL(configPath).href);
-  const exported: UserConfigExport = mod.default ?? mod.config;
-
-  if (typeof exported === "function") {
-    const resolved = await exported({
-      mode: process.env.NODE_ENV || "development",
-    });
-    return [resolved];
-  }
-  return Array.isArray(exported) ? exported : [exported];
+  const exported = await importConfigExport(cwd);
+  return normalizeUserConfigExport(exported);
 }

--- a/packages/config/test/config-loader.test.ts
+++ b/packages/config/test/config-loader.test.ts
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import test from "node:test";
+
+import { resolveConfigModuleUrl } from "../src/config-loader.ts";
+
+test("resolveConfigModuleUrl points to tsgodown.config.ts in cwd", () => {
+  const cwd = "/repo/example";
+  const url = resolveConfigModuleUrl(cwd);
+
+  assert.equal(url.startsWith("file://"), true);
+  assert.equal(
+    decodeURIComponent(new URL(url).pathname),
+    path.resolve(cwd, "tsgodown.config.ts"),
+  );
+});

--- a/packages/config/test/config-normalize.test.ts
+++ b/packages/config/test/config-normalize.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { normalizeUserConfigExport } from "../src/config-normalize.ts";
+
+test("normalizeUserConfigExport wraps plain object", async () => {
+  const output = await normalizeUserConfigExport({ outDir: "dist-go" });
+  assert.deepEqual(output, [{ outDir: "dist-go" }]);
+});
+
+test("normalizeUserConfigExport preserves arrays", async () => {
+  const output = await normalizeUserConfigExport([
+    { outDir: "dist-a" },
+    { outDir: "dist-b" },
+  ]);
+
+  assert.deepEqual(output, [{ outDir: "dist-a" }, { outDir: "dist-b" }]);
+});
+
+test("normalizeUserConfigExport resolves function with NODE_ENV fallback", async () => {
+  const previous = process.env.NODE_ENV;
+  Reflect.deleteProperty(process.env, "NODE_ENV");
+
+  try {
+    const output = await normalizeUserConfigExport((env) => ({
+      define: { MODE: JSON.stringify(env.mode) },
+    }));
+
+    assert.deepEqual(output, [
+      {
+        define: {
+          MODE: '"development"',
+        },
+      },
+    ]);
+  } finally {
+    if (previous === undefined) {
+      Reflect.deleteProperty(process.env, "NODE_ENV");
+    } else {
+      process.env.NODE_ENV = previous;
+    }
+  }
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,8 +1,8 @@
 import fs from "node:fs";
 import path from "node:path";
-import type { UserConfig } from "@tsgodown/config";
 import { loadUserConfig } from "@tsgodown/config";
 import { runPipeline } from "@tsgodown/pipeline";
+import { buildTargetResult, resolveTargetPlan } from "./internal/index.js";
 
 export const ACTIVE_STAGES = [
   "load-config",
@@ -10,9 +10,6 @@ export const ACTIVE_STAGES = [
   "emit",
   "onSuccess",
 ] as const;
-
-const TS_CORE_DEPRECATION_WARNING =
-  "DEPRECATED: TS core analyzer diagnostics are disabled after Rust cutover; use IR diagnostics from the Rust engine.";
 
 export type BuildStage = (typeof ACTIVE_STAGES)[number];
 
@@ -41,21 +38,6 @@ export interface BuildSummary {
   targets: BuildTargetResult[];
 }
 
-function resolvePlan(
-  cwd: string,
-  conf: UserConfig,
-  configIndex: number,
-): BuildTargetPlan {
-  const entry = typeof conf.entry === "string" ? conf.entry : "src/index.ts";
-  const outDir = conf.outDir ?? "dist-go";
-  return {
-    configIndex,
-    entry: path.resolve(cwd, entry),
-    outDir: path.resolve(cwd, outDir),
-    artifact: path.join(cwd, "artifacts", "manifests", "manifest.json"),
-  };
-}
-
 async function run(
   cwd: string,
   command: "build" | "check" | "report",
@@ -74,16 +56,9 @@ async function run(
   }
 
   for (const [idx, conf] of configs.entries()) {
-    const plan = resolvePlan(cwd, conf, idx);
+    const plan = resolveTargetPlan(cwd, conf, idx);
     const artifactExists = fs.existsSync(plan.artifact);
-    targets.push({
-      ...plan,
-      emitted: artifactExists,
-      diagnostics: {
-        routes: 0,
-        warnings: [TS_CORE_DEPRECATION_WARNING],
-      },
-    });
+    targets.push(buildTargetResult(plan, artifactExists));
   }
 
   return {
@@ -115,12 +90,8 @@ export async function stages(
     cwd,
     stages: ACTIVE_STAGES,
     targets: configs.map((conf, idx) => {
-      const plan = resolvePlan(cwd, conf, idx);
-      return {
-        ...plan,
-        diagnostics: { routes: 0, warnings: [TS_CORE_DEPRECATION_WARNING] },
-        emitted: fs.existsSync(plan.artifact),
-      };
+      const plan = resolveTargetPlan(cwd, conf, idx);
+      return buildTargetResult(plan, fs.existsSync(plan.artifact));
     }),
   };
 }

--- a/packages/core/src/internal/index.ts
+++ b/packages/core/src/internal/index.ts
@@ -1,0 +1,2 @@
+export { resolveTargetPlan } from "./target-plan.js";
+export { buildTargetResult } from "./target-result.js";

--- a/packages/core/src/internal/target-plan.ts
+++ b/packages/core/src/internal/target-plan.ts
@@ -1,0 +1,19 @@
+import path from "node:path";
+import type { UserConfig } from "@tsgodown/config";
+import type { BuildTargetPlan } from "../index.js";
+
+export function resolveTargetPlan(
+  cwd: string,
+  conf: UserConfig,
+  configIndex: number,
+): BuildTargetPlan {
+  const entry = typeof conf.entry === "string" ? conf.entry : "src/index.ts";
+  const outDir = conf.outDir ?? "dist-go";
+
+  return {
+    configIndex,
+    entry: path.resolve(cwd, entry),
+    outDir: path.resolve(cwd, outDir),
+    artifact: path.join(cwd, "artifacts", "manifests", "manifest.json"),
+  };
+}

--- a/packages/core/src/internal/target-result.ts
+++ b/packages/core/src/internal/target-result.ts
@@ -1,0 +1,26 @@
+import type {
+  BuildTargetDiagnostics,
+  BuildTargetPlan,
+  BuildTargetResult,
+} from "../index.js";
+
+const TS_CORE_DEPRECATION_WARNING =
+  "DEPRECATED: TS core analyzer diagnostics are disabled after Rust cutover; use IR diagnostics from the Rust engine.";
+
+export function buildTargetDiagnostics(): BuildTargetDiagnostics {
+  return {
+    routes: 0,
+    warnings: [TS_CORE_DEPRECATION_WARNING],
+  };
+}
+
+export function buildTargetResult(
+  plan: BuildTargetPlan,
+  emitted: boolean,
+): BuildTargetResult {
+  return {
+    ...plan,
+    emitted,
+    diagnostics: buildTargetDiagnostics(),
+  };
+}

--- a/packages/core/test/target-plan.test.ts
+++ b/packages/core/test/target-plan.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import test from "node:test";
+
+import { resolveTargetPlan } from "../src/internal/target-plan.ts";
+
+test("resolveTargetPlan applies defaults when entry/outDir are not explicit strings", () => {
+  const cwd = "/repo";
+  const plan = resolveTargetPlan(cwd, { entry: { app: "src/app.ts" } }, 1);
+
+  assert.deepEqual(plan, {
+    configIndex: 1,
+    entry: path.resolve(cwd, "src/index.ts"),
+    outDir: path.resolve(cwd, "dist-go"),
+    artifact: path.join(cwd, "artifacts", "manifests", "manifest.json"),
+  });
+});
+
+test("resolveTargetPlan resolves explicit string entry and outDir", () => {
+  const cwd = "/repo";
+  const plan = resolveTargetPlan(
+    cwd,
+    { entry: "src/custom.ts", outDir: "custom-dist" },
+    0,
+  );
+
+  assert.equal(plan.entry, path.resolve(cwd, "src/custom.ts"));
+  assert.equal(plan.outDir, path.resolve(cwd, "custom-dist"));
+});

--- a/packages/core/test/target-result.test.ts
+++ b/packages/core/test/target-result.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildTargetResult } from "../src/internal/target-result.ts";
+
+test("buildTargetResult keeps plan fields and appends default diagnostics", () => {
+  const result = buildTargetResult(
+    {
+      configIndex: 0,
+      entry: "/repo/src/index.ts",
+      outDir: "/repo/dist-go",
+      artifact: "/repo/artifacts/manifests/manifest.json",
+    },
+    true,
+  );
+
+  assert.equal(result.configIndex, 0);
+  assert.equal(result.entry, "/repo/src/index.ts");
+  assert.equal(result.outDir, "/repo/dist-go");
+  assert.equal(result.artifact, "/repo/artifacts/manifests/manifest.json");
+  assert.equal(result.emitted, true);
+  assert.deepEqual(result.diagnostics, {
+    routes: 0,
+    warnings: [
+      "DEPRECATED: TS core analyzer diagnostics are disabled after Rust cutover; use IR diagnostics from the Rust engine.",
+    ],
+  });
+});


### PR DESCRIPTION
## Summary
- refactored `@tsgodown/config` internals to separate config module loading and config export normalization while keeping `defineConfig`/`loadUserConfig` contracts unchanged
- refactored `@tsgodown/core` internals to isolate target plan/result shaping behind small internal helpers
- added focused unit tests in both packages to strengthen coverage around normalization and target planning/result defaults

## What changed
### packages/config
- added `src/config-loader.ts`
  - `resolveConfigModuleUrl(cwd)`
  - `importConfigExport(cwd)`
- added `src/config-normalize.ts`
  - `normalizeUserConfigExport(exported)`
- simplified `src/load-config.ts` to orchestrate load + normalize only

### packages/core
- added `src/internal/target-plan.ts`
  - `resolveTargetPlan(cwd, conf, configIndex)`
- added `src/internal/target-result.ts`
  - `buildTargetResult(plan, emitted)`
- added `src/internal/index.ts` for internal boundary clarity
- simplified `src/index.ts` by delegating plan/result construction

## Contract & behavior safety
- no public API changes
  - `defineConfig` untouched
  - `loadUserConfig(cwd): Promise<UserConfig[]>` unchanged
- command behavior unchanged (`build`/`check`/`report`/`stages` outputs preserved)

## Tests
- new: `packages/config/test/config-loader.test.ts`
- new: `packages/config/test/config-normalize.test.ts`
- new: `packages/core/test/target-plan.test.ts`
- new: `packages/core/test/target-result.test.ts`

## Full gate (CI order)
1. `pnpm run lint` ✅
2. `pnpm run format:check` ✅
3. `pnpm run build` ✅
4. `pnpm run test` ✅
5. `cargo fmt --all --check` ✅
6. `cargo clippy --workspace --all-targets -- -D warnings` ✅
7. `cargo test --workspace --all-targets` ✅
