### PR TITLE
refactor(tsdown-driver): abstraction-first artifact indexer boundaries

### DIFF
--- a/packages/tsdown-driver/src/artifact-indexer/indexing.ts
+++ b/packages/tsdown-driver/src/artifact-indexer/indexing.ts
@@ -1,0 +1,34 @@
+import type { TsdownBundleLike } from "../types.js";
+import { normalizeChunkFile, uniqueSorted } from "./validation.js";
+
+export interface IndexedArtifacts {
+  chunkFiles: string[];
+  entries: string[];
+}
+
+export function indexArtifacts(
+  cwd: string,
+  bundles: TsdownBundleLike[],
+): IndexedArtifacts {
+  const chunkFiles = uniqueSorted(
+    bundles
+      .flatMap((bundle) => bundle.chunks ?? [])
+      .map((chunk) => normalizeChunkFile(cwd, chunk.fileName))
+      .filter((file): file is string => Boolean(file)),
+  );
+
+  const entries = uniqueSorted(
+    bundles.flatMap((bundle) => {
+      const entryMap = bundle.config?.entry;
+      if (!entryMap) return [];
+      return Object.values(entryMap)
+        .map((entryPath) => normalizeChunkFile(cwd, entryPath))
+        .filter((entry): entry is string => Boolean(entry));
+    }),
+  );
+
+  return {
+    chunkFiles,
+    entries,
+  };
+}

--- a/packages/tsdown-driver/src/artifact-indexer/internal/index.ts
+++ b/packages/tsdown-driver/src/artifact-indexer/internal/index.ts
@@ -1,0 +1,8 @@
+export { indexArtifacts } from "../indexing.js";
+export {
+  isBundleFile,
+  isTypeFile,
+  normalizeChunkFile,
+  normalizeTsconfigPath,
+  uniqueSorted,
+} from "../validation.js";

--- a/packages/tsdown-driver/src/artifact-indexer/shaping.ts
+++ b/packages/tsdown-driver/src/artifact-indexer/shaping.ts
@@ -1,0 +1,51 @@
+import { createHash } from "node:crypto";
+
+import type {
+  ArtifactManifest,
+  BundleFormat,
+  TsdownBundleLike,
+} from "../types.js";
+import {
+  indexArtifacts,
+  isBundleFile,
+  isTypeFile,
+  normalizeTsconfigPath,
+} from "./internal/index.js";
+
+export function shapeArtifactManifest(
+  cwd: string,
+  bundles: TsdownBundleLike[],
+  configPath?: string,
+): ArtifactManifest {
+  const indexed = indexArtifacts(cwd, bundles);
+
+  const chunkSet = new Set(indexed.chunkFiles);
+  const bundleFiles = indexed.chunkFiles.filter(isBundleFile);
+  const bundlesOut = bundleFiles.map((file) => ({
+    file,
+    map: chunkSet.has(`${file}.map`) ? `${file}.map` : undefined,
+    format: inferBundleFormat(file),
+    exports: [],
+  }));
+
+  const manifestBase = {
+    entries: indexed.entries,
+    bundles: bundlesOut,
+    types: indexed.chunkFiles.filter(isTypeFile),
+    tsconfigPath: normalizeTsconfigPath(cwd, bundles, configPath),
+  };
+
+  return {
+    buildId: createBuildId(manifestBase),
+    ...manifestBase,
+  };
+}
+
+function createBuildId(input: Omit<ArtifactManifest, "buildId">): string {
+  const normalized = JSON.stringify(input);
+  return createHash("sha256").update(normalized).digest("hex").slice(0, 16);
+}
+
+function inferBundleFormat(file: string): BundleFormat {
+  return file.endsWith(".cjs") ? "cjs" : "esm";
+}

--- a/packages/tsdown-driver/src/artifact-indexer/validation.ts
+++ b/packages/tsdown-driver/src/artifact-indexer/validation.ts
@@ -1,0 +1,56 @@
+import path from "node:path";
+
+import type { TsdownBundleLike } from "../types.js";
+
+export function isBundleFile(relFile: string): boolean {
+  if (relFile.endsWith(".js.map")) return false;
+  return (
+    relFile.endsWith(".js") ||
+    relFile.endsWith(".mjs") ||
+    relFile.endsWith(".cjs")
+  );
+}
+
+export function isTypeFile(relFile: string): boolean {
+  return (
+    relFile.endsWith(".d.ts") ||
+    relFile.endsWith(".d.mts") ||
+    relFile.endsWith(".d.cts")
+  );
+}
+
+export function normalizeTsconfigPath(
+  cwd: string,
+  bundles: TsdownBundleLike[],
+  configPath?: string,
+): string {
+  if (configPath) return toPosix(configPath);
+
+  for (const bundle of bundles) {
+    const tsconfig = bundle.config?.tsconfig;
+    if (typeof tsconfig === "string") {
+      return normalizeChunkFile(cwd, tsconfig) ?? toPosix(tsconfig);
+    }
+  }
+
+  return "tsconfig.json";
+}
+
+export function normalizeChunkFile(
+  cwd: string,
+  fileName?: string,
+): string | undefined {
+  if (!fileName) return undefined;
+  const normalized = path.isAbsolute(fileName)
+    ? path.relative(cwd, fileName)
+    : fileName;
+  return toPosix(normalized);
+}
+
+export function uniqueSorted(values: string[]): string[] {
+  return [...new Set(values)].sort((a, b) => a.localeCompare(b));
+}
+
+function toPosix(p: string): string {
+  return p.split(path.sep).join("/");
+}

--- a/packages/tsdown-driver/src/manifest.ts
+++ b/packages/tsdown-driver/src/manifest.ts
@@ -1,7 +1,7 @@
-import { createHash } from "node:crypto";
 import { promises as fs } from "node:fs";
 import path from "node:path";
 
+import { shapeArtifactManifest } from "./artifact-indexer/shaping.js";
 import type { ArtifactManifest, TsdownBundleLike } from "./types.js";
 
 export function buildManifestFromBundles(
@@ -9,47 +9,7 @@ export function buildManifestFromBundles(
   bundles: TsdownBundleLike[],
   configPath?: string,
 ): ArtifactManifest {
-  const chunkFiles = uniqueSorted(
-    bundles
-      .flatMap((bundle) => bundle.chunks ?? [])
-      .map((chunk) => normalizeChunkFile(cwd, chunk.fileName))
-      .filter((file): file is string => Boolean(file)),
-  );
-
-  const chunkSet = new Set(chunkFiles);
-  const bundleFiles = chunkFiles.filter(isBundleFile);
-  const bundlesOut = bundleFiles.map((file) => ({
-    file,
-    map: chunkSet.has(`${file}.map`) ? `${file}.map` : undefined,
-    format: file.endsWith(".cjs") ? ("cjs" as const) : ("esm" as const),
-    exports: [],
-  }));
-
-  const typeFiles = chunkFiles.filter(isTypeFile);
-
-  const entries = uniqueSorted(
-    bundles.flatMap((bundle) => {
-      const entryMap = bundle.config?.entry;
-      if (!entryMap) return [];
-      return Object.values(entryMap)
-        .map((entryPath) => normalizeChunkFile(cwd, entryPath))
-        .filter((entry): entry is string => Boolean(entry));
-    }),
-  );
-
-  const tsconfigPath = resolveTsconfigPath(cwd, bundles, configPath);
-
-  const manifestBase = {
-    entries,
-    bundles: bundlesOut,
-    types: typeFiles,
-    tsconfigPath,
-  };
-
-  return {
-    buildId: createBuildId(manifestBase),
-    ...manifestBase,
-  };
+  return shapeArtifactManifest(cwd, bundles, configPath);
 }
 
 export async function writeManifest(
@@ -66,62 +26,4 @@ export async function writeManifest(
     "utf8",
   );
   return manifestPath;
-}
-
-function resolveTsconfigPath(
-  cwd: string,
-  bundles: TsdownBundleLike[],
-  configPath?: string,
-): string {
-  if (configPath) return toPosix(configPath);
-
-  for (const bundle of bundles) {
-    const tsconfig = bundle.config?.tsconfig;
-    if (typeof tsconfig === "string") {
-      return normalizeChunkFile(cwd, tsconfig) ?? toPosix(tsconfig);
-    }
-  }
-
-  return "tsconfig.json";
-}
-
-function createBuildId(input: Omit<ArtifactManifest, "buildId">): string {
-  const normalized = JSON.stringify(input);
-  return createHash("sha256").update(normalized).digest("hex").slice(0, 16);
-}
-
-function isBundleFile(relFile: string): boolean {
-  if (relFile.endsWith(".js.map")) return false;
-  return (
-    relFile.endsWith(".js") ||
-    relFile.endsWith(".mjs") ||
-    relFile.endsWith(".cjs")
-  );
-}
-
-function isTypeFile(relFile: string): boolean {
-  return (
-    relFile.endsWith(".d.ts") ||
-    relFile.endsWith(".d.mts") ||
-    relFile.endsWith(".d.cts")
-  );
-}
-
-function normalizeChunkFile(
-  cwd: string,
-  fileName?: string,
-): string | undefined {
-  if (!fileName) return undefined;
-  const normalized = path.isAbsolute(fileName)
-    ? path.relative(cwd, fileName)
-    : fileName;
-  return toPosix(normalized);
-}
-
-function uniqueSorted(values: string[]): string[] {
-  return [...new Set(values)].sort((a, b) => a.localeCompare(b));
-}
-
-function toPosix(p: string): string {
-  return p.split(path.sep).join("/");
 }


### PR DESCRIPTION
## Summary
- Refactored artifact manifest construction into abstraction-first boundaries under `packages/tsdown-driver/src/artifact-indexer`.
- Separated concerns into:
  - **indexing**: source artifact/entry discovery (`indexing.ts`)
  - **validation/normalization**: file classification and path normalization (`validation.ts`)
  - **shaping/output contract assembly**: deterministic manifest shaping and build-id generation (`shaping.ts`)
- Introduced an internal barrel (`artifact-indexer/internal/index.ts`) to keep shaping wired to stable internal abstractions.
- Kept public behavior and output contract stable by preserving `buildManifestFromBundles` API and delegating through the new boundary.

## Files
- `packages/tsdown-driver/src/manifest.ts`
- `packages/tsdown-driver/src/artifact-indexer/indexing.ts`
- `packages/tsdown-driver/src/artifact-indexer/validation.ts`
- `packages/tsdown-driver/src/artifact-indexer/shaping.ts`
- `packages/tsdown-driver/src/artifact-indexer/internal/index.ts`

## Validation (CI order)
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run build`
- `pnpm run test`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --all-targets`

All passed locally.
