### PR TITLE
refactor(core,config): follow-up internal abstraction cleanup

### DIFF
--- a/packages/config/src/config-normalize.ts
+++ b/packages/config/src/config-normalize.ts
@@ -1,12 +1,16 @@
 import type { UserConfig, UserConfigExport } from "./types.js";
 
+function buildConfigEnv(): { mode: string } {
+  return {
+    mode: process.env.NODE_ENV || "development",
+  };
+}
+
 export async function normalizeUserConfigExport(
   exported: UserConfigExport,
 ): Promise<UserConfig[]> {
   if (typeof exported === "function") {
-    const resolved = await exported({
-      mode: process.env.NODE_ENV || "development",
-    });
+    const resolved = await exported(buildConfigEnv());
     return [resolved];
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,8 +1,11 @@
 import fs from "node:fs";
-import path from "node:path";
 import { loadUserConfig } from "@tsgodown/config";
 import { runPipeline } from "@tsgodown/pipeline";
-import { buildTargetResult, resolveTargetPlan } from "./internal/index.js";
+import {
+  buildTargetResult,
+  resolveArtifactManifestPath,
+  resolveTargetPlan,
+} from "./internal/index.js";
 
 export const ACTIVE_STAGES = [
   "load-config",
@@ -45,12 +48,7 @@ async function run(
   const configs = await loadUserConfig(cwd);
   const targets: BuildTargetResult[] = [];
 
-  const artifactPath = path.join(
-    cwd,
-    "artifacts",
-    "manifests",
-    "manifest.json",
-  );
+  const artifactPath = resolveArtifactManifestPath(cwd);
   if (command === "build" || !fs.existsSync(artifactPath)) {
     await runPipeline(cwd);
   }

--- a/packages/core/src/internal/index.ts
+++ b/packages/core/src/internal/index.ts
@@ -1,2 +1,5 @@
-export { resolveTargetPlan } from "./target-plan.js";
+export {
+  resolveArtifactManifestPath,
+  resolveTargetPlan,
+} from "./target-plan.js";
 export { buildTargetResult } from "./target-result.js";

--- a/packages/core/src/internal/target-plan.ts
+++ b/packages/core/src/internal/target-plan.ts
@@ -2,6 +2,16 @@ import path from "node:path";
 import type { UserConfig } from "@tsgodown/config";
 import type { BuildTargetPlan } from "../index.js";
 
+const ARTIFACT_MANIFEST_SEGMENTS = [
+  "artifacts",
+  "manifests",
+  "manifest.json",
+] as const;
+
+export function resolveArtifactManifestPath(cwd: string): string {
+  return path.join(cwd, ...ARTIFACT_MANIFEST_SEGMENTS);
+}
+
 export function resolveTargetPlan(
   cwd: string,
   conf: UserConfig,
@@ -14,6 +24,6 @@ export function resolveTargetPlan(
     configIndex,
     entry: path.resolve(cwd, entry),
     outDir: path.resolve(cwd, outDir),
-    artifact: path.join(cwd, "artifacts", "manifests", "manifest.json"),
+    artifact: resolveArtifactManifestPath(cwd),
   };
 }


### PR DESCRIPTION
## Summary
- extracted config env object construction into a local helper in `packages/config` normalization flow to keep export handling focused on shape normalization
- centralized artifact manifest path construction in `packages/core` target-planning internals and reused the same helper from `run()` preflight
- kept all public contracts and exported API behavior unchanged (internal-only refactor)

## Why
- reduces duplicated string/path assembly logic
- clarifies responsibility boundaries inside concentrated internals (`config-normalize` and core target plan/run wiring)
- keeps behavior stable while making follow-up maintenance safer

## Validation
- pnpm run lint
- pnpm run format:check
- pnpm run build
- pnpm run test
- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace --all-targets
