### PR TITLE
chore: enforce no-empty-package placeholder policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,5 +38,11 @@ Generated output:
 - Legacy TypeScript core analyze/capability/emit paths are deprecated and disabled in `@tsgodown/core`/`@tsgodown/pipeline` (orchestration/UI only).
 - Active IR model/package is `@tsgodown/ir-core` and policy SSoT remains `IR_SPEC.md` + `CAPABILITY_MATRIX.md`.
 
+## Workspace Package Policy
+- Placeholder packages are not kept as empty directories.
+- If a package is not implemented yet, track it in docs/backlog only (do not create `packages/<name>` until there is executable scaffold/code).
+- `packages/artifact-indexer`, `packages/go-emitter`, `packages/runtime-go`, and `packages/test-harness` are intentionally absent under this policy.
+- Current Go emitter package path is `packages/emitter-go`.
+
 ## License
 MIT

--- a/docs/architecture/OVERVIEW.md
+++ b/docs/architecture/OVERVIEW.md
@@ -27,7 +27,13 @@ Project-scale TS/JS -> Go compiler pipeline using tsdown build artifacts, with *
 - `packages/pipeline`: orchestration-only runtime pipeline
 - `packages/cli`: `tsgodown build/check/report/stages` user entry
 - `packages/core`: command-level aggregation (runtime orchestration only)
+- `packages/emitter-go`: Go emission boundary
 - `packages/analyzer-rust` and `crates/*`: Rust analysis/build core
+
+## Workspace Policy (empty package placeholders)
+- Empty placeholder package directories are prohibited.
+- Unimplemented package ideas must live in backlog/spec docs until a real scaffold is ready.
+- `packages/artifact-indexer`, `packages/go-emitter`, `packages/runtime-go`, and `packages/test-harness` are intentionally not part of the workspace.
 
 ## Migration Checklist (TS core -> Rust core)
 ### Removed from runtime path

--- a/docs/backlog/NODE_COMPAT_MATRIX.md
+++ b/docs/backlog/NODE_COMPAT_MATRIX.md
@@ -7,7 +7,7 @@
 | url | URL, URLSearchParams | TODO | Go net/url map |
 | process | env, argv, cwd | TODO | runtime adapter |
 | timers | setTimeout/setInterval | TODO | goroutine scheduler shim |
-| events | EventEmitter | TODO | runtime-go emitter |
+| events | EventEmitter | TODO | `packages/emitter-go` runtime adapter |
 | crypto | randomUUID/hash | TODO | Go crypto/* mapping |
 | buffer | Buffer basics | TODO | byte slice wrapper |
 | module | ESM/CJS bridge | TODO | pipeline-level transform |


### PR DESCRIPTION
## Summary
- establish a single workspace policy: do **not** keep empty placeholder package directories
- document that unimplemented package ideas must live in backlog/spec docs until real scaffold/code exists
- clarify intentionally absent placeholders to prevent future orchestration tasks from targeting nonexistent packages:
  - `packages/artifact-indexer`
  - `packages/go-emitter`
  - `packages/runtime-go`
  - `packages/test-harness`
- align naming note to current package path `packages/emitter-go`

## Files changed
- `README.md`
- `docs/architecture/OVERVIEW.md`
- `docs/backlog/NODE_COMPAT_MATRIX.md`

## Validation (CI order)
1. `pnpm run lint`
2. `pnpm run format:check`
3. `pnpm run build`
4. `pnpm run test`
5. `cargo fmt --all --check`
6. `cargo clippy --workspace --all-targets -- -D warnings`
7. `cargo test --workspace --all-targets`

All passed.
