### PR TITLE
fix(emitter-go): keep fastify scaffold path compile-ready

### DIFF
--- a/packages/emitter-go/src/render/template-rendering.ts
+++ b/packages/emitter-go/src/render/template-rendering.ts
@@ -15,16 +15,77 @@ function quoteGo(value: string): string {
   return JSON.stringify(value);
 }
 
+const GO_KEYWORDS = new Set([
+  "break",
+  "default",
+  "func",
+  "interface",
+  "select",
+  "case",
+  "defer",
+  "go",
+  "map",
+  "struct",
+  "chan",
+  "else",
+  "goto",
+  "package",
+  "switch",
+  "const",
+  "fallthrough",
+  "if",
+  "range",
+  "type",
+  "continue",
+  "for",
+  "import",
+  "return",
+  "var",
+]);
+
+const RESERVED_BINDING_NAMES = new Set(["w", "req", "_"]);
+
+function capitalize(value: string): string {
+  if (value.length === 0) return value;
+  return `${value[0].toUpperCase()}${value.slice(1)}`;
+}
+
+function resolvePathParamBindingName(
+  name: string,
+  usedNames: Set<string>,
+): string {
+  let base = name;
+  if (GO_KEYWORDS.has(base) || RESERVED_BINDING_NAMES.has(base)) {
+    base = `pathParam${capitalize(name)}`;
+  }
+
+  let candidate = base;
+  let suffix = 2;
+  while (
+    usedNames.has(candidate) ||
+    GO_KEYWORDS.has(candidate) ||
+    RESERVED_BINDING_NAMES.has(candidate)
+  ) {
+    candidate = `${base}${suffix}`;
+    suffix += 1;
+  }
+
+  usedNames.add(candidate);
+  return candidate;
+}
+
 function emitPathParams(route: RouteIR): string[] {
   const names = extractPathParamNames(route.path);
   if (names.length === 0) {
     return [];
   }
 
+  const usedNames = new Set<string>([...RESERVED_BINDING_NAMES]);
   const lines = ["\t// Extracted path params:"];
   for (const name of names) {
-    lines.push(`\t${name} := req.PathValue(${quoteGo(name)})`);
-    lines.push(`\t_ = ${name}`);
+    const bindingName = resolvePathParamBindingName(name, usedNames);
+    lines.push(`\t${bindingName} := req.PathValue(${quoteGo(name)})`);
+    lines.push(`\t_ = ${bindingName}`);
   }
   lines.push("");
 

--- a/packages/emitter-go/test/emit-go.test.ts
+++ b/packages/emitter-go/test/emit-go.test.ts
@@ -143,6 +143,36 @@ test("emitGoProject normalizes route methods and extracts both colon and braces 
   assert.match(emitted, /orderId := req\.PathValue\("orderId"\)/);
 });
 
+test("emitGoProject avoids Go-unsafe path param bindings while preserving PathValue lookups", () => {
+  const outDir = createOutDir();
+
+  emitGoProject(
+    {
+      modules: [],
+      handlers: [{ id: "keywordParams", params: [], async: false }],
+      diagnostics: [],
+      routes: [
+        {
+          method: "GET",
+          path: "/things/:type/:req/:w/:pathParamType",
+          handlerRef: "keywordParams",
+        },
+      ],
+    },
+    outDir,
+  );
+
+  const emitted = fs.readFileSync(path.join(outDir, "main.go"), "utf8");
+
+  assert.match(emitted, /pathParamType := req\.PathValue\("type"\)/);
+  assert.match(emitted, /pathParamReq := req\.PathValue\("req"\)/);
+  assert.match(emitted, /pathParamW := req\.PathValue\("w"\)/);
+  assert.match(emitted, /pathParamType2 := req\.PathValue\("pathParamType"\)/);
+  assert.doesNotMatch(emitted, /\stype := req\.PathValue\("type"\)/);
+  assert.doesNotMatch(emitted, /\sreq := req\.PathValue\("req"\)/);
+  assert.doesNotMatch(emitted, /\sw := req\.PathValue\("w"\)/);
+});
+
 test("emitGoProject surfaces IR diagnostics as actionable comments without adding adapter policy", () => {
   const outDir = createOutDir();
 


### PR DESCRIPTION
## Summary
- make `@tsgodown/emitter-go` route scaffold generation safer for Go compilation by sanitizing extracted path-parameter binding names
- avoid generating invalid/conflicting local variable names for Go keywords and reserved handler bindings (`w`, `req`, `_`)
- keep generated `req.PathValue("<original>")` lookups intact so runtime behavior remains aligned with route params

## What changed
- `packages/emitter-go/src/render/template-rendering.ts`
  - add Go keyword and reserved-binding guards
  - add deterministic binding-name resolver with collision handling (`...2`, `...3`, ...)
  - use resolved safe binding names when emitting path parameter extraction statements
- `packages/emitter-go/test/emit-go.test.ts`
  - add regression test covering keyword/reserved/collision scenarios (`:type`, `:req`, `:w`, `:pathParamType`)
  - assert scaffold preserves `PathValue` keys while avoiding unsafe local declarations

## Why
Fastify-derived routes can contain path param names that are legal in route syntax but unsafe as raw Go local identifiers in generated handlers (e.g. Go keywords or names colliding with existing function params). This change keeps generated scaffolds compile-ready on the milestone path without broad behavior changes.

## Scope control
- only `packages/emitter-go` source + its tests were changed
- no analyzer/IR contract changes
- no policy behavior changes beyond compile-safety of generated local variable names

## Validation (CI order)
- `pnpm run lint` ✅
- `pnpm run format:check` ✅
- `pnpm run build` ✅
- `pnpm run test` ✅
  - note: Go smoke tests in `packages/emitter-go` are environment-gated and skipped when Go toolchain is unavailable
- `cargo fmt --all --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo test --workspace --all-targets` ✅
