### PR TITLE
feat: stabilize M1 pipeline-driver fastify compile path

### DIFF
--- a/.pr-body-m1-pipeline-driver-fastify-path-v1.md
+++ b/.pr-body-m1-pipeline-driver-fastify-path-v1.md
@@ -1,0 +1,39 @@
+## Summary
+- stabilize Milestone 1 pipeline ↔ tsdown-driver integration for fastify scaffold compile path
+- formalize artifact contract as **manifest + index** under `artifacts/manifests/`
+- make pipeline stage orchestration consume driver result contract explicitly
+
+## What changed
+### `packages/tsdown-driver`
+- added `ArtifactManifestIndex` type
+- added `writeManifestArtifacts()` to write:
+  - `artifacts/manifests/manifest.json`
+  - `artifacts/manifests/index.json`
+- kept `writeManifest()` as compatibility wrapper
+- updated `runBuild()` to return `manifestIndexPath` in `RunBuildResult`
+- exported `writeManifestArtifacts` + `ArtifactManifestIndex`
+- extended driver test to validate `manifestIndexPath` and index payload contract
+
+### `packages/pipeline`
+- updated rust adapter boundary to return full `RunBuildResult`
+- stage orchestration now validates manifest/index contract presence from driver result
+- enriched BUILD_IR stage log with `buildId` from manifest
+- extended pipeline e2e to verify `artifacts/manifests/index.json` contract
+
+## Scope guard
+- touched only:
+  - `packages/pipeline/*`
+  - `packages/tsdown-driver/*`
+- no emitter-go internals modified
+
+## Validation (CI order)
+- `pnpm run lint` ✅
+- `pnpm run format:check` ✅
+- `pnpm run build` ✅
+- `pnpm run test` ✅
+- `cargo fmt --all --check` ✅
+- `cargo clippy --workspace --all-targets -- -D warnings` ✅
+- `cargo test --workspace --all-targets` ✅
+
+## Notes
+- manifest/index files are deterministic in shape; `generatedAt` is expected to vary by run.

--- a/packages/pipeline/src/internal/rust-adapter-boundary.ts
+++ b/packages/pipeline/src/internal/rust-adapter-boundary.ts
@@ -1,7 +1,7 @@
-import { runBuild } from "@tsgodown/tsdown-driver";
+import { type RunBuildResult, runBuild } from "@tsgodown/tsdown-driver";
 
 export async function runBuildArtifactsViaRustAdapter(
   cwd: string,
-): Promise<void> {
-  await runBuild(cwd);
+): Promise<RunBuildResult> {
+  return runBuild(cwd);
 }

--- a/packages/pipeline/src/internal/stage-orchestration.ts
+++ b/packages/pipeline/src/internal/stage-orchestration.ts
@@ -19,9 +19,16 @@ export async function orchestratePipelineStages({
 
     try {
       log("[BUILD_ARTIFACTS] collecting build outputs");
-      await runBuildArtifactsViaRustAdapter(cwd);
+      const buildResult = await runBuildArtifactsViaRustAdapter(cwd);
+      if (!buildResult.manifestPath || !buildResult.manifestIndexPath) {
+        throw new Error(
+          "rust adapter contract violation: missing manifest or manifest index path",
+        );
+      }
 
-      log(`[BUILD_IR] analyzing entry: ${entry} (delegated to rust engine)`);
+      log(
+        `[BUILD_IR] analyzing entry: ${entry} (delegated to rust engine, buildId=${buildResult.manifest.buildId})`,
+      );
       log(
         "[CAPABILITY_GATE] validating required capabilities (delegated to rust engine)",
       );

--- a/packages/pipeline/test/pipeline.e2e.test.ts
+++ b/packages/pipeline/test/pipeline.e2e.test.ts
@@ -119,6 +119,25 @@ test("runPipeline delegates build/analysis/capability/emission to rust engine ad
     assert.match(manifest.buildId, /^[a-f0-9]{16}$/);
     assert.deepEqual(manifest.entries, ["src/index.ts"]);
 
+    const manifestIndexPath = path.join(
+      cwd,
+      "artifacts",
+      "manifests",
+      "index.json",
+    );
+    assert.equal(fs.existsSync(manifestIndexPath), true);
+
+    const manifestIndex = JSON.parse(
+      fs.readFileSync(manifestIndexPath, "utf8"),
+    ) as {
+      buildId: string;
+      manifest: string;
+      generatedAt: string;
+    };
+    assert.equal(manifestIndex.buildId, manifest.buildId);
+    assert.equal(manifestIndex.manifest, "manifest.json");
+    assert.equal(typeof manifestIndex.generatedAt, "string");
+
     const goPath = path.join(cwd, "dist-go", "main.go");
     assert.equal(
       fs.existsSync(goPath),

--- a/packages/tsdown-driver/src/index.ts
+++ b/packages/tsdown-driver/src/index.ts
@@ -1,9 +1,14 @@
-export { buildManifestFromBundles, writeManifest } from "./manifest.js";
+export {
+  buildManifestFromBundles,
+  writeManifest,
+  writeManifestArtifacts,
+} from "./manifest.js";
 export { runBuild } from "./run-build.js";
 
 export type {
   ArtifactBundle,
   ArtifactManifest,
+  ArtifactManifestIndex,
   BundleFormat,
   RunBuildResult,
   RustEngineRequest,

--- a/packages/tsdown-driver/src/manifest.ts
+++ b/packages/tsdown-driver/src/manifest.ts
@@ -2,7 +2,11 @@ import { promises as fs } from "node:fs";
 import path from "node:path";
 
 import { shapeArtifactManifest } from "./artifact-indexer/shaping.js";
-import type { ArtifactManifest, TsdownBundleLike } from "./types.js";
+import type {
+  ArtifactManifest,
+  ArtifactManifestIndex,
+  TsdownBundleLike,
+} from "./types.js";
 
 export function buildManifestFromBundles(
   cwd: string,
@@ -16,6 +20,13 @@ export async function writeManifest(
   cwd: string,
   manifest: ArtifactManifest,
 ): Promise<string> {
+  return (await writeManifestArtifacts(cwd, manifest)).manifestPath;
+}
+
+export async function writeManifestArtifacts(
+  cwd: string,
+  manifest: ArtifactManifest,
+): Promise<{ manifestPath: string; manifestIndexPath: string }> {
   const outDir = path.join(cwd, "artifacts", "manifests");
   await fs.mkdir(outDir, { recursive: true });
 
@@ -25,5 +36,22 @@ export async function writeManifest(
     `${JSON.stringify(manifest, null, 2)}\n`,
     "utf8",
   );
-  return manifestPath;
+
+  const manifestIndexPath = path.join(outDir, "index.json");
+  const manifestIndex: ArtifactManifestIndex = {
+    buildId: manifest.buildId,
+    manifest: "manifest.json",
+    generatedAt: new Date().toISOString(),
+  };
+
+  await fs.writeFile(
+    manifestIndexPath,
+    `${JSON.stringify(manifestIndex, null, 2)}\n`,
+    "utf8",
+  );
+
+  return {
+    manifestPath,
+    manifestIndexPath,
+  };
 }

--- a/packages/tsdown-driver/src/run-build.ts
+++ b/packages/tsdown-driver/src/run-build.ts
@@ -1,5 +1,5 @@
 import { normalizeRustEngineResponse } from "./contract.js";
-import { writeManifest } from "./manifest.js";
+import { writeManifestArtifacts } from "./manifest.js";
 import { invokeRustEngine } from "./process-adapter.js";
 import type {
   RunBuildOptions,
@@ -31,10 +31,15 @@ export async function runBuild(
     );
   }
 
-  const manifestPath = await writeManifest(cwd, response.manifest);
+  const { manifestPath, manifestIndexPath } = await writeManifestArtifacts(
+    cwd,
+    response.manifest,
+  );
+
   return {
     mode: "rust-engine-adapter",
     manifestPath,
+    manifestIndexPath,
     manifest: response.manifest,
     diagnostics: response.diagnostics ?? [],
   };

--- a/packages/tsdown-driver/src/types.ts
+++ b/packages/tsdown-driver/src/types.ts
@@ -64,9 +64,16 @@ export type RustEngineResponse =
       guidance?: unknown;
     };
 
+export interface ArtifactManifestIndex {
+  buildId: string;
+  manifest: string;
+  generatedAt: string;
+}
+
 export interface RunBuildResult {
   mode: "rust-engine-adapter";
   manifestPath: string;
+  manifestIndexPath: string;
   manifest: ArtifactManifest;
   diagnostics: string[];
 }

--- a/packages/tsdown-driver/test/driver.test.ts
+++ b/packages/tsdown-driver/test/driver.test.ts
@@ -87,8 +87,19 @@ test("runBuild invokes rust adapter with JSON request contract", async () => {
       result.manifestPath,
       path.join(cwd, "artifacts", "manifests", "manifest.json"),
     );
+    assert.equal(
+      result.manifestIndexPath,
+      path.join(cwd, "artifacts", "manifests", "index.json"),
+    );
     assert.equal(result.manifest.buildId, "aabbccddeeff0011");
     assert.deepEqual(result.diagnostics, ["adapter=stub"]);
+
+    const indexPayload = JSON.parse(
+      fs.readFileSync(result.manifestIndexPath, "utf8"),
+    ) as { buildId: string; manifest: string; generatedAt: string };
+    assert.equal(indexPayload.buildId, "aabbccddeeff0011");
+    assert.equal(indexPayload.manifest, "manifest.json");
+    assert.equal(typeof indexPayload.generatedAt, "string");
   } finally {
     fs.rmSync(cwd, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- stabilize Milestone 1 pipeline ↔ tsdown-driver integration for fastify scaffold compile path
- formalize artifact contract as **manifest + index** under `artifacts/manifests/`
- make pipeline stage orchestration consume driver result contract explicitly

## What changed
### `packages/tsdown-driver`
- added `ArtifactManifestIndex` type
- added `writeManifestArtifacts()` to write:
  - `artifacts/manifests/manifest.json`
  - `artifacts/manifests/index.json`
- kept `writeManifest()` as compatibility wrapper
- updated `runBuild()` to return `manifestIndexPath` in `RunBuildResult`
- exported `writeManifestArtifacts` + `ArtifactManifestIndex`
- extended driver test to validate `manifestIndexPath` and index payload contract

### `packages/pipeline`
- updated rust adapter boundary to return full `RunBuildResult`
- stage orchestration now validates manifest/index contract presence from driver result
- enriched BUILD_IR stage log with `buildId` from manifest
- extended pipeline e2e to verify `artifacts/manifests/index.json` contract

## Scope guard
- touched only:
  - `packages/pipeline/*`
  - `packages/tsdown-driver/*`
- no emitter-go internals modified

## Validation (CI order)
- `pnpm run lint` ✅
- `pnpm run format:check` ✅
- `pnpm run build` ✅
- `pnpm run test` ✅
- `cargo fmt --all --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo test --workspace --all-targets` ✅

## Notes
- manifest/index files are deterministic in shape; `generatedAt` is expected to vary by run.
