### PR TITLE
feat(analyzer-rust): harden fastify contract path for stable Go IR

### DIFF
--- a/packages/analyzer-rust/src/ast.rs
+++ b/packages/analyzer-rust/src/ast.rs
@@ -94,12 +94,20 @@ pub(crate) fn split_top_level(src: &str, delim: char) -> Vec<String> {
 }
 
 pub(crate) fn parse_inline_plugin(expr: &str) -> Option<PluginDef> {
-    let re_arrow =
-        Regex::new(r"(?s)^(?:async\s+)?\(\s*([A-Za-z_$][\w$]*)\s*\)\s*=>\s*\{(.*)\}$").unwrap();
+    let re_arrow = Regex::new(
+        r"(?s)^(?:async\s+)?(?:\(\s*([A-Za-z_$][\w$]*)\s*\)|([A-Za-z_$][\w$]*))\s*=>\s*\{(.*)\}$",
+    )
+    .unwrap();
     if let Some(cap) = re_arrow.captures(expr.trim()) {
+        let param_name = cap
+            .get(1)
+            .or_else(|| cap.get(2))
+            .map(|m| m.as_str())
+            .unwrap_or_default()
+            .to_string();
         return Some(PluginDef {
-            param_name: cap[1].to_string(),
-            body: cap[2].to_string(),
+            param_name,
+            body: cap[3].to_string(),
         });
     }
 

--- a/packages/analyzer-rust/src/defs.rs
+++ b/packages/analyzer-rust/src/defs.rs
@@ -42,7 +42,7 @@ pub(crate) fn collect_plugin_definitions(src: &str) -> HashMap<String, PluginDef
     }
 
     let arrow_re = Regex::new(
-        r"(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(?:async\s+)?\(([^)]*)\)\s*=>\s*\{",
+        r"(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(?:async\s+)?(?:\(([^)]*)\)|([A-Za-z_$][\w$]*))\s*=>\s*\{",
     )
     .unwrap();
     for cap in arrow_re.captures_iter(src) {
@@ -51,7 +51,11 @@ pub(crate) fn collect_plugin_definitions(src: &str) -> HashMap<String, PluginDef
         let Some((body, _)) = capture_balanced(&src[open_idx + 1..], '{', '}') else {
             continue;
         };
-        let params = cap[2]
+        let params = cap
+            .get(2)
+            .map(|m| m.as_str())
+            .or_else(|| cap.get(3).map(|m| m.as_str()))
+            .unwrap_or("")
             .split(',')
             .map(|v| v.trim())
             .filter(|v| !v.is_empty())
@@ -111,11 +115,12 @@ pub(crate) fn collect_handler_definitions(src: &str) -> HashMap<String, HandlerD
         );
     }
 
-    let var_fn_re = Regex::new(r"(?s)(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(async\s+)?(?:function\s*\(([^)]*)\)|\(([^)]*)\)\s*=>)\s*\{").unwrap();
+    let var_fn_re = Regex::new(r"(?s)(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(async\s+)?(?:function\s*\(([^)]*)\)|\(([^)]*)\)\s*=>|([A-Za-z_$][\w$]*)\s*=>)\s*\{").unwrap();
     for cap in var_fn_re.captures_iter(src) {
         let params_src = cap
             .get(3)
             .or_else(|| cap.get(4))
+            .or_else(|| cap.get(5))
             .map(|m| m.as_str())
             .unwrap_or("");
         map.insert(

--- a/packages/analyzer-rust/tests/contract_parity_regression.rs
+++ b/packages/analyzer-rust/tests/contract_parity_regression.rs
@@ -4,10 +4,18 @@ use std::path::PathBuf;
 use analyzer_rust::analyze_fastify_entry;
 use pretty_assertions::assert_eq;
 
+type HandlerContract = (
+    &'static str,
+    Vec<(&'static str, &'static str)>,
+    bool,
+    &'static str,
+);
+
 #[derive(Debug)]
 struct ContractFixture {
     name: &'static str,
     expected_routes: Vec<(&'static str, &'static str, &'static str)>,
+    expected_handlers: Vec<HandlerContract>,
     expected_diag_codes: Vec<&'static str>,
 }
 
@@ -28,6 +36,11 @@ fn contract_fixtures() -> Vec<ContractFixture> {
                 ("POST", "/users", "createUser"),
                 ("PATCH", "/users/:id", "updateUser"),
             ],
+            expected_handlers: vec![
+                ("listUsers", vec![], true, "unknown"),
+                ("createUser", vec![], true, "unknown"),
+                ("updateUser", vec![], false, "unknown"),
+            ],
             expected_diag_codes: vec![],
         },
         ContractFixture {
@@ -39,6 +52,13 @@ fn contract_fixtures() -> Vec<ContractFixture> {
                 ("POST", "/private/devices", "createPrivateDevice"),
                 ("GET", "/internal/metrics", "listInternalMetrics"),
             ],
+            expected_handlers: vec![
+                ("listApiUsers", vec![], false, "unknown"),
+                ("listApiUserById", vec![], false, "unknown"),
+                ("listPrivateDevices", vec![], false, "unknown"),
+                ("createPrivateDevice", vec![], false, "unknown"),
+                ("listInternalMetrics", vec![], false, "unknown"),
+            ],
             expected_diag_codes: vec![],
         },
         ContractFixture {
@@ -48,11 +68,29 @@ fn contract_fixtures() -> Vec<ContractFixture> {
                 ("GET", "/v1/users/:id", "showV1User"),
                 ("GET", "/v1/admin/accounts", "listAccounts"),
             ],
+            expected_handlers: vec![
+                ("listV1Users", vec![], false, "unknown"),
+                ("showV1User", vec![], false, "unknown"),
+                ("listAccounts", vec![], false, "unknown"),
+            ],
+            expected_diag_codes: vec![],
+        },
+        ContractFixture {
+            name: "single-param-arrow-fastify.fixture.txt",
+            expected_routes: vec![
+                ("GET", "/api/v1/users", "listUsers"),
+                ("PATCH", "/api/v1/users/:id", "updateUser"),
+            ],
+            expected_handlers: vec![
+                ("listUsers", vec![("req", "request")], true, "unknown"),
+                ("updateUser", vec![("reply", "response")], false, "unknown"),
+            ],
             expected_diag_codes: vec![],
         },
         ContractFixture {
             name: "unsupported-fastify.fixture.txt",
             expected_routes: vec![],
+            expected_handlers: vec![],
             expected_diag_codes: vec![
                 "ANALYZER_UNRESOLVED_PLUGIN",
                 "ANALYZER_UNSUPPORTED_DYNAMIC_PATH",
@@ -77,6 +115,31 @@ fn rust_contract_parity_routes_and_diagnostics_are_stable() {
         assert_eq!(
             actual_routes, case.expected_routes,
             "route contract drifted for fixture: {}",
+            case.name
+        );
+
+        let actual_handlers = ir
+            .handlers
+            .iter()
+            .map(|h| {
+                (
+                    h.id.as_str(),
+                    h.params
+                        .iter()
+                        .map(|p| (p.name.as_str(), p.role.as_str()))
+                        .collect::<Vec<_>>(),
+                    h.r#async,
+                    h.semantics
+                        .as_ref()
+                        .map(|s| s.response_mode.as_str())
+                        .unwrap_or("<missing>"),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            actual_handlers, case.expected_handlers,
+            "handler contract drifted for fixture: {}",
             case.name
         );
 

--- a/packages/analyzer-rust/tests/fastify_ast_analyzer.rs
+++ b/packages/analyzer-rust/tests/fastify_ast_analyzer.rs
@@ -174,3 +174,46 @@ fn keeps_ssot_boundary_extraction_and_diagnostics_only() {
     assert!(!codes.iter().any(|c| c == "CAPABILITY_UNMET"));
     assert!(!codes.iter().any(|c| c.starts_with("CAPABILITY_")));
 }
+
+#[test]
+fn handles_single_param_arrow_plugins_and_handlers() {
+    let (file, src) = fixture("single-param-arrow-fastify.fixture.txt");
+    let ir = analyze_fastify_entry(&file, &src);
+
+    assert_eq!(
+        ir.routes
+            .iter()
+            .map(|r| (r.method.as_str(), r.path.as_str(), r.handler_ref.as_str()))
+            .collect::<Vec<_>>(),
+        vec![
+            ("GET", "/api/v1/users", "listUsers"),
+            ("PATCH", "/api/v1/users/:id", "updateUser"),
+        ]
+    );
+
+    assert_eq!(
+        ir.handlers
+            .iter()
+            .map(|h| {
+                (
+                    h.id.as_str(),
+                    h.params
+                        .iter()
+                        .map(|p| (p.name.as_str(), p.role.as_str()))
+                        .collect::<Vec<_>>(),
+                    h.r#async,
+                    h.semantics
+                        .as_ref()
+                        .map(|s| s.response_mode.as_str())
+                        .unwrap_or("<missing>"),
+                )
+            })
+            .collect::<Vec<_>>(),
+        vec![
+            ("listUsers", vec![("req", "request")], true, "unknown",),
+            ("updateUser", vec![("reply", "response")], false, "unknown",),
+        ]
+    );
+
+    assert!(ir.diagnostics.is_empty());
+}

--- a/packages/analyzer-rust/tests/fixtures/single-param-arrow-fastify.fixture.txt
+++ b/packages/analyzer-rust/tests/fixtures/single-param-arrow-fastify.fixture.txt
@@ -1,0 +1,15 @@
+import Fastify from "fastify";
+
+const app = Fastify();
+
+const listUsers = async req => {};
+const updateUser = reply => {};
+
+const usersPlugin = scope => {
+  scope.get("/users", listUsers);
+  scope.route({ method: "PATCH", path: "/users/:id", handler: updateUser });
+};
+
+app.register(inner => {
+  inner.register(usersPlugin, { prefix: "/v1" });
+}, { prefix: "/api" });


### PR DESCRIPTION
## Summary
- Hardened `packages/analyzer-rust` fastify contract extraction to support single-parameter arrow callbacks (with and without parentheses) for both plugin and handler definitions.
- Added regression coverage to keep route/handler/diagnostics IR contract stable for Go compile path.
- Kept changes strictly scoped to `packages/analyzer-rust` and directly related fixtures/tests.

## What changed
- `src/ast.rs`
  - Extended inline plugin parsing to support:
    - `(scope) => { ... }`
    - `scope => { ... }`
  - Preserved existing function-expression support.
- `src/defs.rs`
  - Extended plugin definition collection to support single-param arrow definitions without parentheses.
  - Extended handler definition collection to support single-param arrow handlers without parentheses.
- `tests/fixtures/single-param-arrow-fastify.fixture.txt`
  - Added fixture exercising nested register + prefix composition using single-param arrow plugins/handlers.
- `tests/fastify_ast_analyzer.rs`
  - Added assertion test validating route extraction + handler IR completeness (params/roles/async/semantics) for single-param arrow pattern.
- `tests/contract_parity_regression.rs`
  - Added new fixture case for single-param arrow pattern.
  - Expanded parity checks to include handler contract (id, param roles, async, semantics) in addition to routes/diagnostics.

## Scope/safety
- No behavior expansion outside fastify analyzer milestone path.
- No changes outside `packages/analyzer-rust` (plus directly tied fixture/test files).

## Gate results (CI order)
1. `pnpm install --frozen-lockfile` ✅
2. `pnpm run lint` ✅
3. `pnpm run format:check` ✅
4. `pnpm run build` ✅
5. `pnpm run test` ✅
6. `cargo fmt --all --check` ✅
7. `cargo clippy --workspace --all-targets -- -D warnings` ✅
8. `cargo test --workspace --all-targets` ✅
