### PR TITLE
fix(emitter-go): stabilize scaffold compile path for empty fastify methods

### DIFF
--- a/packages/emitter-go/src/render/route-normalization.ts
+++ b/packages/emitter-go/src/render/route-normalization.ts
@@ -1,7 +1,8 @@
 import type { RouteIR } from "@tsgodown/ir-core";
 
 export function normalizeHttpMethod(method: string): string {
-  return method.trim().toUpperCase();
+  const normalized = method.trim().toUpperCase();
+  return normalized.length > 0 ? normalized : "GET";
 }
 
 export function normalizeRoutePath(pathname: string): string {

--- a/packages/emitter-go/test/emit-go.test.ts
+++ b/packages/emitter-go/test/emit-go.test.ts
@@ -143,6 +143,34 @@ test("emitGoProject normalizes route methods and extracts both colon and braces 
   assert.match(emitted, /orderId := req\.PathValue\("orderId"\)/);
 });
 
+test("emitGoProject falls back to GET for empty route methods to keep scaffold boot-stable", () => {
+  const outDir = createOutDir();
+
+  emitGoProject(
+    {
+      modules: [],
+      handlers: [{ id: "fallbackMethod", params: [], async: false }],
+      diagnostics: [],
+      routes: [
+        {
+          method: "   " as ProgramIR["routes"][number]["method"],
+          path: "/health",
+          handlerRef: "fallbackMethod",
+        },
+      ],
+    },
+    outDir,
+  );
+
+  const emitted = fs.readFileSync(path.join(outDir, "main.go"), "utf8");
+
+  assert.match(emitted, /mux\.HandleFunc\("GET \/health", route0\)/);
+  assert.match(
+    emitted,
+    /TODO\(tsgodown\): Implement handler "fallbackMethod" for GET \/health\./,
+  );
+});
+
 test("emitGoProject avoids Go-unsafe path param bindings while preserving PathValue lookups", () => {
   const outDir = createOutDir();
 


### PR DESCRIPTION
## Summary
- scoped second-pass compile-stability cleanup to `packages/emitter-go`
- hardened route method normalization to prevent empty method tokens from producing unstable scaffold route patterns
- added focused regression coverage for bootstrap-stable fallback behavior

## What changed
1. `packages/emitter-go/src/render/route-normalization.ts`
   - `normalizeHttpMethod` now falls back to `GET` when the incoming method is empty/whitespace after normalization.
2. `packages/emitter-go/test/emit-go.test.ts`
   - added `emitGoProject falls back to GET for empty route methods to keep scaffold boot-stable`.
   - verifies both route registration pattern and TODO scaffold metadata use `GET` fallback.

## Why this is safe
- behavior only changes for invalid/empty method inputs
- valid methods keep previous normalization behavior (`trim().toUpperCase()`)
- no API surface changes

## Gate results (CI order)
- `pnpm run lint` ✅
- `pnpm run build` ✅
- `pnpm run test` ✅
  - note: existing Go smoke tests in emitter-go remain skipped in this environment (toolchain/CI guard), unchanged by this PR
