### PR TITLE
test(analyzer-rust): stabilize fastify edge IR fixtures

### DIFF
--- a/packages/analyzer-rust/src/traversal.rs
+++ b/packages/analyzer-rust/src/traversal.rs
@@ -22,10 +22,46 @@ pub(crate) fn analyze_scope(
     while let Some(pos) = body[idx..].find(&format!("{}.", instance_name)) {
         let start = idx + pos;
         let tail = &body[start + instance_name.len() + 1..];
-        let mut advanced = false;
+
+        if let Some(consumed) = analyze_call_chain(
+            tail,
+            file,
+            instance_name,
+            prefix,
+            plugin_defs,
+            handler_defs,
+            routes,
+            handlers,
+            diagnostics,
+        ) {
+            idx = start + instance_name.len() + 1 + consumed;
+            continue;
+        }
+
+        idx = start + 1;
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn analyze_call_chain(
+    mut chain: &str,
+    file: &str,
+    instance_name: &str,
+    prefix: &str,
+    plugin_defs: &HashMap<String, PluginDef>,
+    handler_defs: &HashMap<String, HandlerDef>,
+    routes: &mut Vec<RouteIR>,
+    handlers: &mut Vec<HandlerIR>,
+    diagnostics: &mut Vec<DiagnosticIR>,
+) -> Option<usize> {
+    let original_len = chain.len();
+    let mut matched_any = false;
+
+    loop {
+        let mut matched_here = false;
 
         for method in ["get", "post", "put", "delete", "patch"] {
-            if let Some(args) = capture_call_args(tail, method) {
+            if let Some(args) = capture_call_args(chain, method) {
                 extract_shorthand_route(
                     &args,
                     file,
@@ -37,46 +73,68 @@ pub(crate) fn analyze_scope(
                     handler_defs,
                     diagnostics,
                 );
-                idx = start + instance_name.len() + 1 + method.len() + args.len() + 2;
-                advanced = true;
+                let consumed = method.len() + args.len() + 2;
+                chain = &chain[consumed..];
+                matched_any = true;
+                matched_here = true;
                 break;
             }
         }
-        if advanced {
-            continue;
+
+        if !matched_here {
+            if let Some(args) = capture_call_args(chain, "route") {
+                extract_route_object(
+                    &args,
+                    file,
+                    instance_name,
+                    prefix,
+                    routes,
+                    handlers,
+                    handler_defs,
+                    diagnostics,
+                );
+                let consumed = "route".len() + args.len() + 2;
+                chain = &chain[consumed..];
+                matched_any = true;
+                matched_here = true;
+            }
         }
 
-        if let Some(args) = capture_call_args(tail, "route") {
-            extract_route_object(
-                &args,
-                file,
-                instance_name,
-                prefix,
-                routes,
-                handlers,
-                handler_defs,
-                diagnostics,
-            );
-            idx = start + instance_name.len() + 1 + "route".len() + args.len() + 2;
-            continue;
+        if !matched_here {
+            if let Some(args) = capture_call_args(chain, "register") {
+                analyze_register_call(
+                    &args,
+                    file,
+                    instance_name,
+                    prefix,
+                    plugin_defs,
+                    handler_defs,
+                    routes,
+                    handlers,
+                    diagnostics,
+                );
+                let consumed = "register".len() + args.len() + 2;
+                chain = &chain[consumed..];
+                matched_any = true;
+                matched_here = true;
+            }
         }
 
-        if let Some(args) = capture_call_args(tail, "register") {
-            analyze_register_call(
-                &args,
-                file,
-                instance_name,
-                prefix,
-                plugin_defs,
-                handler_defs,
-                routes,
-                handlers,
-                diagnostics,
-            );
-            idx = start + instance_name.len() + 1 + "register".len() + args.len() + 2;
-            continue;
+        if !matched_here {
+            break;
         }
 
-        idx = start + 1;
+        let trimmed = chain.trim_start();
+        if !trimmed.starts_with('.') {
+            chain = trimmed;
+            break;
+        }
+        chain = &trimmed[1..];
+    }
+
+    if matched_any {
+        Some(original_len - chain.len())
+    } else {
+        None
     }
 }

--- a/packages/analyzer-rust/tests/contract_parity_regression.rs
+++ b/packages/analyzer-rust/tests/contract_parity_regression.rs
@@ -88,6 +88,56 @@ fn contract_fixtures() -> Vec<ContractFixture> {
             expected_diag_codes: vec![],
         },
         ContractFixture {
+            name: "chaining-routes-fastify.fixture.txt",
+            expected_routes: vec![
+                ("GET", "/users", "listUsers"),
+                ("POST", "/users", "createUser"),
+                ("PATCH", "/users/:id", "updateUser"),
+            ],
+            expected_handlers: vec![
+                ("listUsers", vec![], false, "unknown"),
+                ("createUser", vec![], true, "unknown"),
+                ("updateUser", vec![], false, "unknown"),
+            ],
+            expected_diag_codes: vec![],
+        },
+        ContractFixture {
+            name: "nested-plugin-chaining-fastify.fixture.txt",
+            expected_routes: vec![
+                ("GET", "/api/users", "listApiUsers"),
+                ("POST", "/api/users", "createApiUser"),
+                ("GET", "/api/v2/users", "listNestedUsers"),
+            ],
+            expected_handlers: vec![
+                ("listApiUsers", vec![("req", "request")], false, "unknown"),
+                ("createApiUser", vec![("req", "request")], false, "unknown"),
+                (
+                    "listNestedUsers",
+                    vec![("request", "request")],
+                    false,
+                    "unknown",
+                ),
+            ],
+            expected_diag_codes: vec![],
+        },
+        ContractFixture {
+            name: "single-param-function-plugin-fastify.fixture.txt",
+            expected_routes: vec![
+                ("GET", "/admin/audit/logs", "listAuditLogs"),
+                ("POST", "/admin/audit/logs", "createAuditLog"),
+            ],
+            expected_handlers: vec![
+                ("listAuditLogs", vec![("req", "request")], false, "unknown"),
+                (
+                    "createAuditLog",
+                    vec![("reply", "response")],
+                    false,
+                    "unknown",
+                ),
+            ],
+            expected_diag_codes: vec![],
+        },
+        ContractFixture {
             name: "unsupported-fastify.fixture.txt",
             expected_routes: vec![],
             expected_handlers: vec![],

--- a/packages/analyzer-rust/tests/fastify_ast_analyzer.rs
+++ b/packages/analyzer-rust/tests/fastify_ast_analyzer.rs
@@ -217,3 +217,52 @@ fn handles_single_param_arrow_plugins_and_handlers() {
 
     assert!(ir.diagnostics.is_empty());
 }
+
+#[test]
+fn handles_chained_routes_nested_plugins_and_single_param_function_plugins() {
+    let cases = vec![
+        (
+            "chaining-routes-fastify.fixture.txt",
+            vec![
+                ("GET", "/users", "listUsers"),
+                ("POST", "/users", "createUser"),
+                ("PATCH", "/users/:id", "updateUser"),
+            ],
+        ),
+        (
+            "nested-plugin-chaining-fastify.fixture.txt",
+            vec![
+                ("GET", "/api/users", "listApiUsers"),
+                ("POST", "/api/users", "createApiUser"),
+                ("GET", "/api/v2/users", "listNestedUsers"),
+            ],
+        ),
+        (
+            "single-param-function-plugin-fastify.fixture.txt",
+            vec![
+                ("GET", "/admin/audit/logs", "listAuditLogs"),
+                ("POST", "/admin/audit/logs", "createAuditLog"),
+            ],
+        ),
+    ];
+
+    for (name, expected_routes) in cases {
+        let (file, src) = fixture(name);
+        let ir = analyze_fastify_entry(&file, &src);
+
+        assert_eq!(
+            ir.routes
+                .iter()
+                .map(|r| (r.method.as_str(), r.path.as_str(), r.handler_ref.as_str()))
+                .collect::<Vec<_>>(),
+            expected_routes,
+            "route extraction drifted for fixture: {}",
+            name
+        );
+        assert!(
+            ir.diagnostics.is_empty(),
+            "unexpected diagnostics for fixture: {}",
+            name
+        );
+    }
+}

--- a/packages/analyzer-rust/tests/fixtures/chaining-routes-fastify.fixture.txt
+++ b/packages/analyzer-rust/tests/fixtures/chaining-routes-fastify.fixture.txt
@@ -1,0 +1,11 @@
+import Fastify from "fastify";
+
+const app = Fastify();
+
+function listUsers() {}
+const createUser = async () => {};
+const updateUser = function () {};
+
+app.get("/users", listUsers)
+  .post("/users", createUser)
+  .route({ method: "PATCH", url: "/users/:id", handler: updateUser });

--- a/packages/analyzer-rust/tests/fixtures/nested-plugin-chaining-fastify.fixture.txt
+++ b/packages/analyzer-rust/tests/fixtures/nested-plugin-chaining-fastify.fixture.txt
@@ -1,0 +1,16 @@
+import Fastify from "fastify";
+
+const app = Fastify();
+
+const listApiUsers = req => {};
+const createApiUser = req => {};
+const listNestedUsers = request => {};
+
+app.register(scope => {
+  scope.get("/users", listApiUsers)
+    .post("/users", createApiUser);
+
+  scope.register(inner => {
+    inner.get("/users", listNestedUsers);
+  }, { prefix: "/v2" });
+}, { prefix: "/api" });

--- a/packages/analyzer-rust/tests/fixtures/single-param-function-plugin-fastify.fixture.txt
+++ b/packages/analyzer-rust/tests/fixtures/single-param-function-plugin-fastify.fixture.txt
@@ -1,0 +1,15 @@
+import Fastify from "fastify";
+
+const app = Fastify();
+
+const listAuditLogs = req => {};
+const createAuditLog = reply => {};
+
+function auditPlugin(plugin) {
+  plugin.get("/logs", listAuditLogs);
+  plugin.route({ method: "POST", path: "/logs", handler: createAuditLog });
+}
+
+app.register(function scope(instance) {
+  instance.register(auditPlugin, { prefix: "/audit" });
+}, { prefix: "/admin" });


### PR DESCRIPTION
## Summary
- strengthen analyzer-rust IR contract stability for additional Fastify edge patterns with narrow fixtures/tests
- add contract coverage for:
  - chained route calls on the same Fastify instance
  - nested plugin + chaining combinations with prefix propagation
  - single-parameter function plugin variation
- extend traversal to consume chained calls (`.get().post().route().register()`) after a matched instance call without broadening unsupported patterns

## Scope
- packages/analyzer-rust only (+ tests/fixtures)

## Changes
- `packages/analyzer-rust/src/traversal.rs`
  - add chain-aware call consumption in `analyze_scope` via `analyze_call_chain`
  - preserve existing extract/diagnose boundaries and diagnostics behavior
- `packages/analyzer-rust/tests/fastify_ast_analyzer.rs`
  - add regression test covering chained routes, nested plugin chaining, and single-param function plugin fixture
- `packages/analyzer-rust/tests/contract_parity_regression.rs`
  - include new fixtures in parity matrix for routes/handlers/diagnostics stability
- new fixtures:
  - `packages/analyzer-rust/tests/fixtures/chaining-routes-fastify.fixture.txt`
  - `packages/analyzer-rust/tests/fixtures/nested-plugin-chaining-fastify.fixture.txt`
  - `packages/analyzer-rust/tests/fixtures/single-param-function-plugin-fastify.fixture.txt`

## Gate Results (CI order)
1. `pnpm run format:check` ✅
2. `pnpm run lint` ✅
3. `pnpm run build` ✅
4. `pnpm run test` ✅

Additional package-level verification:
- `cargo test` in `packages/analyzer-rust` ✅

## Risk / Notes
- behavior is intentionally narrow and fixture-driven
- no cross-package contract changes outside analyzer-rust scope
