### PR TITLE
feat: harden pipeline-driver artifact contract diagnostics

### DIFF
--- a/packages/pipeline/src/internal/stage-orchestration.ts
+++ b/packages/pipeline/src/internal/stage-orchestration.ts
@@ -1,4 +1,5 @@
 import type { UserConfig } from "@tsgodown/config";
+import type { RunBuildResult } from "@tsgodown/tsdown-driver";
 
 import { formatPipelineFailure, resolveEntry } from "./result-normalization.js";
 import { runBuildArtifactsViaRustAdapter } from "./rust-adapter-boundary.js";
@@ -20,11 +21,7 @@ export async function orchestratePipelineStages({
     try {
       log("[BUILD_ARTIFACTS] collecting build outputs");
       const buildResult = await runBuildArtifactsViaRustAdapter(cwd);
-      if (!buildResult.manifestPath || !buildResult.manifestIndexPath) {
-        throw new Error(
-          "rust adapter contract violation: missing manifest or manifest index path",
-        );
-      }
+      assertBuildArtifactContract(buildResult);
 
       log(
         `[BUILD_IR] analyzing entry: ${entry} (delegated to rust engine, buildId=${buildResult.manifest.buildId})`,
@@ -37,5 +34,31 @@ export async function orchestratePipelineStages({
     } catch (cause) {
       throw formatPipelineFailure(entry, cause);
     }
+  }
+}
+
+export function assertBuildArtifactContract(buildResult: RunBuildResult): void {
+  const violations: string[] = [];
+
+  if (!buildResult.manifestPath?.trim()) {
+    violations.push("manifestPath must be a non-empty string");
+  }
+
+  if (!buildResult.manifestIndexPath?.trim()) {
+    violations.push("manifestIndexPath must be a non-empty string");
+  }
+
+  if (!buildResult.manifest?.buildId?.trim()) {
+    violations.push("manifest.buildId must be a non-empty string");
+  }
+
+  if (!Array.isArray(buildResult.manifest?.entries)) {
+    violations.push("manifest.entries must be an array");
+  }
+
+  if (violations.length > 0) {
+    throw new Error(
+      `rust adapter artifact contract violation: ${violations.join("; ")}`,
+    );
   }
 }

--- a/packages/pipeline/test/stage-orchestration.test.ts
+++ b/packages/pipeline/test/stage-orchestration.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { assertBuildArtifactContract } from "../src/internal/stage-orchestration.ts";
+
+test("assertBuildArtifactContract reports missing/invalid artifact fields clearly", () => {
+  assert.throws(
+    () =>
+      assertBuildArtifactContract({
+        mode: "rust-engine-adapter",
+        manifestPath: "",
+        manifestIndexPath: "",
+        manifest: {
+          buildId: "",
+          entries: "not-an-array" as unknown as string[],
+          bundles: [],
+          types: [],
+          tsconfigPath: "tsconfig.json",
+        },
+        diagnostics: [],
+      }),
+    /artifact contract violation: manifestPath must be a non-empty string; manifestIndexPath must be a non-empty string; manifest\.buildId must be a non-empty string; manifest\.entries must be an array/,
+  );
+});

--- a/packages/tsdown-driver/src/index.ts
+++ b/packages/tsdown-driver/src/index.ts
@@ -1,4 +1,5 @@
 export {
+  assertManifestIndexContract,
   buildManifestFromBundles,
   writeManifest,
   writeManifestArtifacts,

--- a/packages/tsdown-driver/src/manifest.ts
+++ b/packages/tsdown-driver/src/manifest.ts
@@ -44,6 +44,8 @@ export async function writeManifestArtifacts(
     generatedAt: new Date().toISOString(),
   };
 
+  assertManifestIndexContract(manifest, manifestIndex);
+
   await fs.writeFile(
     manifestIndexPath,
     `${JSON.stringify(manifestIndex, null, 2)}\n`,
@@ -54,4 +56,49 @@ export async function writeManifestArtifacts(
     manifestPath,
     manifestIndexPath,
   };
+}
+
+export function assertManifestIndexContract(
+  manifest: ArtifactManifest,
+  manifestIndex: ArtifactManifestIndex,
+): void {
+  const violations: string[] = [];
+
+  if (!manifest.buildId?.trim()) {
+    violations.push("manifest.buildId must be a non-empty string");
+  }
+
+  if (!manifestIndex.buildId?.trim()) {
+    violations.push("manifest index buildId must be a non-empty string");
+  }
+
+  if (
+    manifest.buildId?.trim() &&
+    manifestIndex.buildId?.trim() &&
+    manifestIndex.buildId !== manifest.buildId
+  ) {
+    violations.push(
+      `manifest index buildId mismatch (manifest=${manifest.buildId}, index=${manifestIndex.buildId})`,
+    );
+  }
+
+  if (manifestIndex.manifest !== "manifest.json") {
+    violations.push(
+      `manifest index manifest must equal \"manifest.json\" (received=${manifestIndex.manifest})`,
+    );
+  }
+
+  if (!manifestIndex.generatedAt?.trim()) {
+    violations.push("manifest index generatedAt must be a non-empty string");
+  } else if (Number.isNaN(Date.parse(manifestIndex.generatedAt))) {
+    violations.push(
+      `manifest index generatedAt must be ISO-8601 parseable (received=${manifestIndex.generatedAt})`,
+    );
+  }
+
+  if (violations.length > 0) {
+    throw new Error(
+      `[tsdown-driver] artifact contract violation: ${violations.join("; ")}`,
+    );
+  }
 }

--- a/packages/tsdown-driver/src/run-build.ts
+++ b/packages/tsdown-driver/src/run-build.ts
@@ -2,6 +2,7 @@ import { normalizeRustEngineResponse } from "./contract.js";
 import { writeManifestArtifacts } from "./manifest.js";
 import { invokeRustEngine } from "./process-adapter.js";
 import type {
+  ArtifactManifest,
   RunBuildOptions,
   RunBuildResult,
   RustEngineRequest,
@@ -36,6 +37,12 @@ export async function runBuild(
     response.manifest,
   );
 
+  assertRunBuildArtifactContract({
+    manifestPath,
+    manifestIndexPath,
+    manifest: response.manifest,
+  });
+
   return {
     mode: "rust-engine-adapter",
     manifestPath,
@@ -43,4 +50,34 @@ export async function runBuild(
     manifest: response.manifest,
     diagnostics: response.diagnostics ?? [],
   };
+}
+
+function assertRunBuildArtifactContract(input: {
+  manifestPath: string;
+  manifestIndexPath: string;
+  manifest: ArtifactManifest;
+}): void {
+  const violations: string[] = [];
+
+  if (!input.manifestPath?.trim()) {
+    violations.push("manifestPath must be a non-empty string");
+  }
+
+  if (!input.manifestIndexPath?.trim()) {
+    violations.push("manifestIndexPath must be a non-empty string");
+  }
+
+  if (!input.manifest?.buildId?.trim()) {
+    violations.push("manifest.buildId must be a non-empty string");
+  }
+
+  if (!Array.isArray(input.manifest?.entries)) {
+    violations.push("manifest.entries must be an array");
+  }
+
+  if (violations.length > 0) {
+    throw new Error(
+      `[tsdown-driver] artifact contract violation: ${violations.join("; ")}`,
+    );
+  }
 }

--- a/packages/tsdown-driver/test/driver.test.ts
+++ b/packages/tsdown-driver/test/driver.test.ts
@@ -7,6 +7,7 @@ import test from "node:test";
 import {
   type RustEngineRequest,
   type RustEngineResponse,
+  assertManifestIndexContract,
   buildManifestFromBundles,
   runBuild,
 } from "../src/index.ts";
@@ -46,6 +47,33 @@ test("buildManifestFromBundles maps real bundle, sourcemap and d.ts outputs", ()
   assert.deepEqual(manifest.types, ["dist/index.d.ts"]);
   assert.equal(manifest.tsconfigPath, "tsconfig.build.json");
   assert.match(manifest.buildId, /^[a-f0-9]{16}$/);
+});
+
+test("assertManifestIndexContract rejects malformed artifact index payloads with actionable details", () => {
+  const manifest = {
+    buildId: "aabbccddeeff0011",
+    entries: ["src/index.ts"],
+    bundles: [
+      {
+        file: "dist/index.mjs",
+        map: "dist/index.mjs.map",
+        format: "esm" as const,
+        exports: [],
+      },
+    ],
+    types: ["dist/index.d.ts"],
+    tsconfigPath: "tsconfig.json",
+  };
+
+  assert.throws(
+    () =>
+      assertManifestIndexContract(manifest, {
+        buildId: "ffeeddccbbaa9988",
+        manifest: "manifest-v2.json",
+        generatedAt: "not-a-date",
+      }),
+    /artifact contract violation: manifest index buildId mismatch .*manifest index manifest must equal "manifest\.json" .*generatedAt must be ISO-8601 parseable/s,
+  );
 });
 
 test("runBuild invokes rust adapter with JSON request contract", async () => {


### PR DESCRIPTION
## Summary
- harden pipeline ↔ tsdown-driver artifact contract checks around manifest/index fields and shape
- replace single generic pipeline invariant error with field-level violations for clearer diagnostics
- add tsdown-driver manifest-index contract assertion to guard buildId/manifest reference/generatedAt invariants
- add focused tests in both packages to lock diagnostic behavior

## Scope
- `packages/pipeline`
- `packages/tsdown-driver`

## Changes
- `packages/pipeline/src/internal/stage-orchestration.ts`
  - added `assertBuildArtifactContract(buildResult)` with explicit per-field violations
  - orchestration now validates adapter result via helper before downstream stages
- `packages/pipeline/test/stage-orchestration.test.ts`
  - new test verifies deterministic, actionable invariant message for malformed build artifacts
- `packages/tsdown-driver/src/manifest.ts`
  - added `assertManifestIndexContract(manifest, manifestIndex)`
  - `writeManifestArtifacts` now asserts index invariants before writing
- `packages/tsdown-driver/src/run-build.ts`
  - added local `assertRunBuildArtifactContract(...)` to validate return payload shape consistency
- `packages/tsdown-driver/src/index.ts`
  - exported `assertManifestIndexContract`
- `packages/tsdown-driver/test/driver.test.ts`
  - added test for malformed manifest-index invariant diagnostics

## Validation (CI order)
1. `pnpm install --frozen-lockfile`
2. `pnpm run lint`
3. `pnpm run format:check`
4. `pnpm run build`
5. `pnpm run test`
6. `cargo fmt --all --check`
7. `cargo clippy --workspace --all-targets -- -D warnings`
8. `cargo test --workspace --all-targets`

All passed.
