### PR TITLE
chore(emitter-go): polish deterministic scaffold output formatting

### DIFF
--- a/packages/emitter-go/src/render/template-rendering.ts
+++ b/packages/emitter-go/src/render/template-rendering.ts
@@ -108,7 +108,6 @@ export function renderRoute(
 
   const lines: string[] = [
     `func ${routeHandlerName(index)}(w http.ResponseWriter, req *http.Request) {`,
-    "",
     "\t// Route metadata:",
     `\t//   Method: ${normalizedMethod}`,
     `\t//   Path: ${quoteGo(normalizedPath)}`,


### PR DESCRIPTION
## Summary
- Polished `packages/emitter-go` scaffold output formatting with a minimal, non-functional consistency update.
- Removed an unnecessary blank line at the start of each generated route handler body so emitted Go output is more gofmt-aligned and stable-looking without behavior change.

## Scope
- `packages/emitter-go` only.
- No behavior changes to routing, normalization, diagnostics, or response behavior.

## Changed files
- `packages/emitter-go/src/render/template-rendering.ts`

## Validation (required full local CI sequence)
1. `pnpm run lint` ✅
2. `pnpm run format:check` ✅
3. `pnpm run build` ✅
4. `pnpm run test` ✅
5. `cargo fmt --all --check` ✅
6. `cargo clippy --workspace --all-targets -- -D warnings` ✅
7. `cargo test --workspace --all-targets` ✅

## Notes
- Go smoke tests in `packages/emitter-go/test/emit-go.test.ts` remain conditionally skipped in this environment as designed (`CI`/toolchain gating), with all non-skipped tests passing.
