### PR TITLE
Milestone 1 Round 3: polish pipeline/driver diagnostics consistency

### DIFF
--- a/packages/pipeline/src/internal/result-normalization.ts
+++ b/packages/pipeline/src/internal/result-normalization.ts
@@ -11,11 +11,12 @@ export function normalizePipelineCause(cause: unknown): string {
 }
 
 export function formatPipelineFailure(entry: string, cause: unknown): Error {
-  const message = normalizePipelineCause(cause);
+  const message =
+    normalizePipelineCause(cause).trim() || "unknown pipeline failure";
   return new Error(
     [
       `[pipeline] failed for entry \"${entry}\"`,
-      `source: ${entry}`,
+      `source: pipeline-entry(${entry})`,
       `cause: ${message}`,
       "guidance: Verify rust engine build/analyze contract and tsgodown.config.ts settings.",
     ].join("; "),

--- a/packages/pipeline/src/internal/stage-orchestration.ts
+++ b/packages/pipeline/src/internal/stage-orchestration.ts
@@ -58,7 +58,7 @@ export function assertBuildArtifactContract(buildResult: RunBuildResult): void {
 
   if (violations.length > 0) {
     throw new Error(
-      `rust adapter artifact contract violation: ${violations.join("; ")}`,
+      `[pipeline] artifact contract violation: ${violations.join("; ")}`,
     );
   }
 }

--- a/packages/tsdown-driver/src/run-build.ts
+++ b/packages/tsdown-driver/src/run-build.ts
@@ -28,7 +28,12 @@ export async function runBuild(
 
   if (!response.ok) {
     throw new Error(
-      `[tsdown-driver] rust engine failed source=${response.error.source} cause=${response.error.cause} guidance=${response.error.guidance}`,
+      [
+        "[tsdown-driver] rust engine failed",
+        `source=${response.error.source}`,
+        `cause=${response.error.cause}`,
+        `guidance=${response.error.guidance}`,
+      ].join("; "),
     );
   }
 


### PR DESCRIPTION
## Summary
- Polish M1 contract-failure diagnostics consistency between `packages/pipeline` and `packages/tsdown-driver`.
- Keep behavior stable while improving message clarity and delimiter consistency.

## What changed
### `packages/pipeline`
- `src/internal/result-normalization.ts`
  - Kept pipeline failure envelope format stable (`source:`, `cause:`, `guidance:`) for CLI compatibility.
  - Clarified source field to `pipeline-entry(<entry>)`.
  - Hardened cause normalization fallback to `unknown pipeline failure` when normalized text is blank.
- `src/internal/stage-orchestration.ts`
  - Standardized artifact contract violation prefix to `[pipeline] artifact contract violation: ...` for consistency with package-scoped diagnostics style.

### `packages/tsdown-driver`
- `src/run-build.ts`
  - Normalized rust-engine failure message assembly to a deterministic semicolon-delimited shape:
    - `[tsdown-driver] rust engine failed; source=...; cause=...; guidance=...`
  - No contract parsing behavior changes.

## Scope check
- Only touched:
  - `packages/pipeline`
  - `packages/tsdown-driver`
- No behavior changes outside diagnostics/message presentation.

## Validation (required full local CI sequence)
1. `pnpm run lint` ✅
2. `pnpm run format:check` ✅
3. `pnpm run build` ✅
4. `pnpm run test` ✅
5. `cargo fmt --all --check` ✅
6. `cargo clippy --workspace --all-targets -- -D warnings` ✅
7. `cargo test --workspace --all-targets` ✅

All gates passed locally.
