### PR TITLE
test(analyzer-rust): final fastify sweep add put/delete chain guards

### DIFF
--- a/.pr-body-m1-r3-analyzer-final-sweep-v1.md
+++ b/.pr-body-m1-r3-analyzer-final-sweep-v1.md
@@ -1,0 +1,25 @@
+## Summary
+- add a final Fastify analyzer fixture/test guard for chained `put` + `delete` shorthand routes
+- extend analyzer-rust contract parity coverage so PUT/DELETE extraction and handler metadata remain stable
+- keep scope limited to `packages/analyzer-rust` tests/fixtures only (no runtime behavior expansion)
+
+## What changed
+- `packages/analyzer-rust/tests/fixtures/put-delete-chaining-fastify.fixture.txt`
+  - new fixture covering chained `app.put(...).delete(...)`
+- `packages/analyzer-rust/tests/fastify_ast_analyzer.rs`
+  - include the new fixture in chained-route regression assertions
+- `packages/analyzer-rust/tests/contract_parity_regression.rs`
+  - add new contract fixture expectations for routes/handlers/diagnostics
+
+## Why
+- final fastify pattern sweep found missing stability coverage for shorthand `PUT`/`DELETE` chain extraction
+- this closes a contract-test gap without changing analyzer behavior
+
+## Validation (full required local CI sequence)
+1. `pnpm run lint` ✅
+2. `pnpm run format:check` ✅
+3. `pnpm run build` ✅
+4. `pnpm run test` ✅
+5. `cargo fmt --all --check` ✅
+6. `cargo clippy --workspace --all-targets -- -D warnings` ✅
+7. `cargo test --workspace --all-targets` ✅

--- a/packages/analyzer-rust/tests/contract_parity_regression.rs
+++ b/packages/analyzer-rust/tests/contract_parity_regression.rs
@@ -138,6 +138,18 @@ fn contract_fixtures() -> Vec<ContractFixture> {
             expected_diag_codes: vec![],
         },
         ContractFixture {
+            name: "put-delete-chaining-fastify.fixture.txt",
+            expected_routes: vec![
+                ("PUT", "/users/:id", "replaceUser"),
+                ("DELETE", "/users/:id", "removeUser"),
+            ],
+            expected_handlers: vec![
+                ("replaceUser", vec![], false, "unknown"),
+                ("removeUser", vec![], true, "unknown"),
+            ],
+            expected_diag_codes: vec![],
+        },
+        ContractFixture {
             name: "unsupported-fastify.fixture.txt",
             expected_routes: vec![],
             expected_handlers: vec![],

--- a/packages/analyzer-rust/tests/fastify_ast_analyzer.rs
+++ b/packages/analyzer-rust/tests/fastify_ast_analyzer.rs
@@ -244,6 +244,13 @@ fn handles_chained_routes_nested_plugins_and_single_param_function_plugins() {
                 ("POST", "/admin/audit/logs", "createAuditLog"),
             ],
         ),
+        (
+            "put-delete-chaining-fastify.fixture.txt",
+            vec![
+                ("PUT", "/users/:id", "replaceUser"),
+                ("DELETE", "/users/:id", "removeUser"),
+            ],
+        ),
     ];
 
     for (name, expected_routes) in cases {

--- a/packages/analyzer-rust/tests/fixtures/put-delete-chaining-fastify.fixture.txt
+++ b/packages/analyzer-rust/tests/fixtures/put-delete-chaining-fastify.fixture.txt
@@ -1,0 +1,9 @@
+import Fastify from "fastify";
+
+const app = Fastify();
+
+function replaceUser() {}
+const removeUser = async () => {};
+
+app.put("/users/:id", replaceUser)
+  .delete("/users/:id", removeUser);


### PR DESCRIPTION
## Summary
- add a final Fastify analyzer fixture/test guard for chained `put` + `delete` shorthand routes
- extend analyzer-rust contract parity coverage so PUT/DELETE extraction and handler metadata remain stable
- keep scope limited to `packages/analyzer-rust` tests/fixtures only (no runtime behavior expansion)

## What changed
- `packages/analyzer-rust/tests/fixtures/put-delete-chaining-fastify.fixture.txt`
  - new fixture covering chained `app.put(...).delete(...)`
- `packages/analyzer-rust/tests/fastify_ast_analyzer.rs`
  - include the new fixture in chained-route regression assertions
- `packages/analyzer-rust/tests/contract_parity_regression.rs`
  - add new contract fixture expectations for routes/handlers/diagnostics

## Why
- final fastify pattern sweep found missing stability coverage for shorthand `PUT`/`DELETE` chain extraction
- this closes a contract-test gap without changing analyzer behavior

## Validation (full required local CI sequence)
1. `pnpm run lint` ✅
2. `pnpm run format:check` ✅
3. `pnpm run build` ✅
4. `pnpm run test` ✅
5. `cargo fmt --all --check` ✅
6. `cargo clippy --workspace --all-targets -- -D warnings` ✅
7. `cargo test --workspace --all-targets` ✅
