### PR TITLE
test(m1): finalize acceptance naming and assertion readability

### DIFF
--- a/.pr-body-m1-r3-acceptance-finalize-v1.md
+++ b/.pr-body-m1-r3-acceptance-finalize-v1.md
@@ -1,0 +1,21 @@
+## Summary
+- finalized M1 acceptance scenario naming for the fastify -> Go compile success path in both pipeline and CLI e2e tests
+- extracted repeated Go scaffold/compile assertions into focused helper functions to improve test readability without changing behavior
+- documented the exact M1 acceptance scenario in `docs/specs/TESTING_STRATEGY.md`
+
+## Scope
+- test/docs naming + assertion clarity only around the M1 acceptance path
+- no analyzer-rust internals changed
+- no emitter-go internals changed
+
+## Validation
+Executed full gate in required order:
+1. `pnpm run lint`
+2. `pnpm run format:check`
+3. `pnpm run build`
+4. `pnpm run test`
+5. `cargo fmt --all --check`
+6. `cargo clippy --workspace --all-targets -- -D warnings`
+7. `cargo test --workspace --all-targets`
+
+All passed.

--- a/docs/specs/TESTING_STRATEGY.md
+++ b/docs/specs/TESTING_STRATEGY.md
@@ -19,6 +19,19 @@
 - Integration: rust adapter contract + pipeline orchestration
 - E2E: 실제 예제 프로젝트 변환 후 CLI/build contract 검증
 
+## M1 acceptance scenario (Fastify -> Go compile success path)
+M1 수용 기준은 아래 단일 성공 경로를 명확히 고정한다.
+
+1. 입력: Fastify scaffold TypeScript 엔트리(`src/index.ts`)
+2. 실행: `runPipeline` 또는 CLI `build`를 Rust adapter 경유로 실행
+3. 산출: `dist-go/main.go` 생성 확인
+4. 가독성 고정 assertion:
+   - Go scaffold shape (`package main`, `func main()`, `GET /health` route binding)
+   - Go toolchain 존재 시 `go mod init` + `go build ./...` 성공
+
+주의: 이 시나리오 검증은 acceptance naming/assertion clarity 범위에 한정하며,
+`analyzer-rust` / `emitter-go` 내부 구현 세부사항은 테스트 대상에서 제외한다.
+
 ## Required checks per PR/turn
 - `npm run build` (or `pnpm run build`)
 - `npm run test` (or `pnpm run test`)

--- a/packages/cli/test/commands.e2e.test.ts
+++ b/packages/cli/test/commands.e2e.test.ts
@@ -171,6 +171,37 @@ function createRustEngineLauncherWithGoMain(cwd: string): string {
   ]);
 }
 
+function assertGoMainScaffold(goSource: string) {
+  assert.match(goSource, /^package main/m);
+  assert.match(goSource, /func main\(\)/);
+  assert.match(goSource, /http\.HandleFunc\("GET \/health"/);
+}
+
+function assertGoBuildSuccessIfToolchainAvailable(goDir: string) {
+  const hasGoToolchain =
+    spawnSync("go", ["version"], { encoding: "utf8" }).status === 0;
+
+  if (!hasGoToolchain) {
+    return;
+  }
+
+  const modInit = spawnSync(
+    "go",
+    ["mod", "init", "example.com/tsgodown-cli-fastify-min"],
+    {
+      cwd: goDir,
+      encoding: "utf8",
+    },
+  );
+  assert.equal(modInit.status, 0, modInit.stderr || modInit.stdout);
+
+  const goBuild = spawnSync("go", ["build", "./..."], {
+    cwd: goDir,
+    encoding: "utf8",
+  });
+  assert.equal(goBuild.status, 0, goBuild.stderr || goBuild.stdout);
+}
+
 function parseJsonStdout(stdout: string) {
   const jsonStart = stdout.indexOf("{");
   assert.ok(jsonStart >= 0, "expected JSON output");
@@ -652,7 +683,7 @@ test("rust-only fixture matrix keeps build/check/report/stages deterministic", (
   }
 });
 
-test("CLI build fastify-min fixture emits deterministic compile-valid Go scaffold", () => {
+test("M1 acceptance: CLI build fastify-min fixture -> dist-go/main.go -> go build (if available)", () => {
   const cwd = setupProjectFromFixture("fastify-min");
   const rustLauncher = createRustEngineLauncherWithGoMain(cwd);
 
@@ -674,30 +705,8 @@ test("CLI build fastify-min fixture emits deterministic compile-valid Go scaffol
     crypto.createHash("sha256").update(goMain).digest("hex"),
     "7ee934e294fa4b3f5f5006ac4b265f8815d8d4778023e9ea226732279f6ab257",
   );
-  assert.match(goMain, /^package main/m);
-  assert.match(goMain, /func main\(\)/);
-  assert.match(goMain, /http\.HandleFunc\("GET \/health"/);
-
-  const hasGoToolchain =
-    spawnSync("go", ["version"], { encoding: "utf8" }).status === 0;
-
-  if (hasGoToolchain) {
-    const modInit = spawnSync(
-      "go",
-      ["mod", "init", "example.com/tsgodown-cli-fastify-min"],
-      {
-        cwd: path.dirname(goPath),
-        encoding: "utf8",
-      },
-    );
-    assert.equal(modInit.status, 0, modInit.stderr || modInit.stdout);
-
-    const goBuild = spawnSync("go", ["build", "./..."], {
-      cwd: path.dirname(goPath),
-      encoding: "utf8",
-    });
-    assert.equal(goBuild.status, 0, goBuild.stderr || goBuild.stdout);
-  }
+  assertGoMainScaffold(goMain);
+  assertGoBuildSuccessIfToolchainAvailable(path.dirname(goPath));
 });
 
 test("rust-only fixture matrix surfaces deterministic contract error path", () => {

--- a/packages/pipeline/test/pipeline.e2e.test.ts
+++ b/packages/pipeline/test/pipeline.e2e.test.ts
@@ -111,7 +111,38 @@ function setupProject() {
   return dir;
 }
 
-test("runPipeline acceptance: fastify scaffold TS input flows through rust-adapter pipeline and emits valid Go scaffold", async () => {
+function assertGoMainScaffold(goSource: string) {
+  assert.match(goSource, /^package main/m);
+  assert.match(goSource, /func main\(\)/);
+  assert.match(goSource, /http\.HandleFunc\("GET \/health"/);
+}
+
+function assertGoBuildSuccessIfToolchainAvailable(goDir: string) {
+  const hasGoToolchain =
+    spawnSync("go", ["version"], { encoding: "utf8" }).status === 0;
+
+  if (!hasGoToolchain) {
+    return;
+  }
+
+  const modInit = spawnSync(
+    "go",
+    ["mod", "init", "example.com/tsgodown-pipeline"],
+    {
+      cwd: goDir,
+      encoding: "utf8",
+    },
+  );
+  assert.equal(modInit.status, 0, modInit.stderr || modInit.stdout);
+
+  const goBuild = spawnSync("go", ["build", "./..."], {
+    cwd: goDir,
+    encoding: "utf8",
+  });
+  assert.equal(goBuild.status, 0, goBuild.stderr || goBuild.stdout);
+}
+
+test("M1 acceptance: runPipeline fastify scaffold TS -> dist-go/main.go -> go build (if available)", async () => {
   const cwd = setupProject();
   const logs: string[] = [];
   const launcherPath = createRustLauncher(cwd);
@@ -169,29 +200,8 @@ test("runPipeline acceptance: fastify scaffold TS input flows through rust-adapt
     assert.equal(fs.existsSync(goPath), true);
 
     const emittedGo = fs.readFileSync(goPath, "utf8");
-    assert.match(emittedGo, /^package main/m);
-    assert.match(emittedGo, /func main\(\)/);
-    assert.match(emittedGo, /http\.HandleFunc\("GET \/health"/);
-
-    const hasGoToolchain =
-      spawnSync("go", ["version"], { encoding: "utf8" }).status === 0;
-    if (hasGoToolchain) {
-      const modInit = spawnSync(
-        "go",
-        ["mod", "init", "example.com/tsgodown-pipeline"],
-        {
-          cwd: path.dirname(goPath),
-          encoding: "utf8",
-        },
-      );
-      assert.equal(modInit.status, 0, modInit.stderr || modInit.stdout);
-
-      const goBuild = spawnSync("go", ["build", "./..."], {
-        cwd: path.dirname(goPath),
-        encoding: "utf8",
-      });
-      assert.equal(goBuild.status, 0, goBuild.stderr || goBuild.stdout);
-    }
+    assertGoMainScaffold(emittedGo);
+    assertGoBuildSuccessIfToolchainAvailable(path.dirname(goPath));
   } finally {
     if (prevRustBin === undefined) {
       Reflect.deleteProperty(process.env, "TSGODOWN_RUST_ENGINE_BIN");


### PR DESCRIPTION
## Summary
- finalized M1 acceptance scenario naming for the fastify -> Go compile success path in both pipeline and CLI e2e tests
- extracted repeated Go scaffold/compile assertions into focused helper functions to improve test readability without changing behavior
- documented the exact M1 acceptance scenario in `docs/specs/TESTING_STRATEGY.md`

## Scope
- test/docs naming + assertion clarity only around the M1 acceptance path
- no analyzer-rust internals changed
- no emitter-go internals changed

## Validation
Executed full gate in required order:
1. `pnpm run lint`
2. `pnpm run format:check`
3. `pnpm run build`
4. `pnpm run test`
5. `cargo fmt --all --check`
6. `cargo clippy --workspace --all-targets -- -D warnings`
7. `cargo test --workspace --all-targets`

All passed.
