### PR TITLE
test(emitter-go): strengthen Go compile smoke fixtures

### DIFF
--- a/packages/emitter-go/test/emit-go.test.ts
+++ b/packages/emitter-go/test/emit-go.test.ts
@@ -243,53 +243,98 @@ const hasGoToolchain =
   spawnSync("go", ["version"], { encoding: "utf8" }).status === 0;
 const runGoSmoke = hasGoToolchain && process.env.CI !== "true";
 
+function assertBuildsWithGoToolchain(fixture: ProgramIR, fixtureName: string) {
+  const outDir = createOutDir();
+  emitGoProject(fixture, outDir);
+
+  const modulePath = `example.com/tsgodown-smoke/${fixtureName}`;
+  const modInit = spawnSync("go", ["mod", "init", modulePath], {
+    cwd: outDir,
+    encoding: "utf8",
+  });
+  assert.equal(
+    modInit.status,
+    0,
+    `go mod init failed for fixture ${fixtureName} in ${outDir}\nstdout:\n${modInit.stdout}\nstderr:\n${modInit.stderr}`,
+  );
+
+  const result = spawnSync("go", ["build", "./..."], {
+    cwd: outDir,
+    encoding: "utf8",
+  });
+  assert.equal(
+    result.status,
+    0,
+    `go build failed for fixture ${fixtureName} in ${outDir}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+  );
+}
+
 test(
   "emitGoProject smoke: generated representative fixtures can go build",
   { skip: !runGoSmoke },
   () => {
-    const fixtures: ProgramIR[] = [
-      sampleIr,
+    const fixtures: Array<{ name: string; ir: ProgramIR }> = [
       {
-        modules: [],
-        handlers: [{ id: "nested", params: [], async: false }],
-        diagnostics: [],
-        routes: [
-          {
-            method: "PATCH",
-            path: "/api/v2/users/:id/devices/{deviceId}",
-            handlerRef: "nested",
-          },
-        ],
+        name: "sample-ir",
+        ir: sampleIr,
+      },
+      {
+        name: "nested-restish-route",
+        ir: {
+          modules: [],
+          handlers: [{ id: "nested", params: [], async: false }],
+          diagnostics: [],
+          routes: [
+            {
+              method: "PATCH",
+              path: "/api/v2/users/:id/devices/{deviceId}",
+              handlerRef: "nested",
+            },
+          ],
+        },
+      },
+      {
+        name: "empty-method-fallback-and-diagnostics",
+        ir: {
+          modules: [],
+          handlers: [{ id: "fallback", params: [], async: false }],
+          diagnostics: [
+            {
+              level: "warn",
+              code: "UNSUPPORTED_DYNAMIC_PATH",
+              message:
+                "unsupported dynamic path in fastify.get(...). Use string literal path (e.g. '/users/:id') for IR extraction.",
+              source: { file: "src/server.ts", line: 9, column: 2 },
+            },
+          ],
+          routes: [
+            {
+              method: "   " as ProgramIR["routes"][number]["method"],
+              path: "/health",
+              handlerRef: "fallback",
+            },
+          ],
+        },
+      },
+      {
+        name: "go-unsafe-path-params",
+        ir: {
+          modules: [],
+          handlers: [{ id: "keywordParams", params: [], async: false }],
+          diagnostics: [],
+          routes: [
+            {
+              method: "GET",
+              path: "/things/:type/:req/:w/:pathParamType",
+              handlerRef: "keywordParams",
+            },
+          ],
+        },
       },
     ];
 
     for (const fixture of fixtures) {
-      const outDir = createOutDir();
-      emitGoProject(fixture, outDir);
-
-      const modInit = spawnSync(
-        "go",
-        ["mod", "init", "example.com/tsgodown-smoke"],
-        {
-          cwd: outDir,
-          encoding: "utf8",
-        },
-      );
-      assert.equal(
-        modInit.status,
-        0,
-        `go mod init failed for fixture in ${outDir}\nstdout:\n${modInit.stdout}\nstderr:\n${modInit.stderr}`,
-      );
-
-      const result = spawnSync("go", ["build", "./..."], {
-        cwd: outDir,
-        encoding: "utf8",
-      });
-      assert.equal(
-        result.status,
-        0,
-        `go build failed for fixture in ${outDir}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
-      );
+      assertBuildsWithGoToolchain(fixture.ir, fixture.name);
     }
   },
 );


### PR DESCRIPTION
## Summary
- strengthened `packages/emitter-go` Go compile smoke coverage by expanding representative IR fixtures used by the smoke test
- kept existing gate behavior unchanged: smoke tests still run only when Go toolchain exists and `CI !== "true"`
- refactored repetitive Go build smoke setup into a helper for clearer fixture-level failure reporting

## What changed
- `packages/emitter-go/test/emit-go.test.ts`
  - added `assertBuildsWithGoToolchain(fixture, fixtureName)` helper
  - expanded fixture matrix from 2 to 4 representative cases:
    - baseline `sampleIr`
    - nested REST-style path params (`:id` + `{deviceId}`)
    - empty-method fallback + diagnostics comment path
    - Go-unsafe path param names (`:type/:req/:w/...`) sanitization path
  - improved assertion messages to include fixture name/module path context

## Validation
Ran required full local CI sequence in exact order:
1. `pnpm run lint` ✅
2. `pnpm run format:check` ✅
3. `pnpm run build` ✅
4. `pnpm run test` ✅ (emitter-go Go smoke tests skipped because local Go toolchain is unavailable)
5. `cargo fmt --all --check` ✅
6. `cargo clippy --workspace --all-targets -- -D warnings` ✅
7. `cargo test --workspace --all-targets` ✅

## Notes
- Local environment has no `go` binary (`go: command not found`), so Go-dependent smoke tests remain correctly gated/skipped as designed.
