### PR TITLE
M1 R4: clarify analyzer-rust fastify support boundaries

### DIFF
--- a/packages/analyzer-rust/src/ast.rs
+++ b/packages/analyzer-rust/src/ast.rs
@@ -159,10 +159,11 @@ pub(crate) fn extract_object_string_prop(obj: &str, key: &str) -> Option<String>
 
 pub(crate) fn extract_object_handler_ref(obj: &str, key: &str) -> Option<String> {
     let pattern = format!(
-        r#"(?s)(?:\b{}\b|"{}")\s*:\s*([A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*)"#,
+        r#"(?s)(?:\b{}\b|"{}")\s*:\s*([^,}}]+)"#,
         regex::escape(key),
         regex::escape(key)
     );
     let re = Regex::new(&pattern).unwrap();
-    re.captures(obj).map(|c| c[1].to_string())
+    let expr = re.captures(obj).map(|c| c[1].trim().to_string())?;
+    extract_handler_ref(&expr)
 }

--- a/packages/analyzer-rust/src/routes.rs
+++ b/packages/analyzer-rust/src/routes.rs
@@ -71,9 +71,9 @@ pub(crate) fn extract_route_object(
     let Some(obj) = first_object_literal(args) else {
         diagnostics.push(diag(
             file,
-            "ANALYZER_UNSUPPORTED_ROUTE_OBJECT",
+            "ANALYZER_UNSUPPORTED_ROUTE_OBJECT_SHAPE",
             &format!(
-                "unsupported route object method in {}.route({{...}})",
+                "unsupported route object pattern in {}.route(...). Provide an inline object literal (e.g. {{ method: 'GET', url: '/users', handler: listUsers }}).",
                 instance_name
             ),
         ));
@@ -90,7 +90,7 @@ pub(crate) fn extract_route_object(
     let Some(method) = method else {
         diagnostics.push(diag(
             file,
-            "ANALYZER_UNSUPPORTED_ROUTE_OBJECT",
+            "ANALYZER_UNSUPPORTED_ROUTE_OBJECT_METHOD",
             &format!(
                 "unsupported route object method in {}.route({{...}}): missing string 'method'. Supported methods: GET|POST|PUT|DELETE|PATCH.",
                 instance_name
@@ -101,7 +101,7 @@ pub(crate) fn extract_route_object(
     if !supported.contains(method.as_str()) {
         diagnostics.push(diag(
             file,
-            "ANALYZER_UNSUPPORTED_ROUTE_OBJECT",
+            "ANALYZER_UNSUPPORTED_ROUTE_OBJECT_METHOD",
             &format!(
                 "unsupported route object method in {}.route({{...}}): '{}'. Supported methods: GET|POST|PUT|DELETE|PATCH.",
                 instance_name,

--- a/packages/analyzer-rust/tests/contract_parity_regression.rs
+++ b/packages/analyzer-rust/tests/contract_parity_regression.rs
@@ -159,6 +159,18 @@ fn contract_fixtures() -> Vec<ContractFixture> {
                 "ANALYZER_UNSUPPORTED_INLINE_HANDLER",
             ],
         },
+        ContractFixture {
+            name: "unsupported-route-object-fastify.fixture.txt",
+            expected_routes: vec![],
+            expected_handlers: vec![],
+            expected_diag_codes: vec![
+                "ANALYZER_UNSUPPORTED_DYNAMIC_PATH",
+                "ANALYZER_UNSUPPORTED_INLINE_HANDLER",
+                "ANALYZER_UNSUPPORTED_ROUTE_OBJECT_METHOD",
+                "ANALYZER_UNSUPPORTED_ROUTE_OBJECT_METHOD",
+                "ANALYZER_UNSUPPORTED_ROUTE_OBJECT_SHAPE",
+            ],
+        },
     ]
 }
 

--- a/packages/analyzer-rust/tests/fastify_ast_analyzer.rs
+++ b/packages/analyzer-rust/tests/fastify_ast_analyzer.rs
@@ -273,3 +273,63 @@ fn handles_chained_routes_nested_plugins_and_single_param_function_plugins() {
         );
     }
 }
+
+#[test]
+fn emits_deterministic_boundary_diagnostics_for_unsupported_route_object_patterns() {
+    let (file, src) = fixture("unsupported-route-object-fastify.fixture.txt");
+    let ir = analyze_fastify_entry(&file, &src);
+
+    assert!(ir.routes.is_empty());
+
+    let actual = ir
+        .diagnostics
+        .iter()
+        .map(|d| {
+            (
+                d.code.as_str(),
+                d.message.as_str(),
+                d.level.as_str(),
+                d.source
+                    .as_ref()
+                    .map(|s| s.file.as_str())
+                    .unwrap_or("<missing-source-file>"),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        actual,
+        vec![
+            (
+                "ANALYZER_UNSUPPORTED_ROUTE_OBJECT_SHAPE",
+                "unsupported route object pattern in fastify.route(...). Provide an inline object literal (e.g. { method: 'GET', url: '/users', handler: listUsers }).",
+                "warn",
+                file.as_str(),
+            ),
+            (
+                "ANALYZER_UNSUPPORTED_ROUTE_OBJECT_METHOD",
+                "unsupported route object method in fastify.route({...}): missing string 'method'. Supported methods: GET|POST|PUT|DELETE|PATCH.",
+                "warn",
+                file.as_str(),
+            ),
+            (
+                "ANALYZER_UNSUPPORTED_ROUTE_OBJECT_METHOD",
+                "unsupported route object method in fastify.route({...}): 'OPTIONS'. Supported methods: GET|POST|PUT|DELETE|PATCH.",
+                "warn",
+                file.as_str(),
+            ),
+            (
+                "ANALYZER_UNSUPPORTED_DYNAMIC_PATH",
+                "unsupported route object path in fastify.route({...}). Provide string literal 'url' or 'path' (e.g. '/users/:id').",
+                "warn",
+                file.as_str(),
+            ),
+            (
+                "ANALYZER_UNSUPPORTED_INLINE_HANDLER",
+                "unsupported route object handler in fastify.route({...}). Provide named handler reference in 'handler' field.",
+                "warn",
+                file.as_str(),
+            ),
+        ]
+    );
+}

--- a/packages/analyzer-rust/tests/fixtures/unsupported-route-object-fastify.fixture.txt
+++ b/packages/analyzer-rust/tests/fixtures/unsupported-route-object-fastify.fixture.txt
@@ -1,0 +1,15 @@
+import Fastify from "fastify";
+
+const fastify = Fastify();
+const routeConfig = { method: "GET", url: "/from-config", handler: listFromConfig };
+const dynamicPath = "/dynamic";
+
+function listUsers() {}
+function listAdmins() {}
+function listAudits() {}
+
+fastify.route(routeConfig);
+fastify.route({ url: "/users", handler: listUsers });
+fastify.route({ method: "OPTIONS", url: "/admins", handler: listAdmins });
+fastify.route({ method: "GET", url: dynamicPath, handler: listAudits });
+fastify.route({ method: "POST", url: "/inline", handler: async () => {} });


### PR DESCRIPTION
## Summary
- Clarify `packages/analyzer-rust` Fastify route-object support boundaries with explicit diagnostics for unsupported patterns.
- Keep behavior narrow: no new extraction capabilities, only clearer unsupported signaling and contract fixtures.

## Changes
### Analyzer updates (`packages/analyzer-rust/src`)
- `routes.rs`
  - Added explicit diagnostic code for unsupported route-object shape:
    - `ANALYZER_UNSUPPORTED_ROUTE_OBJECT_SHAPE`
  - Added explicit diagnostic code for route-object method boundary failures:
    - `ANALYZER_UNSUPPORTED_ROUTE_OBJECT_METHOD`
  - Kept existing method allowlist boundary explicit (`GET|POST|PUT|DELETE|PATCH`).
- `ast.rs`
  - Hardened `extract_object_handler_ref` to parse the full property expression and only accept named handler references.
  - Prevents accidental extraction of `async` from inline handlers like `handler: async () => {}`.

### Fixtures/tests updates (`packages/analyzer-rust/tests`)
- Added fixture:
  - `tests/fixtures/unsupported-route-object-fastify.fixture.txt`
- `fastify_ast_analyzer.rs`
  - Added deterministic boundary test asserting exact diagnostic `(code, message, level, source.file)` sequence for unsupported route-object patterns.
- `contract_parity_regression.rs`
  - Added the new fixture into contract parity expectations with stable diagnostic codes.

## Why
This freezes supported/unsupported Fastify route-object boundaries with deterministic diagnostics and fixtures, reducing ambiguity and drift risk without broadening analyzer behavior.

## Validation (required full local CI sequence)
1. `pnpm run lint` ✅
2. `pnpm run format:check` ✅
3. `pnpm run build` ✅
4. `pnpm run test` ✅
5. `cargo fmt --all --check` ✅
6. `cargo clippy --workspace --all-targets -- -D warnings` ✅
7. `cargo test --workspace --all-targets` ✅
