### PR TITLE
feat: polish pipeline failure reporting UX for stage-wise debugging

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,11 @@
 #!/usr/bin/env node
 import { isCommand, parseArgv } from "./argv.js";
 import { executeCommand } from "./command-executor.js";
+import {
+  extractCommandErrorDetails,
+  printHumanError,
+  printJson,
+} from "./output/index.js";
 
 async function main() {
   const { command, json } = parseArgv(process.argv.slice(2));
@@ -16,7 +21,22 @@ async function main() {
 try {
   await main();
 } catch (error) {
-  const msg = error instanceof Error ? error.message : String(error);
-  console.error(`[tsgodown] command failed: ${msg}`);
+  const details = extractCommandErrorDetails(error);
+  const { json } = parseArgv(process.argv.slice(2));
+
+  if (json) {
+    printJson({
+      ok: false,
+      error: {
+        message: details.message,
+        source: details.source,
+        stage: details.stage,
+        cause: details.cause,
+        guidance: details.guidance,
+      },
+    });
+  } else {
+    printHumanError(details);
+  }
   process.exit(1);
 }

--- a/packages/cli/src/output/error.ts
+++ b/packages/cli/src/output/error.ts
@@ -1,0 +1,58 @@
+export interface CommandErrorDetails {
+  message: string;
+  source?: string;
+  stage?: string;
+  cause?: string;
+  guidance?: string;
+}
+
+export function extractCommandErrorDetails(
+  error: unknown,
+): CommandErrorDetails {
+  const message = error instanceof Error ? error.message : String(error);
+
+  const details: CommandErrorDetails = { message };
+  const fields = parseDelimitedKeyValuePairs(message);
+
+  details.source = fields.source;
+  details.stage = fields.stage;
+  details.cause = fields.cause;
+  details.guidance = fields.guidance;
+
+  return details;
+}
+
+export function printHumanError(details: CommandErrorDetails): void {
+  console.error(`[tsgodown] command failed: ${details.message}`);
+  if (details.source) {
+    console.error(`source: ${details.source}`);
+  }
+  if (details.stage) {
+    console.error(`stage: ${details.stage}`);
+  }
+  if (details.cause) {
+    console.error(`cause: ${details.cause}`);
+  }
+  if (details.guidance) {
+    console.error(`guidance: ${details.guidance}`);
+  }
+}
+
+function parseDelimitedKeyValuePairs(message: string): Record<string, string> {
+  const parsed: Record<string, string> = {};
+  for (const token of message.split(";")) {
+    const item = token.trim();
+    const idx = item.indexOf(":");
+    if (idx <= 0) {
+      continue;
+    }
+
+    const key = item.slice(0, idx).trim().toLowerCase();
+    const value = item.slice(idx + 1).trim();
+    if (!key || !value) {
+      continue;
+    }
+    parsed[key] = value;
+  }
+  return parsed;
+}

--- a/packages/cli/src/output/index.ts
+++ b/packages/cli/src/output/index.ts
@@ -1,2 +1,3 @@
 export { humanPrintSummary, humanPrintStages } from "./human.js";
 export { printJson } from "./json.js";
+export { extractCommandErrorDetails, printHumanError } from "./error.js";

--- a/packages/cli/test/commands.e2e.test.ts
+++ b/packages/cli/test/commands.e2e.test.ts
@@ -455,12 +455,65 @@ test("CLI fail diagnostics include source/cause/guidance contract", () => {
   });
   assert.notEqual(result.status, 0, "build should fail for missing entry");
 
+  const parsed = parseJsonStdout(result.stdout) as {
+    error: Record<string, string>;
+  };
+  const haystack = JSON.stringify(parsed.error);
   for (const token of fixture.stderrIncludes) {
     assert.match(
-      result.stderr,
+      haystack,
       new RegExp(token.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")),
     );
   }
+});
+
+test("CLI --json failure output keeps source/stage/cause/guidance consistent", () => {
+  const cwd = setupProject(
+    ["const fastify = {} as any;", "fastify.get('/health', () => {});"],
+    'export default { entry: "src/missing.ts", outDir: "dist-go" };\n',
+  );
+
+  const rustLauncher = createRustEngineLauncher(cwd, [
+    "for await (const _ of process.stdin) { /* drain */ }",
+    "const response = {",
+    "  ok: false,",
+    "  error: {",
+    "    source: 'rust-engine-adapter',",
+    "    cause: 'ENOENT: missing entry src/missing.ts',",
+    "    guidance: 'Verify tsgodown.config.ts entry path and file existence.'",
+    "  }",
+    "};",
+    "process.stdout.write(JSON.stringify(response));",
+  ]);
+
+  const result = runCli(cwd, "build", {
+    ...process.env,
+    TSGODOWN_RUST_ENGINE_BIN: rustLauncher,
+  });
+
+  assert.notEqual(result.status, 0, "build should fail for missing entry");
+  const parsed = parseJsonStdout(result.stdout) as {
+    ok: boolean;
+    error: {
+      source?: string;
+      stage?: string;
+      cause?: string;
+      guidance?: string;
+      message: string;
+    };
+  };
+
+  assert.equal(parsed.ok, false);
+  assert.equal(parsed.error.source, "pipeline-entry(src/missing.ts)");
+  assert.equal(parsed.error.stage, "BUILD_ARTIFACTS");
+  assert.match(
+    parsed.error.cause ?? "",
+    /\[tsdown-driver\] rust engine failed/,
+  );
+  assert.equal(
+    parsed.error.guidance,
+    "Verify rust engine build/analyze contract and tsgodown.config.ts settings.",
+  );
 });
 
 test("CLI fails with explicit diagnostic when rust engine bin env is missing", () => {
@@ -475,10 +528,16 @@ test("CLI fails with explicit diagnostic when rust engine bin env is missing", (
 
   const result = runCli(cwd, "build", env);
   assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /source=rust-engine-bin-env/);
-  assert.match(result.stderr, /cause=TSGODOWN_RUST_ENGINE_BIN is not set/);
+  const parsed = parseJsonStdout(result.stdout) as {
+    error: { message: string };
+  };
+  assert.match(parsed.error.message, /source=rust-engine-bin-env/);
   assert.match(
-    result.stderr,
+    parsed.error.message,
+    /cause=TSGODOWN_RUST_ENGINE_BIN is not set/,
+  );
+  assert.match(
+    parsed.error.message,
     /guidance=Set TSGODOWN_RUST_ENGINE_BIN to the Rust engine executable path\./,
   );
 });
@@ -499,10 +558,13 @@ test("CLI fails with explicit diagnostic when rust engine binary cannot spawn", 
   });
 
   assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /source=rust-engine-binary-spawn/);
-  assert.match(result.stderr, /cause=Error: spawn .* ENOENT/);
+  const parsed = parseJsonStdout(result.stdout) as {
+    error: { message: string };
+  };
+  assert.match(parsed.error.message, /source=rust-engine-binary-spawn/);
+  assert.match(parsed.error.message, /cause=Error: spawn .* ENOENT/);
   assert.match(
-    result.stderr,
+    parsed.error.message,
     /guidance=Check TSGODOWN_RUST_ENGINE_BIN points to an executable binary\./,
   );
 });
@@ -525,13 +587,16 @@ test("CLI fails with explicit diagnostic when rust engine exits non-zero", () =>
   });
 
   assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /source=rust-engine-binary/);
+  const parsed = parseJsonStdout(result.stdout) as {
+    error: { message: string };
+  };
+  assert.match(parsed.error.message, /source=rust-engine-binary/);
   assert.match(
-    result.stderr,
+    parsed.error.message,
     /cause=exit=17 stderr=fatal: fixture forced non-zero exit/,
   );
   assert.match(
-    result.stderr,
+    parsed.error.message,
     /guidance=Inspect rust engine logs and JSON response contract\./,
   );
 });
@@ -635,10 +700,13 @@ test("CLI surfaces rust adapter error propagation format", () => {
   });
 
   assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /source=rust-engine-adapter/);
-  assert.match(result.stderr, /cause=invalid build graph/);
+  const parsed = parseJsonStdout(result.stdout) as {
+    error: { message: string };
+  };
+  assert.match(parsed.error.message, /source=rust-engine-adapter/);
+  assert.match(parsed.error.message, /cause=invalid build graph/);
   assert.match(
-    result.stderr,
+    parsed.error.message,
     /guidance=Check Rust engine JSON contract and retry\./,
   );
 });
@@ -785,10 +853,16 @@ test("rust-only fixture matrix surfaces deterministic contract error path", () =
       TSGODOWN_RUST_ENGINE_BIN: rustLauncher,
     });
     assert.notEqual(result.status, 0, `${command} should fail`);
-    assert.match(result.stderr, /source=rust-engine-adapter/);
-    assert.match(result.stderr, /cause=ENOENT: missing entry src\/missing\.ts/);
+    const parsed = parseJsonStdout(result.stdout) as {
+      error: { message: string };
+    };
+    assert.match(parsed.error.message, /source=rust-engine-adapter/);
     assert.match(
-      result.stderr,
+      parsed.error.message,
+      /cause=ENOENT: missing entry src\/missing\.ts/,
+    );
+    assert.match(
+      parsed.error.message,
       /guidance=Verify tsgodown\.config\.ts entry path and file existence\./,
     );
   }

--- a/packages/cli/test/fixtures/contract-fail.json
+++ b/packages/cli/test/fixtures/contract-fail.json
@@ -1,9 +1,9 @@
 {
   "stderrIncludes": [
-    "[tsgodown] command failed:",
-    "source:",
-    "cause:",
-    "guidance:",
+    "source",
+    "stage",
+    "cause",
+    "guidance",
     "tsgodown.config.ts"
   ]
 }

--- a/packages/pipeline/src/internal/result-normalization.ts
+++ b/packages/pipeline/src/internal/result-normalization.ts
@@ -2,6 +2,13 @@ import type { UserConfig } from "@tsgodown/config";
 
 const DEFAULT_ENTRY = "src/index.ts";
 
+export interface PipelineFailureDetails {
+  source: string;
+  stage: string;
+  cause: string;
+  guidance: string;
+}
+
 export function resolveEntry(config: UserConfig): string {
   return typeof config.entry === "string" ? config.entry : DEFAULT_ENTRY;
 }
@@ -10,15 +17,60 @@ export function normalizePipelineCause(cause: unknown): string {
   return cause instanceof Error ? cause.message : String(cause);
 }
 
-export function formatPipelineFailure(entry: string, cause: unknown): Error {
-  const message =
-    normalizePipelineCause(cause).trim() || "unknown pipeline failure";
+export function formatPipelineFailure(
+  entry: string,
+  detailsOrCause: PipelineFailureDetails | unknown,
+): Error {
+  const details = normalizePipelineFailureDetails(entry, detailsOrCause);
   return new Error(
     [
       `[pipeline] failed for entry \"${entry}\"`,
-      `source: pipeline-entry(${entry})`,
-      `cause: ${message}`,
-      "guidance: Verify rust engine build/analyze contract and tsgodown.config.ts settings.",
+      `source: ${details.source}`,
+      `stage: ${details.stage}`,
+      `cause: ${details.cause}`,
+      `guidance: ${details.guidance}`,
     ].join("; "),
+  );
+}
+
+function normalizePipelineFailureDetails(
+  entry: string,
+  detailsOrCause: PipelineFailureDetails | unknown,
+): PipelineFailureDetails {
+  if (isPipelineFailureDetails(detailsOrCause)) {
+    return {
+      source: detailsOrCause.source.trim() || `pipeline-entry(${entry})`,
+      stage: detailsOrCause.stage.trim() || "UNKNOWN",
+      cause: detailsOrCause.cause.trim() || "unknown pipeline failure",
+      guidance:
+        detailsOrCause.guidance.trim() ||
+        "Verify rust engine build/analyze contract and tsgodown.config.ts settings.",
+    };
+  }
+
+  const message =
+    normalizePipelineCause(detailsOrCause).trim() || "unknown pipeline failure";
+  return {
+    source: `pipeline-entry(${entry})`,
+    stage: "UNKNOWN",
+    cause: message,
+    guidance:
+      "Verify rust engine build/analyze contract and tsgodown.config.ts settings.",
+  };
+}
+
+function isPipelineFailureDetails(
+  value: unknown,
+): value is PipelineFailureDetails {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const candidate = value as Partial<PipelineFailureDetails>;
+  return (
+    typeof candidate.source === "string" &&
+    typeof candidate.stage === "string" &&
+    typeof candidate.cause === "string" &&
+    typeof candidate.guidance === "string"
   );
 }

--- a/packages/pipeline/src/internal/stage-orchestration.ts
+++ b/packages/pipeline/src/internal/stage-orchestration.ts
@@ -17,22 +17,36 @@ export async function orchestratePipelineStages({
 }: StageOrchestrationOptions): Promise<void> {
   for (const config of configs) {
     const entry = resolveEntry(config);
+    let stage = "BUILD_ARTIFACTS";
 
     try {
       log("[BUILD_ARTIFACTS] collecting build outputs");
       const buildResult = await runBuildArtifactsViaRustAdapter(cwd);
       assertBuildArtifactContract(buildResult);
 
+      stage = "BUILD_IR";
       log(
         `[BUILD_IR] analyzing entry: ${entry} (delegated to rust engine, buildId=${buildResult.manifest.buildId})`,
       );
+
+      stage = "CAPABILITY_GATE";
       log(
         "[CAPABILITY_GATE] validating required capabilities (delegated to rust engine)",
       );
+
+      stage = "EMIT_GO";
       log("[EMIT_GO] writing Go scaffold (delegated to rust engine)");
+
+      stage = "ON_SUCCESS";
       await config.onSuccess?.();
     } catch (cause) {
-      throw formatPipelineFailure(entry, cause);
+      throw formatPipelineFailure(entry, {
+        source: `pipeline-entry(${entry})`,
+        stage,
+        cause: cause instanceof Error ? cause.message : String(cause),
+        guidance:
+          "Verify rust engine build/analyze contract and tsgodown.config.ts settings.",
+      });
     }
   }
 }

--- a/packages/pipeline/test/result-normalization.test.ts
+++ b/packages/pipeline/test/result-normalization.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { formatPipelineFailure } from "../src/internal/result-normalization.ts";
+
+test("formatPipelineFailure keeps source/stage/cause/guidance contract", () => {
+  const error = formatPipelineFailure("src/missing.ts", {
+    source: "pipeline-entry(src/missing.ts)",
+    stage: "BUILD_ARTIFACTS",
+    cause:
+      "source=rust-engine-adapter; cause=ENOENT: missing entry src/missing.ts; guidance=Verify tsgodown.config.ts entry path and file existence.",
+    guidance:
+      "Verify rust engine build/analyze contract and tsgodown.config.ts settings.",
+  });
+
+  assert.match(
+    error.message,
+    /\[pipeline\] failed for entry "src\/missing\.ts"/,
+  );
+  assert.match(error.message, /source: pipeline-entry\(src\/missing\.ts\)/);
+  assert.match(error.message, /stage: BUILD_ARTIFACTS/);
+  assert.match(error.message, /cause: source=rust-engine-adapter/);
+  assert.match(
+    error.message,
+    /guidance: Verify rust engine build\/analyze contract and tsgodown\.config\.ts settings\./,
+  );
+});


### PR DESCRIPTION
## Summary
- polish pipeline failure reporting for stage-wise debugging while keeping backward-compatible message contracts
- align CLI error surfacing between human output and `--json` output
- preserve existing success-path output contracts for build/check/report/stages

## What changed
### `packages/pipeline`
- added structured pipeline failure details (`source`, `stage`, `cause`, `guidance`) in failure formatting utility
- kept existing semicolon-delimited failure message contract and added `stage:` field for better stage-wise debugging
- updated stage orchestration to track current stage and include it in thrown pipeline failures
- added regression test to lock source/stage/cause/guidance failure contract

### `packages/cli`
- added error output helper to parse semicolon-delimited diagnostics from pipeline failures
- non-json path now prints structured human diagnostics (`source`, `stage`, `cause`, `guidance`) while preserving `[tsgodown] command failed: ...`
- `--json` path now emits structured failure JSON:
  - `ok: false`
  - `error.message`
  - `error.source`
  - `error.stage`
  - `error.cause`
  - `error.guidance`
- updated CLI e2e failure tests to assert JSON failure payload consistency

## Backward compatibility notes
- existing semicolon-delimited error text remains compatible
- success JSON contract for commands remains unchanged
- additional `stage` metadata is additive on failure path

## Validation
Executed full required local CI sequence in exact order:
1. `pnpm run lint` ✅
2. `pnpm run format:check` ✅
3. `pnpm run build` ✅
4. `pnpm run test` ✅
5. `cargo fmt --all --check` ✅
6. `cargo clippy --workspace --all-targets -- -D warnings` ✅
7. `cargo test --workspace --all-targets` ✅
