### PR TITLE
test(emitter-go): lock representative outputs with golden fixtures

### DIFF
--- a/packages/emitter-go/test/emit-go.test.ts
+++ b/packages/emitter-go/test/emit-go.test.ts
@@ -24,36 +24,26 @@ function createOutDir() {
   return dir;
 }
 
-const sampleIr: ProgramIR = {
-  modules: [],
-  handlers: [
-    {
-      id: "health",
-      params: [
-        { name: "req", role: "request" },
-        { name: "reply", role: "response" },
-      ],
-      async: false,
-      semantics: { responseMode: "response-object" },
-    },
-    {
-      id: "createUser",
-      params: [{ name: "req", role: "request" }],
-      async: true,
-      semantics: { responseMode: "return" },
-    },
-  ],
-  diagnostics: [],
-  routes: [
-    {
-      method: "GET",
-      path: "/health",
-      handlerRef: "health",
-      middlewareRefs: ["auth"],
-    },
-    { method: "POST", path: "/users/:id", handlerRef: "createUser" },
-  ],
-};
+const fixturesDir = path.join(import.meta.dirname, "fixtures");
+
+function readFixture(name: string): ProgramIR {
+  return JSON.parse(
+    fs.readFileSync(path.join(fixturesDir, `${name}.fixture.json`), "utf8"),
+  ) as ProgramIR;
+}
+
+function readGolden(name: string): string {
+  return fs.readFileSync(path.join(fixturesDir, `${name}.golden.go`), "utf8");
+}
+
+const representativeFixtureNames = [
+  "sample-ir",
+  "nested-restish-route",
+  "empty-method-fallback-and-diagnostics",
+  "go-unsafe-path-params",
+] as const;
+
+const sampleIr = readFixture("sample-ir");
 
 test("emitGoProject emits deterministic main.go scaffold with method-aware route registration and actionable TODO stubs", () => {
   const outDir = createOutDir();
@@ -112,6 +102,22 @@ test("emitGoProject output is byte-for-byte stable across repeated runs", () => 
   const second = fs.readFileSync(path.join(secondOutDir, "main.go"), "utf8");
 
   assert.equal(first, second);
+});
+
+test("emitGoProject representative fixtures stay locked to checked-in golden outputs", () => {
+  for (const fixtureName of representativeFixtureNames) {
+    const outDir = createOutDir();
+    emitGoProject(readFixture(fixtureName), outDir);
+
+    const emitted = fs.readFileSync(path.join(outDir, "main.go"), "utf8");
+    const golden = readGolden(fixtureName);
+
+    assert.equal(
+      emitted,
+      golden,
+      `fixture ${fixtureName} drifted from golden output; if intentional, refresh ${fixtureName}.golden.go`,
+    );
+  }
 });
 
 test("emitGoProject normalizes route methods and extracts both colon and braces path params", () => {
@@ -273,68 +279,8 @@ test(
   "emitGoProject smoke: generated representative fixtures can go build",
   { skip: !runGoSmoke },
   () => {
-    const fixtures: Array<{ name: string; ir: ProgramIR }> = [
-      {
-        name: "sample-ir",
-        ir: sampleIr,
-      },
-      {
-        name: "nested-restish-route",
-        ir: {
-          modules: [],
-          handlers: [{ id: "nested", params: [], async: false }],
-          diagnostics: [],
-          routes: [
-            {
-              method: "PATCH",
-              path: "/api/v2/users/:id/devices/{deviceId}",
-              handlerRef: "nested",
-            },
-          ],
-        },
-      },
-      {
-        name: "empty-method-fallback-and-diagnostics",
-        ir: {
-          modules: [],
-          handlers: [{ id: "fallback", params: [], async: false }],
-          diagnostics: [
-            {
-              level: "warn",
-              code: "UNSUPPORTED_DYNAMIC_PATH",
-              message:
-                "unsupported dynamic path in fastify.get(...). Use string literal path (e.g. '/users/:id') for IR extraction.",
-              source: { file: "src/server.ts", line: 9, column: 2 },
-            },
-          ],
-          routes: [
-            {
-              method: "   " as ProgramIR["routes"][number]["method"],
-              path: "/health",
-              handlerRef: "fallback",
-            },
-          ],
-        },
-      },
-      {
-        name: "go-unsafe-path-params",
-        ir: {
-          modules: [],
-          handlers: [{ id: "keywordParams", params: [], async: false }],
-          diagnostics: [],
-          routes: [
-            {
-              method: "GET",
-              path: "/things/:type/:req/:w/:pathParamType",
-              handlerRef: "keywordParams",
-            },
-          ],
-        },
-      },
-    ];
-
-    for (const fixture of fixtures) {
-      assertBuildsWithGoToolchain(fixture.ir, fixture.name);
+    for (const fixtureName of representativeFixtureNames) {
+      assertBuildsWithGoToolchain(readFixture(fixtureName), fixtureName);
     }
   },
 );

--- a/packages/emitter-go/test/fixtures/empty-method-fallback-and-diagnostics.fixture.json
+++ b/packages/emitter-go/test/fixtures/empty-method-fallback-and-diagnostics.fixture.json
@@ -1,0 +1,19 @@
+{
+  "modules": [],
+  "handlers": [{ "id": "fallback", "params": [], "async": false }],
+  "diagnostics": [
+    {
+      "level": "warn",
+      "code": "UNSUPPORTED_DYNAMIC_PATH",
+      "message": "unsupported dynamic path in fastify.get(...). Use string literal path (e.g. '/users/:id') for IR extraction.",
+      "source": { "file": "src/server.ts", "line": 9, "column": 2 }
+    }
+  ],
+  "routes": [
+    {
+      "method": "   ",
+      "path": "/health",
+      "handlerRef": "fallback"
+    }
+  ]
+}

--- a/packages/emitter-go/test/fixtures/empty-method-fallback-and-diagnostics.golden.go
+++ b/packages/emitter-go/test/fixtures/empty-method-fallback-and-diagnostics.golden.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// IR diagnostics carried from rust analyzer (SSoT):
+// Generated Go may be scaffold-only until these diagnostics are resolved.
+// [warn] UNSUPPORTED_DYNAMIC_PATH: unsupported dynamic path in fastify.get(...). Use string literal path (e.g. '/users/:id') for IR extraction.
+//   at src/server.ts:9:2
+// Action: fix diagnostics in source and regenerate. Emitter does not own policy decisions.
+
+func registerRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("GET /health", route0)
+}
+
+func resolveListenAddr() string {
+	if addr := strings.TrimSpace(os.Getenv("TSGODOWN_ADDR")); addr != "" {
+		return addr
+	}
+	if port := strings.TrimSpace(os.Getenv("PORT")); port != "" {
+		if strings.Contains(port, ":") {
+			return port
+		}
+		return ":" + port
+	}
+	return ":18081"
+}
+
+func main() {
+	mux := http.NewServeMux()
+	registerRoutes(mux)
+	addr := resolveListenAddr()
+	fmt.Println("tsgodown scaffold listening on", addr)
+	server := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		fmt.Println("server exited:", err)
+	}
+}
+
+func route0(w http.ResponseWriter, req *http.Request) {
+	// Route metadata:
+	//   Method: GET
+	//   Path: "/health"
+	//   Pattern: "GET /health"
+	//   Handler: "fallback"
+	//   Handler params: none
+	//   Handler async: false
+	//   Handler response mode: unknown
+	// TODO(tsgodown): Implement handler "fallback" for GET /health.
+	//   - Replace this scaffold with application logic.
+	//   - Validate request input and map to domain arguments.
+	//   - Write response status, headers, and body.
+
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.WriteHeader(http.StatusNotImplemented)
+	fmt.Fprintln(w, "TODO implement handler fallback for GET /health")
+}

--- a/packages/emitter-go/test/fixtures/go-unsafe-path-params.fixture.json
+++ b/packages/emitter-go/test/fixtures/go-unsafe-path-params.fixture.json
@@ -1,0 +1,12 @@
+{
+  "modules": [],
+  "handlers": [{ "id": "keywordParams", "params": [], "async": false }],
+  "diagnostics": [],
+  "routes": [
+    {
+      "method": "GET",
+      "path": "/things/:type/:req/:w/:pathParamType",
+      "handlerRef": "keywordParams"
+    }
+  ]
+}

--- a/packages/emitter-go/test/fixtures/go-unsafe-path-params.golden.go
+++ b/packages/emitter-go/test/fixtures/go-unsafe-path-params.golden.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+func registerRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("GET /things/{type}/{req}/{w}/{pathParamType}", route0)
+}
+
+func resolveListenAddr() string {
+	if addr := strings.TrimSpace(os.Getenv("TSGODOWN_ADDR")); addr != "" {
+		return addr
+	}
+	if port := strings.TrimSpace(os.Getenv("PORT")); port != "" {
+		if strings.Contains(port, ":") {
+			return port
+		}
+		return ":" + port
+	}
+	return ":18081"
+}
+
+func main() {
+	mux := http.NewServeMux()
+	registerRoutes(mux)
+	addr := resolveListenAddr()
+	fmt.Println("tsgodown scaffold listening on", addr)
+	server := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		fmt.Println("server exited:", err)
+	}
+}
+
+func route0(w http.ResponseWriter, req *http.Request) {
+	// Route metadata:
+	//   Method: GET
+	//   Path: "/things/:type/:req/:w/:pathParamType"
+	//   Pattern: "GET /things/{type}/{req}/{w}/{pathParamType}"
+	//   Handler: "keywordParams"
+	//   Handler params: none
+	//   Handler async: false
+	//   Handler response mode: unknown
+	// TODO(tsgodown): Implement handler "keywordParams" for GET /things/:type/:req/:w/:pathParamType.
+	//   - Replace this scaffold with application logic.
+	//   - Validate request input and map to domain arguments.
+	//   - Write response status, headers, and body.
+
+	// Extracted path params:
+	pathParamType := req.PathValue("type")
+	_ = pathParamType
+	pathParamReq := req.PathValue("req")
+	_ = pathParamReq
+	pathParamW := req.PathValue("w")
+	_ = pathParamW
+	pathParamType2 := req.PathValue("pathParamType")
+	_ = pathParamType2
+
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.WriteHeader(http.StatusNotImplemented)
+	fmt.Fprintln(w, "TODO implement handler keywordParams for GET /things/:type/:req/:w/:pathParamType")
+}

--- a/packages/emitter-go/test/fixtures/nested-restish-route.fixture.json
+++ b/packages/emitter-go/test/fixtures/nested-restish-route.fixture.json
@@ -1,0 +1,12 @@
+{
+  "modules": [],
+  "handlers": [{ "id": "nested", "params": [], "async": false }],
+  "diagnostics": [],
+  "routes": [
+    {
+      "method": "PATCH",
+      "path": "/api/v2/users/:id/devices/{deviceId}",
+      "handlerRef": "nested"
+    }
+  ]
+}

--- a/packages/emitter-go/test/fixtures/nested-restish-route.golden.go
+++ b/packages/emitter-go/test/fixtures/nested-restish-route.golden.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+func registerRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("PATCH /api/v2/users/{id}/devices/{deviceId}", route0)
+}
+
+func resolveListenAddr() string {
+	if addr := strings.TrimSpace(os.Getenv("TSGODOWN_ADDR")); addr != "" {
+		return addr
+	}
+	if port := strings.TrimSpace(os.Getenv("PORT")); port != "" {
+		if strings.Contains(port, ":") {
+			return port
+		}
+		return ":" + port
+	}
+	return ":18081"
+}
+
+func main() {
+	mux := http.NewServeMux()
+	registerRoutes(mux)
+	addr := resolveListenAddr()
+	fmt.Println("tsgodown scaffold listening on", addr)
+	server := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		fmt.Println("server exited:", err)
+	}
+}
+
+func route0(w http.ResponseWriter, req *http.Request) {
+	// Route metadata:
+	//   Method: PATCH
+	//   Path: "/api/v2/users/:id/devices/{deviceId}"
+	//   Pattern: "PATCH /api/v2/users/{id}/devices/{deviceId}"
+	//   Handler: "nested"
+	//   Handler params: none
+	//   Handler async: false
+	//   Handler response mode: unknown
+	// TODO(tsgodown): Implement handler "nested" for PATCH /api/v2/users/:id/devices/{deviceId}.
+	//   - Replace this scaffold with application logic.
+	//   - Validate request input and map to domain arguments.
+	//   - Write response status, headers, and body.
+
+	// Extracted path params:
+	id := req.PathValue("id")
+	_ = id
+	deviceId := req.PathValue("deviceId")
+	_ = deviceId
+
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.WriteHeader(http.StatusNotImplemented)
+	fmt.Fprintln(w, "TODO implement handler nested for PATCH /api/v2/users/:id/devices/{deviceId}")
+}

--- a/packages/emitter-go/test/fixtures/sample-ir.fixture.json
+++ b/packages/emitter-go/test/fixtures/sample-ir.fixture.json
@@ -1,0 +1,34 @@
+{
+  "modules": [],
+  "handlers": [
+    {
+      "id": "health",
+      "params": [
+        { "name": "req", "role": "request" },
+        { "name": "reply", "role": "response" }
+      ],
+      "async": false,
+      "semantics": { "responseMode": "response-object" }
+    },
+    {
+      "id": "createUser",
+      "params": [{ "name": "req", "role": "request" }],
+      "async": true,
+      "semantics": { "responseMode": "return" }
+    }
+  ],
+  "diagnostics": [],
+  "routes": [
+    {
+      "method": "GET",
+      "path": "/health",
+      "handlerRef": "health",
+      "middlewareRefs": ["auth"]
+    },
+    {
+      "method": "POST",
+      "path": "/users/:id",
+      "handlerRef": "createUser"
+    }
+  ]
+}

--- a/packages/emitter-go/test/fixtures/sample-ir.golden.go
+++ b/packages/emitter-go/test/fixtures/sample-ir.golden.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+func registerRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("GET /health", route0)
+	mux.HandleFunc("POST /users/{id}", route1)
+}
+
+func resolveListenAddr() string {
+	if addr := strings.TrimSpace(os.Getenv("TSGODOWN_ADDR")); addr != "" {
+		return addr
+	}
+	if port := strings.TrimSpace(os.Getenv("PORT")); port != "" {
+		if strings.Contains(port, ":") {
+			return port
+		}
+		return ":" + port
+	}
+	return ":18081"
+}
+
+func main() {
+	mux := http.NewServeMux()
+	registerRoutes(mux)
+	addr := resolveListenAddr()
+	fmt.Println("tsgodown scaffold listening on", addr)
+	server := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		fmt.Println("server exited:", err)
+	}
+}
+
+func route0(w http.ResponseWriter, req *http.Request) {
+	// Route metadata:
+	//   Method: GET
+	//   Path: "/health"
+	//   Pattern: "GET /health"
+	//   Handler: "health"
+	//   Handler params: request:req, response:reply
+	//   Handler async: false
+	//   Handler response mode: response-object
+	//   Middleware: ["auth"]
+	// TODO(tsgodown): Implement handler "health" for GET /health.
+	//   - Replace this scaffold with application logic.
+	//   - Validate request input and map to domain arguments.
+	//   - Write response status, headers, and body.
+
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.WriteHeader(http.StatusNotImplemented)
+	fmt.Fprintln(w, "TODO implement handler health for GET /health")
+}
+
+func route1(w http.ResponseWriter, req *http.Request) {
+	// Route metadata:
+	//   Method: POST
+	//   Path: "/users/:id"
+	//   Pattern: "POST /users/{id}"
+	//   Handler: "createUser"
+	//   Handler params: request:req
+	//   Handler async: true
+	//   Handler response mode: return
+	// TODO(tsgodown): Implement handler "createUser" for POST /users/:id.
+	//   - Replace this scaffold with application logic.
+	//   - Validate request input and map to domain arguments.
+	//   - Write response status, headers, and body.
+
+	// Extracted path params:
+	id := req.PathValue("id")
+	_ = id
+
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.WriteHeader(http.StatusNotImplemented)
+	fmt.Fprintln(w, "TODO implement handler createUser for POST /users/:id")
+}


### PR DESCRIPTION
## Summary
- add representative emitter-go IR fixtures under `packages/emitter-go/test/fixtures`
- add checked-in `*.golden.go` outputs generated from current emitter-go rendering
- add a deterministic golden lock test that compares emitted `main.go` byte-for-byte against fixture goldens
- refactor existing smoke fixture list to reuse the checked-in fixture JSON files

## Why
Milestone 1 Round 5 closing requires deterministic output guards for representative emitter-go paths. These fixture+golden comparisons catch accidental output drift early and make intentional emitter changes explicit.

## Scope
- `packages/emitter-go/test/emit-go.test.ts`
- `packages/emitter-go/test/fixtures/*`

## Verification (required order)
1. `pnpm run lint` ✅
2. `pnpm run format:check` ✅
3. `pnpm run build` ✅
4. `pnpm run test` ✅
5. `cargo fmt --all --check` ✅
6. `cargo clippy --workspace --all-targets -- -D warnings` ✅
7. `cargo test --workspace --all-targets` ✅
