### PR TITLE
docs(spec): sync analyzer-rust support boundaries and diagnostic mapping

### DIFF
--- a/docs/specs/IR_SPEC.md
+++ b/docs/specs/IR_SPEC.md
@@ -72,6 +72,44 @@ interface DiagnosticIR {
 }
 ```
 
+## analyzer-rust Fastify boundary (M1)
+`packages/analyzer-rust`는 M1에서 **extract/diagnose only** 범위를 유지한다.
+
+### Supported boundary (현재 추출 보장 범위)
+- Shorthand route: `fastify.<method>('literal-path', namedHandler)`
+  - method: `GET|POST|PUT|DELETE|PATCH`
+  - path: 문자열 리터럴
+  - handler: 식별자 기반 named reference
+- Route object: `fastify.route({ method, url|path, handler })`
+  - object: inline object literal
+  - method: 문자열 + `GET|POST|PUT|DELETE|PATCH`
+  - `url` 또는 `path`: 문자열 리터럴
+  - `handler`: named reference
+- Register/plugin:
+  - inline plugin callback 또는 same-file named plugin reference
+  - `register(..., { prefix: '/v1' })` prefix 누적 반영
+
+### Unsupported boundary → DiagnosticIR.code mapping
+- `DYNAMIC_IMPORT_DETECTED`
+  - trigger: `import(...)` 동적 import 사용
+- `ANALYZER_UNRESOLVED_PLUGIN`
+  - trigger: `register(pluginRef, ...)`에서 same-file plugin 정의를 해석하지 못함
+- `ANALYZER_UNSUPPORTED_REGISTER_CALLBACK`
+  - trigger: inline callback/same-file named reference가 아닌 register callback 패턴
+- `ANALYZER_UNSUPPORTED_DYNAMIC_PATH`
+  - trigger: route path(`url`/`path` 포함)가 문자열 리터럴이 아님
+- `ANALYZER_UNSUPPORTED_INLINE_HANDLER`
+  - trigger: handler가 named reference가 아님(예: inline function)
+- `ANALYZER_UNSUPPORTED_ROUTE_OBJECT_SHAPE`
+  - trigger: `fastify.route(...)`가 inline object literal 형태가 아님
+- `ANALYZER_UNSUPPORTED_ROUTE_OBJECT_METHOD`
+  - trigger: route object의 `method` 누락/비문자열/allowlist 외 값
+
+### SSoT boundary
+- analyzer-rust는 capability/policy 판정을 수행하지 않는다.
+- `CAPABILITY_*` 계열 코드는 analyzer-rust에서 emit하지 않는다.
+- 관련 계약은 `packages/analyzer-rust/tests/contract_parity_regression.rs`에서 고정한다.
+
 ## Data sources
 - tsdown 산출물(JS bundle)
 - source map

--- a/docs/specs/TESTING_STRATEGY.md
+++ b/docs/specs/TESTING_STRATEGY.md
@@ -22,6 +22,13 @@
 ## M1 acceptance scenario (Fastify -> Go compile success path)
 M1 수용 기준은 아래 단일 성공 경로를 명확히 고정한다.
 
+## analyzer-rust boundary contract (M1)
+- `packages/analyzer-rust/tests/contract_parity_regression.rs`를 analyzer-rust SSoT 계약 고정 테스트로 유지한다.
+- 지원 경계(supported extraction shape)와 비지원 경계(unsupported shape)는 fixture 기반으로 고정한다.
+- 비지원 경계는 **DiagnosticIR.code 매핑까지 포함해** 회귀 방지한다.
+  - 예: `ANALYZER_UNSUPPORTED_DYNAMIC_PATH`, `ANALYZER_UNSUPPORTED_INLINE_HANDLER`, `ANALYZER_UNSUPPORTED_ROUTE_OBJECT_METHOD` 등
+- analyzer-rust는 capability policy 진단(`CAPABILITY_*`)을 emit하지 않는다.
+
 1. 입력: Fastify scaffold TypeScript 엔트리(`src/index.ts`)
 2. 실행: `runPipeline` 또는 CLI `build`를 Rust adapter 경유로 실행
 3. 산출: `dist-go/main.go` 생성 확인


### PR DESCRIPTION
## Summary
Sync analyzer-rust support/unsupported boundaries into docs/specs and freeze diagnostic code mapping at spec level.

## What changed
- `docs/specs/IR_SPEC.md`
  - Added `analyzer-rust Fastify boundary (M1)` section.
  - Documented **supported extraction boundary** for shorthand/route-object/register-prefix patterns.
  - Added explicit **unsupported boundary → DiagnosticIR.code mapping**:
    - `DYNAMIC_IMPORT_DETECTED`
    - `ANALYZER_UNRESOLVED_PLUGIN`
    - `ANALYZER_UNSUPPORTED_REGISTER_CALLBACK`
    - `ANALYZER_UNSUPPORTED_DYNAMIC_PATH`
    - `ANALYZER_UNSUPPORTED_INLINE_HANDLER`
    - `ANALYZER_UNSUPPORTED_ROUTE_OBJECT_SHAPE`
    - `ANALYZER_UNSUPPORTED_ROUTE_OBJECT_METHOD`
  - Re-stated SSoT boundary: analyzer-rust is extract/diagnose-only and must not emit `CAPABILITY_*` diagnostics.

- `docs/specs/TESTING_STRATEGY.md`
  - Added analyzer-rust boundary contract section tying fixture contract parity tests to diagnostic code mapping regression prevention.

## Why
Round 4 introduced clear unsupported diagnostics in analyzer-rust implementation/tests. This PR closes the loop by syncing those support/unsupported boundaries into the canonical specs/docs, reducing drift risk between behavior and SSoT docs.

## Validation (required full local CI sequence)
1. `pnpm run lint` ✅
2. `pnpm run format:check` ✅
3. `pnpm run build` ✅
4. `pnpm run test` ✅
5. `cargo fmt --all --check` ✅
6. `cargo clippy --workspace --all-targets -- -D warnings` ✅
7. `cargo test --workspace --all-targets` ✅
