### PR TITLE
test(m1): lock single release-gate verification path

### DIFF
--- a/.pr-body-m1-r5-release-gate-v1.md
+++ b/.pr-body-m1-r5-release-gate-v1.md
@@ -1,0 +1,28 @@
+## Summary
+- lock M1 release gate to a single canonical verification path for Fastify scaffold -> Go compile success
+- add explicit gate script and package script entry for repeatable execution
+- align testing strategy docs with the canonical gate definition
+
+## Changes
+- rename CLI M1 acceptance test to canonical gate name
+- downgrade pipeline test naming to regression (non-gate path)
+- add `scripts/m1-release-gate.sh`
+- add root script `pnpm run gate:m1`
+- add `docs/specs/M1_RELEASE_GATE.md`
+- update `docs/specs/TESTING_STRATEGY.md` M1 section to reference single canonical gate
+
+## Scope guard
+- touched only tests/scripts/docs (plus package script wiring)
+- no analyzer/emitter internal logic changes
+
+## Verification
+Executed locally in required order:
+1. `pnpm run lint`
+2. `pnpm run format:check`
+3. `pnpm run build`
+4. `pnpm run test`
+5. `cargo fmt --all --check`
+6. `cargo clippy --workspace --all-targets -- -D warnings`
+7. `cargo test --workspace --all-targets`
+
+All checks passed.

--- a/docs/specs/M1_RELEASE_GATE.md
+++ b/docs/specs/M1_RELEASE_GATE.md
@@ -1,0 +1,20 @@
+# M1 Release Gate (Canonical Path)
+
+Milestone 1 is release-gated by a **single canonical verification path**:
+
+- Test name: `M1 release gate: CLI build fastify-min fixture -> dist-go/main.go -> go build (if available)`
+- Location: `packages/cli/test/commands.e2e.test.ts`
+- Runner: `pnpm run gate:m1`
+
+## What this gate verifies
+
+1. Fastify-min fixture can be built through the CLI + Rust adapter path.
+2. `dist-go/main.go` is emitted.
+3. Emitted Go scaffold shape is valid (`package main`, `func main`, health route scaffold).
+4. If the Go toolchain exists on the machine, `go build ./...` succeeds.
+
+## Why a single path
+
+- Prevents divergent M1 acceptance definitions across tests.
+- Makes release readiness checks fast and deterministic.
+- Keeps M1 sign-off criteria explicit for final push/PR verification.

--- a/docs/specs/TESTING_STRATEGY.md
+++ b/docs/specs/TESTING_STRATEGY.md
@@ -19,8 +19,22 @@
 - Integration: rust adapter contract + pipeline orchestration
 - E2E: 실제 예제 프로젝트 변환 후 CLI/build contract 검증
 
-## M1 acceptance scenario (Fastify -> Go compile success path)
-M1 수용 기준은 아래 단일 성공 경로를 명확히 고정한다.
+## M1 release gate (Fastify -> Go compile success path)
+M1 릴리스 게이트는 아래 **단일 canonical 경로**로 고정한다.
+
+- 테스트 위치: `packages/cli/test/commands.e2e.test.ts`
+- 테스트 이름: `M1 release gate: CLI build fastify-min fixture -> dist-go/main.go -> go build (if available)`
+- 실행 커맨드: `pnpm run gate:m1`
+
+검증 항목:
+1. 입력: Fastify-min fixture TypeScript 엔트리(`src/index.ts`)
+2. 실행: CLI `build`를 Rust adapter 경유로 실행
+3. 산출: `dist-go/main.go` 생성 확인
+4. assertion:
+   - Go scaffold shape (`package main`, `func main()`, `GET /health` route binding)
+   - Go toolchain 존재 시 `go build ./...` 성공
+
+주의: 게이트는 실행 경로 검증에 한정하며, `analyzer-rust`/`emitter-go` 내부 구현 세부사항은 대상에서 제외한다.
 
 ## analyzer-rust boundary contract (M1)
 - `packages/analyzer-rust/tests/contract_parity_regression.rs`를 analyzer-rust SSoT 계약 고정 테스트로 유지한다.
@@ -28,16 +42,6 @@ M1 수용 기준은 아래 단일 성공 경로를 명확히 고정한다.
 - 비지원 경계는 **DiagnosticIR.code 매핑까지 포함해** 회귀 방지한다.
   - 예: `ANALYZER_UNSUPPORTED_DYNAMIC_PATH`, `ANALYZER_UNSUPPORTED_INLINE_HANDLER`, `ANALYZER_UNSUPPORTED_ROUTE_OBJECT_METHOD` 등
 - analyzer-rust는 capability policy 진단(`CAPABILITY_*`)을 emit하지 않는다.
-
-1. 입력: Fastify scaffold TypeScript 엔트리(`src/index.ts`)
-2. 실행: `runPipeline` 또는 CLI `build`를 Rust adapter 경유로 실행
-3. 산출: `dist-go/main.go` 생성 확인
-4. 가독성 고정 assertion:
-   - Go scaffold shape (`package main`, `func main()`, `GET /health` route binding)
-   - Go toolchain 존재 시 `go mod init` + `go build ./...` 성공
-
-주의: 이 시나리오 검증은 acceptance naming/assertion clarity 범위에 한정하며,
-`analyzer-rust` / `emitter-go` 내부 구현 세부사항은 테스트 대상에서 제외한다.
 
 ## Required checks per PR/turn
 - `npm run build` (or `pnpm run build`)

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "typecheck": "pnpm run build",
     "lint": "biome lint .",
     "format:check": "biome check . --linter-enabled=false",
-    "format": "biome format --write ."
+    "format": "biome format --write .",
+    "gate:m1": "./scripts/m1-release-gate.sh"
   },
   "devDependencies": {
     "@types/node": "^24.3.0",

--- a/packages/cli/test/commands.e2e.test.ts
+++ b/packages/cli/test/commands.e2e.test.ts
@@ -807,7 +807,7 @@ test("rust-only fixture matrix keeps build/check/report/stages deterministic", (
   }
 });
 
-test("M1 acceptance: CLI build fastify-min fixture -> dist-go/main.go -> go build (if available)", () => {
+test("M1 release gate: CLI build fastify-min fixture -> dist-go/main.go -> go build (if available)", () => {
   const cwd = setupProjectFromFixture("fastify-min");
   const rustLauncher = createRealRustEngineLauncherWithGoMain(cwd);
 

--- a/packages/pipeline/test/pipeline.e2e.test.ts
+++ b/packages/pipeline/test/pipeline.e2e.test.ts
@@ -142,7 +142,7 @@ function assertGoBuildSuccessIfToolchainAvailable(goDir: string) {
   assert.equal(goBuild.status, 0, goBuild.stderr || goBuild.stdout);
 }
 
-test("M1 acceptance: runPipeline fastify scaffold TS -> dist-go/main.go -> go build (if available)", async () => {
+test("M1 regression: runPipeline fastify scaffold TS -> dist-go/main.go -> go build (if available)", async () => {
   const cwd = setupProject();
   const logs: string[] = [];
   const launcherPath = createRustLauncher(cwd);

--- a/scripts/m1-release-gate.sh
+++ b/scripts/m1-release-gate.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Canonical M1 release-gate verification path:
+# fastify scaffold fixture -> dist-go/main.go scaffold -> go build (if Go is available)
+
+pnpm --filter tsgodown exec node --import tsx --test test/commands.e2e.test.ts --test-name-pattern "^M1 release gate:"


### PR DESCRIPTION
## Summary
- lock M1 release gate to a single canonical verification path for Fastify scaffold -> Go compile success
- add explicit gate script and package script entry for repeatable execution
- align testing strategy docs with the canonical gate definition

## Changes
- rename CLI M1 acceptance test to canonical gate name
- downgrade pipeline test naming to regression (non-gate path)
- add `scripts/m1-release-gate.sh`
- add root script `pnpm run gate:m1`
- add `docs/specs/M1_RELEASE_GATE.md`
- update `docs/specs/TESTING_STRATEGY.md` M1 section to reference single canonical gate

## Scope guard
- touched only tests/scripts/docs (plus package script wiring)
- no analyzer/emitter internal logic changes

## Verification
Executed locally in required order:
1. `pnpm run lint`
2. `pnpm run format:check`
3. `pnpm run build`
4. `pnpm run test`
5. `cargo fmt --all --check`
6. `cargo clippy --workspace --all-targets -- -D warnings`
7. `cargo test --workspace --all-targets`

All checks passed.
