### PR TITLE
Milestone 1 Round 5: lock CLI human+json output snapshots

### DIFF
--- a/.pr-body-m1-r5-cli-output-snapshots-v1.md
+++ b/.pr-body-m1-r5-cli-output-snapshots-v1.md
@@ -1,0 +1,22 @@
+## Summary
+- add snapshot-style CLI output regression tests for `build` command success/failure paths
+- lock both human-readable and `--json` output shapes to fixture snapshots
+- normalize temporary cwd paths to keep snapshots deterministic across environments
+
+## Scope
+- `packages/cli/test/output-snapshots.test.ts`
+- `packages/cli/test/fixtures/snapshots/*`
+
+## Why
+- protect CLI output contracts from accidental drift
+- provide regression safety for both human-facing and machine-facing output modes
+
+## Validation
+Executed in required order and all passed:
+1. `pnpm run lint`
+2. `pnpm run format:check`
+3. `pnpm run build`
+4. `pnpm run test`
+5. `cargo fmt --all --check`
+6. `cargo clippy --workspace --all-targets -- -D warnings`
+7. `cargo test --workspace --all-targets`

--- a/packages/cli/test/fixtures/snapshots/build-failure.human.stderr.txt
+++ b/packages/cli/test/fixtures/snapshots/build-failure.human.stderr.txt
@@ -1,0 +1,5 @@
+[tsgodown] command failed: [pipeline] failed for entry "src/index.ts"; source: pipeline-entry(src/index.ts); stage: BUILD_ARTIFACTS; cause: [tsdown-driver] rust engine failed; source=rust-engine-adapter; cause=invalid build graph; guidance=Check Rust engine JSON contract and retry.; guidance: Verify rust engine build/analyze contract and tsgodown.config.ts settings.
+source: pipeline-entry(src/index.ts)
+stage: BUILD_ARTIFACTS
+cause: [tsdown-driver] rust engine failed
+guidance: Verify rust engine build/analyze contract and tsgodown.config.ts settings.

--- a/packages/cli/test/fixtures/snapshots/build-failure.human.stdout.txt
+++ b/packages/cli/test/fixtures/snapshots/build-failure.human.stdout.txt
@@ -1,0 +1,1 @@
+[BUILD_ARTIFACTS] collecting build outputs

--- a/packages/cli/test/fixtures/snapshots/build-failure.json.stdout.txt
+++ b/packages/cli/test/fixtures/snapshots/build-failure.json.stdout.txt
@@ -1,0 +1,11 @@
+[BUILD_ARTIFACTS] collecting build outputs
+{
+  "ok": false,
+  "error": {
+    "message": "[pipeline] failed for entry \"src/index.ts\"; source: pipeline-entry(src/index.ts); stage: BUILD_ARTIFACTS; cause: [tsdown-driver] rust engine failed; source=rust-engine-adapter; cause=invalid build graph; guidance=Check Rust engine JSON contract and retry.; guidance: Verify rust engine build/analyze contract and tsgodown.config.ts settings.",
+    "source": "pipeline-entry(src/index.ts)",
+    "stage": "BUILD_ARTIFACTS",
+    "cause": "[tsdown-driver] rust engine failed",
+    "guidance": "Verify rust engine build/analyze contract and tsgodown.config.ts settings."
+  }
+}

--- a/packages/cli/test/fixtures/snapshots/build-success.human.stdout.txt
+++ b/packages/cli/test/fixtures/snapshots/build-success.human.stdout.txt
@@ -1,0 +1,15 @@
+[BUILD_ARTIFACTS] collecting build outputs
+[BUILD_IR] analyzing entry: src/index.ts (delegated to rust engine, buildId=1122334455667788)
+[CAPABILITY_GATE] validating required capabilities (delegated to rust engine)
+[EMIT_GO] writing Go scaffold (delegated to rust engine)
+[tsgodown] build completed
+cwd: <CWD>
+stages: load-config -> analyze -> emit -> onSuccess
+
+- config #0
+  entry: <CWD>/src/index.ts
+  outDir: <CWD>/dist-go
+  artifact: <CWD>/artifacts/manifests/manifest.json (present)
+  routes: 0
+  warnings:
+    - DEPRECATED: TS core analyzer diagnostics are disabled after Rust cutover; use IR diagnostics from the Rust engine.

--- a/packages/cli/test/fixtures/snapshots/build-success.json.stdout.txt
+++ b/packages/cli/test/fixtures/snapshots/build-success.json.stdout.txt
@@ -1,0 +1,30 @@
+[BUILD_ARTIFACTS] collecting build outputs
+[BUILD_IR] analyzing entry: src/index.ts (delegated to rust engine, buildId=1122334455667788)
+[CAPABILITY_GATE] validating required capabilities (delegated to rust engine)
+[EMIT_GO] writing Go scaffold (delegated to rust engine)
+{
+  "ok": true,
+  "cwd": "<CWD>",
+  "command": "build",
+  "stages": [
+    "load-config",
+    "analyze",
+    "emit",
+    "onSuccess"
+  ],
+  "targets": [
+    {
+      "configIndex": 0,
+      "entry": "<CWD>/src/index.ts",
+      "outDir": "<CWD>/dist-go",
+      "artifact": "<CWD>/artifacts/manifests/manifest.json",
+      "emitted": true,
+      "diagnostics": {
+        "routes": 0,
+        "warnings": [
+          "DEPRECATED: TS core analyzer diagnostics are disabled after Rust cutover; use IR diagnostics from the Rust engine."
+        ]
+      }
+    }
+  ]
+}

--- a/packages/cli/test/output-snapshots.test.ts
+++ b/packages/cli/test/output-snapshots.test.ts
@@ -1,0 +1,157 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { after, test } from "node:test";
+
+const tempDirs: string[] = [];
+const fixturesDir = path.join(import.meta.dirname, "fixtures", "snapshots");
+const cliEntry = path.resolve(import.meta.dirname, "..", "dist", "index.js");
+
+after(() => {
+  for (const dir of tempDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function setupProject() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tsgodown-cli-snapshots-"));
+  tempDirs.push(dir);
+
+  fs.mkdirSync(path.join(dir, "src"), { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, "src", "index.ts"),
+    [
+      "const app = { get: (_path: string, _handler: () => unknown) => undefined };",
+      "app.get('/health', () => ({ ok: true }));",
+    ].join("\n"),
+  );
+  fs.writeFileSync(
+    path.join(dir, "tsgodown.config.ts"),
+    'export default { entry: "src/index.ts", outDir: "dist-go" };\n',
+  );
+
+  fs.mkdirSync(path.join(dir, "dist"), { recursive: true });
+  fs.writeFileSync(path.join(dir, "dist", "index.js"), "export {};\n");
+
+  return dir;
+}
+
+function createRustEngineLauncher(
+  cwd: string,
+  responseScript: string[],
+): string {
+  const stubPath = path.join(cwd, `rust-stub-${crypto.randomUUID()}.mjs`);
+  fs.writeFileSync(stubPath, responseScript.join("\n"));
+
+  const launcherPath = path.join(
+    cwd,
+    `rust-launcher-${crypto.randomUUID()}.sh`,
+  );
+  fs.writeFileSync(
+    launcherPath,
+    `#!/usr/bin/env bash\nexec ${JSON.stringify(process.execPath)} ${JSON.stringify(stubPath)}\n`,
+  );
+  fs.chmodSync(launcherPath, 0o755);
+  return launcherPath;
+}
+
+function runBuild(cwd: string, json: boolean, rustLauncher: string) {
+  return spawnSync(
+    process.execPath,
+    [cliEntry, "build", ...(json ? ["--json"] : [])],
+    {
+      cwd,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        TSGODOWN_RUST_ENGINE_BIN: rustLauncher,
+      },
+    },
+  );
+}
+
+function normalizeOutput(cwd: string, output: string): string {
+  const roots = [cwd];
+  try {
+    roots.push(fs.realpathSync(cwd));
+  } catch {
+    // noop
+  }
+
+  roots.sort((a, b) => b.length - a.length);
+
+  let normalized = output;
+  for (const root of roots) {
+    normalized = normalized.split(root).join("<CWD>");
+  }
+  return normalized;
+}
+
+function readFixture(name: string): string {
+  return fs.readFileSync(path.join(fixturesDir, name), "utf8");
+}
+
+test("snapshot: build success output (human + json)", () => {
+  const cwd = setupProject();
+  const rustLauncher = createRustEngineLauncher(cwd, [
+    "for await (const _ of process.stdin) { /* drain */ }",
+    "process.stdout.write(JSON.stringify({",
+    "  ok: true,",
+    "  diagnostics: ['engine=rust-binary-stub'],",
+    "  manifest: {",
+    "    buildId: '1122334455667788',",
+    "    entries: ['src/index.ts'],",
+    "    bundles: [{ file: 'dist/index.mjs', map: 'dist/index.mjs.map', format: 'esm', exports: [] }],",
+    "    types: ['dist/index.d.ts'],",
+    "    tsconfigPath: 'tsconfig.json'",
+    "  }",
+    "}));",
+  ]);
+
+  const human = runBuild(cwd, false, rustLauncher);
+  assert.equal(human.status, 0, human.stderr);
+  assert.equal(human.stderr, "");
+
+  const humanOut = normalizeOutput(cwd, human.stdout);
+  assert.equal(humanOut, readFixture("build-success.human.stdout.txt"));
+
+  const json = runBuild(cwd, true, rustLauncher);
+  assert.equal(json.status, 0, json.stderr);
+  assert.equal(json.stderr, "");
+
+  const jsonOut = normalizeOutput(cwd, json.stdout);
+  assert.equal(jsonOut, readFixture("build-success.json.stdout.txt"));
+});
+
+test("snapshot: build failure output (human + json)", () => {
+  const cwd = setupProject();
+  const rustLauncher = createRustEngineLauncher(cwd, [
+    "for await (const _ of process.stdin) { /* drain */ }",
+    "process.stdout.write(JSON.stringify({",
+    "  ok: false,",
+    "  error: {",
+    "    source: 'rust-engine-adapter',",
+    "    cause: 'invalid build graph',",
+    "    guidance: 'Check Rust engine JSON contract and retry.'",
+    "  }",
+    "}));",
+  ]);
+
+  const human = runBuild(cwd, false, rustLauncher);
+  assert.notEqual(human.status, 0, "build should fail");
+
+  const humanOut = normalizeOutput(cwd, human.stdout);
+  const humanErr = normalizeOutput(cwd, human.stderr);
+  assert.equal(humanOut, readFixture("build-failure.human.stdout.txt"));
+  assert.equal(humanErr, readFixture("build-failure.human.stderr.txt"));
+
+  const json = runBuild(cwd, true, rustLauncher);
+  assert.notEqual(json.status, 0, "build --json should fail");
+  assert.equal(json.stderr, "");
+
+  const jsonOut = normalizeOutput(cwd, json.stdout);
+  assert.equal(jsonOut, readFixture("build-failure.json.stdout.txt"));
+});


### PR DESCRIPTION
## Summary
- add snapshot-style CLI output regression tests for `build` command success/failure paths
- lock both human-readable and `--json` output shapes to fixture snapshots
- normalize temporary cwd paths to keep snapshots deterministic across environments

## Scope
- `packages/cli/test/output-snapshots.test.ts`
- `packages/cli/test/fixtures/snapshots/*`

## Why
- protect CLI output contracts from accidental drift
- provide regression safety for both human-facing and machine-facing output modes

## Validation
Executed in required order and all passed:
1. `pnpm run lint`
2. `pnpm run format:check`
3. `pnpm run build`
4. `pnpm run test`
5. `cargo fmt --all --check`
6. `cargo clippy --workspace --all-targets -- -D warnings`
7. `cargo test --workspace --all-targets`
