### PR TITLE
fix(gate): ensure m1 gate runs single release-gate test

### DIFF
--- a/scripts/m1-release-gate.sh
+++ b/scripts/m1-release-gate.sh
@@ -4,4 +4,8 @@ set -euo pipefail
 # Canonical M1 release-gate verification path:
 # fastify scaffold fixture -> dist-go/main.go scaffold -> go build (if Go is available)
 
-pnpm --filter tsgodown exec node --import tsx --test test/commands.e2e.test.ts --test-name-pattern "^M1 release gate:"
+pnpm --filter tsgodown run build
+(
+  cd packages/cli
+  node --import tsx --test-name-pattern "^M1 release gate:" --test test/commands.e2e.test.ts
+)


### PR DESCRIPTION
## Summary
- fix `gate:m1` script so it reliably executes only the M1 release-gate test
- run CLI build first, then execute node test runner with `--test-name-pattern` in the correct option order
- prevent accidental execution of unrelated CLI e2e tests

## Validation
- `pnpm run gate:m1`
