### PR TITLE
feat(analyzer-rust): support typed async/error-handling TS handler signatures (#72)

### DIFF
--- a/packages/analyzer-rust/src/defs.rs
+++ b/packages/analyzer-rust/src/defs.rs
@@ -18,7 +18,10 @@ pub(crate) struct HandlerDef {
 pub(crate) fn collect_plugin_definitions(src: &str) -> HashMap<String, PluginDef> {
     let mut map = HashMap::new();
 
-    let fn_re = Regex::new(r"function\s+([A-Za-z_$][\w$]*)\s*\(([^)]*)\)\s*\{").unwrap();
+    let fn_re = Regex::new(
+        r"(?:async\s+)?function\s+([A-Za-z_$][\w$]*)\s*\(([^)]*)\)\s*(?::\s*[^\{=;]+)?\s*\{",
+    )
+    .unwrap();
     for cap in fn_re.captures_iter(src) {
         let Some(m0) = cap.get(0) else { continue };
         let open_idx = m0.end() - 1;
@@ -42,7 +45,7 @@ pub(crate) fn collect_plugin_definitions(src: &str) -> HashMap<String, PluginDef
     }
 
     let arrow_re = Regex::new(
-        r"(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(?:async\s+)?(?:\(([^)]*)\)|([A-Za-z_$][\w$]*))\s*=>\s*\{",
+        r"(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*(?::\s*[^=]+?)?\s*=\s*(?:async\s+)?(?:\(([^)]*)\)\s*(?::\s*[^\{=;]+)?|([A-Za-z_$][\w$]*)\s*(?::\s*[^\{=;]+)?)\s*=>\s*\{",
     )
     .unwrap();
     for cap in arrow_re.captures_iter(src) {
@@ -72,7 +75,7 @@ pub(crate) fn collect_plugin_definitions(src: &str) -> HashMap<String, PluginDef
     }
 
     let var_fn_re = Regex::new(
-        r"(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(?:async\s+)?function\s*\(([^)]*)\)\s*\{",
+        r"(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*(?::\s*[^=]+?)?\s*=\s*(?:async\s+)?function\s*\(([^)]*)\)\s*(?::\s*[^\{=;]+)?\s*\{",
     )
     .unwrap();
     for cap in var_fn_re.captures_iter(src) {
@@ -103,8 +106,10 @@ pub(crate) fn collect_plugin_definitions(src: &str) -> HashMap<String, PluginDef
 pub(crate) fn collect_handler_definitions(src: &str) -> HashMap<String, HandlerDef> {
     let mut map = HashMap::new();
 
-    let fn_re =
-        Regex::new(r"(?s)(async\s+)?function\s+([A-Za-z_$][\w$]*)\s*\(([^)]*)\)\s*\{").unwrap();
+    let fn_re = Regex::new(
+        r"(?s)(async\s+)?function\s+([A-Za-z_$][\w$]*)\s*\(([^)]*)\)\s*(?::\s*[^\{=;]+)?\s*\{",
+    )
+    .unwrap();
     for cap in fn_re.captures_iter(src) {
         map.insert(
             cap[2].to_string(),
@@ -115,7 +120,10 @@ pub(crate) fn collect_handler_definitions(src: &str) -> HashMap<String, HandlerD
         );
     }
 
-    let var_fn_re = Regex::new(r"(?s)(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(async\s+)?(?:function\s*\(([^)]*)\)|\(([^)]*)\)\s*=>|([A-Za-z_$][\w$]*)\s*=>)\s*\{").unwrap();
+    let var_fn_re = Regex::new(
+        r"(?s)(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*(?::\s*[^=]+?)?\s*=\s*(async\s+)?(?:function\s*\(([^)]*)\)\s*(?::\s*[^\{=;]+)?|\(([^)]*)\)\s*(?::\s*[^\{=;]+)?=>|([A-Za-z_$][\w$]*)\s*(?::\s*[^\{=;]+)?=>)\s*\{",
+    )
+    .unwrap();
     for cap in var_fn_re.captures_iter(src) {
         let params_src = cap
             .get(3)
@@ -144,6 +152,17 @@ fn split_params(src: &str) -> Vec<String> {
     src.split(',')
         .map(|s| s.trim())
         .filter(|s| !s.is_empty())
-        .map(ToString::to_string)
+        .map(normalize_param_name)
+        .filter(|s| !s.is_empty())
         .collect()
+}
+
+fn normalize_param_name(param: &str) -> String {
+    let without_default = param.split('=').next().unwrap_or(param).trim();
+    let without_type = without_default
+        .split(':')
+        .next()
+        .unwrap_or(without_default)
+        .trim();
+    without_type.trim_start_matches("...").trim().to_string()
 }

--- a/packages/analyzer-rust/tests/fastify_ast_analyzer.rs
+++ b/packages/analyzer-rust/tests/fastify_ast_analyzer.rs
@@ -219,6 +219,53 @@ fn handles_single_param_arrow_plugins_and_handlers() {
 }
 
 #[test]
+fn extracts_typed_async_handlers_with_try_catch_error_flow() {
+    let (file, src) = fixture("typed-async-error-handling-fastify.fixture.txt");
+    let ir = analyze_fastify_entry(&file, &src);
+
+    assert_eq!(
+        ir.routes
+            .iter()
+            .map(|r| (r.method.as_str(), r.path.as_str(), r.handler_ref.as_str()))
+            .collect::<Vec<_>>(),
+        vec![
+            ("GET", "/users/:id", "getUser"),
+            ("POST", "/users", "createUser"),
+        ]
+    );
+
+    assert_eq!(
+        ir.handlers
+            .iter()
+            .map(|h| {
+                (
+                    h.id.as_str(),
+                    h.params
+                        .iter()
+                        .map(|p| (p.name.as_str(), p.role.as_str()))
+                        .collect::<Vec<_>>(),
+                    h.r#async,
+                )
+            })
+            .collect::<Vec<_>>(),
+        vec![
+            (
+                "getUser",
+                vec![("req", "request"), ("reply", "response")],
+                true,
+            ),
+            (
+                "createUser",
+                vec![("req", "request"), ("reply", "response")],
+                true,
+            ),
+        ]
+    );
+
+    assert!(ir.diagnostics.is_empty());
+}
+
+#[test]
 fn handles_chained_routes_nested_plugins_and_single_param_function_plugins() {
     let cases = vec![
         (

--- a/packages/analyzer-rust/tests/fixtures/typed-async-error-handling-fastify.fixture.txt
+++ b/packages/analyzer-rust/tests/fixtures/typed-async-error-handling-fastify.fixture.txt
@@ -1,0 +1,32 @@
+import Fastify from "fastify";
+import type { FastifyReply, FastifyRequest } from "fastify";
+
+const fastify = Fastify();
+
+type AppRequest = FastifyRequest<{ Params: { id: string } }>;
+type AppReply = FastifyReply;
+
+const getUser = async (
+  req: AppRequest,
+  reply: AppReply,
+): Promise<void> => {
+  try {
+    await reply.send({ id: req.params.id });
+  } catch (error) {
+    reply.code(500).send({ error: "internal" });
+  }
+};
+
+async function createUser(
+  req: FastifyRequest,
+  reply: FastifyReply,
+): Promise<void> {
+  try {
+    await reply.code(201).send({ ok: true });
+  } catch (_error) {
+    reply.code(500).send({ error: "internal" });
+  }
+}
+
+fastify.get("/users/:id", getUser);
+fastify.post("/users", createUser);


### PR DESCRIPTION
## Summary
- add RED test coverage for typed async Fastify handlers containing try/catch error-handling flow
- support TS function/arrow signature variants in analyzer-rust definition collection:
  - optional variable type annotations on const/let/var handlers/plugins
  - optional return type annotations before function bodies
  - async function declarations with return type annotations
- normalize collected handler param names by stripping TS type/default/rest syntax so role inference remains stable (`req`/`reply`)

## TDD (RED -> GREEN -> REFACTOR)
- RED: added `extracts_typed_async_handlers_with_try_catch_error_flow` and fixture `typed-async-error-handling-fastify.fixture.txt`; test initially failed (missing handler extraction / typed params unresolved)
- GREEN: updated regex-based handler/plugin definition extraction + param normalization
- REFACTOR: ran formatter (`cargo fmt`) and kept behavior deterministic under existing analyzer parity tests

## Test evidence
- `pnpm install --frozen-lockfile` ✅
- `pnpm run lint` ✅
- `pnpm run format:check` ✅
- `pnpm run build` ✅
- `pnpm run test` ⚠️ hangs after all visible package test cases complete; isolated package runs pass (including CLI)
- `cargo fmt --all --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo test --workspace --all-targets` ✅
- `./scripts/smoke-m1.sh` ✅

## Link
- Closes #72
