### PR TITLE
fix(test): prevent emitter-go smoke server process hang

### DIFF
--- a/packages/emitter-go/test/emit-go.test.ts
+++ b/packages/emitter-go/test/emit-go.test.ts
@@ -314,7 +314,7 @@ test(
         ...process.env,
         PORT: port,
       },
-      stdio: "pipe",
+      stdio: "ignore",
     });
 
     const url = `http://127.0.0.1:${port}/health`;


### PR DESCRIPTION
## Summary
- prevent emitter-go smoke runtime test from hanging by avoiding inherited stdio pipes on spawned go server
- keep cleanup semantics unchanged while reducing chance of lingering child process/stall

## Validation
- pnpm install --frozen-lockfile
- pnpm run lint
- pnpm run format:check
- pnpm run build
- pnpm run test
- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace --all-targets
- ./scripts/smoke-m1.sh