### PR TITLE
feat(analyzer-rust): harden IR/diagnostics contract with golden edge tests (#73)

### DIFF
--- a/packages/analyzer-rust/src/diagnostics.rs
+++ b/packages/analyzer-rust/src/diagnostics.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use crate::ir::{DiagnosticIR, DiagnosticSourceIR};
 
 pub(crate) fn diag(file: &str, code: &str, message: &str) -> DiagnosticIR {
@@ -9,4 +11,27 @@ pub(crate) fn diag(file: &str, code: &str, message: &str) -> DiagnosticIR {
             file: file.to_string(),
         }),
     }
+}
+
+pub(crate) fn dedupe_diagnostics(diagnostics: Vec<DiagnosticIR>) -> Vec<DiagnosticIR> {
+    let mut seen = HashSet::new();
+    let mut deduped = Vec::with_capacity(diagnostics.len());
+
+    for diagnostic in diagnostics {
+        let source_file = diagnostic
+            .source
+            .as_ref()
+            .map(|source| source.file.as_str())
+            .unwrap_or("");
+        let key = format!(
+            "{}\u{001F}{}\u{001F}{}\u{001F}{}",
+            diagnostic.level, diagnostic.code, diagnostic.message, source_file
+        );
+
+        if seen.insert(key) {
+            deduped.push(diagnostic);
+        }
+    }
+
+    deduped
 }

--- a/packages/analyzer-rust/src/lib.rs
+++ b/packages/analyzer-rust/src/lib.rs
@@ -12,7 +12,7 @@ pub use ir::{
 };
 
 use defs::{collect_handler_definitions, collect_plugin_definitions, detect_root_instance_name};
-use diagnostics::diag;
+use diagnostics::{dedupe_diagnostics, diag};
 use traversal::analyze_scope;
 
 pub fn analyze_fastify_entry(file: &str, src: &str) -> ProgramIR {
@@ -40,7 +40,7 @@ pub fn analyze_fastify_entry(file: &str, src: &str) -> ProgramIR {
         diagnostics.push(diag(
             file,
             "DYNAMIC_IMPORT_DETECTED",
-            "dynamic import detected",
+            "dynamic import detected; use static import declarations for deterministic IR extraction.",
         ));
     }
 
@@ -48,6 +48,6 @@ pub fn analyze_fastify_entry(file: &str, src: &str) -> ProgramIR {
         modules: vec![],
         routes,
         handlers,
-        diagnostics,
+        diagnostics: dedupe_diagnostics(diagnostics),
     }
 }

--- a/packages/analyzer-rust/tests/fixtures/duplicate-diagnostics-fastify.fixture.txt
+++ b/packages/analyzer-rust/tests/fixtures/duplicate-diagnostics-fastify.fixture.txt
@@ -1,0 +1,13 @@
+import Fastify from "fastify";
+
+const fastify = Fastify();
+const dynamicPath = "/x";
+
+fastify.get(dynamicPath, handler);
+fastify.get(dynamicPath, handler);
+fastify.post("/inline", async () => {});
+fastify.post("/inline", async () => {});
+fastify.register(externalPlugin, { prefix: "/v2" });
+fastify.register(externalPlugin, { prefix: "/v3" });
+
+function handler() {}

--- a/packages/analyzer-rust/tests/fixtures/duplicate-diagnostics-fastify.golden.txt
+++ b/packages/analyzer-rust/tests/fixtures/duplicate-diagnostics-fastify.golden.txt
@@ -1,0 +1,7 @@
+routes=[]
+handlers=[]
+diagnostics=[
+  {level=warn,code=ANALYZER_UNSUPPORTED_DYNAMIC_PATH,message=unsupported dynamic path in fastify.get(...). Use string literal path (e.g. '/users/:id') for IR extraction.,source.file=duplicate-diagnostics-fastify.fixture.txt},
+  {level=warn,code=ANALYZER_UNSUPPORTED_INLINE_HANDLER,message=unsupported non-reference handler in fastify.post('/inline', handler). Extract handler to a named function and pass its identifier.,source.file=duplicate-diagnostics-fastify.fixture.txt},
+  {level=warn,code=ANALYZER_UNRESOLVED_PLUGIN,message=register plugin 'externalPlugin' could not be resolved in current file. Ensure plugin is declared in the same file or use an inline callback.,source.file=duplicate-diagnostics-fastify.fixture.txt},
+]

--- a/packages/analyzer-rust/tests/fixtures/dynamic-import-fastify.fixture.txt
+++ b/packages/analyzer-rust/tests/fixtures/dynamic-import-fastify.fixture.txt
@@ -1,0 +1,11 @@
+import Fastify from "fastify";
+
+const fastify = Fastify();
+
+fastify.get("/users", listUsers);
+
+async function loadModule() {
+  return import("./lazy.js");
+}
+
+function listUsers() {}

--- a/packages/analyzer-rust/tests/fixtures/dynamic-import-fastify.golden.txt
+++ b/packages/analyzer-rust/tests/fixtures/dynamic-import-fastify.golden.txt
@@ -1,0 +1,5 @@
+routes=[GET /users -> listUsers]
+handlers=[listUsers(req=[];async=false;mode=unknown)]
+diagnostics=[
+  {level=warn,code=DYNAMIC_IMPORT_DETECTED,message=dynamic import detected; use static import declarations for deterministic IR extraction.,source.file=dynamic-import-fastify.fixture.txt},
+]

--- a/packages/analyzer-rust/tests/ir_diagnostics_golden.rs
+++ b/packages/analyzer-rust/tests/ir_diagnostics_golden.rs
@@ -1,0 +1,94 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use analyzer_rust::analyze_fastify_entry;
+use pretty_assertions::assert_eq;
+
+fn fixture_path(name: &str) -> PathBuf {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("tests/fixtures");
+    path.push(name);
+    path
+}
+
+fn fixture(name: &str) -> (String, String) {
+    let path = fixture_path(name);
+    let src = fs::read_to_string(&path).expect("fixture must exist");
+    (path.to_string_lossy().to_string(), src)
+}
+
+fn render_contract(name: &str) -> String {
+    let (file, src) = fixture(name);
+    let ir = analyze_fastify_entry(&file, &src);
+
+    let routes = if ir.routes.is_empty() {
+        "routes=[]".to_string()
+    } else {
+        let body = ir
+            .routes
+            .iter()
+            .map(|r| format!("{} {} -> {}", r.method, r.path, r.handler_ref))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("routes=[{}]", body)
+    };
+
+    let handlers = if ir.handlers.is_empty() {
+        "handlers=[]".to_string()
+    } else {
+        let body = ir
+            .handlers
+            .iter()
+            .map(|h| {
+                format!(
+                    "{}(req={:?};async={};mode={})",
+                    h.id,
+                    h.params
+                        .iter()
+                        .map(|p| (&p.name, &p.role))
+                        .collect::<Vec<_>>(),
+                    h.r#async,
+                    h.semantics
+                        .as_ref()
+                        .map(|s| s.response_mode.as_str())
+                        .unwrap_or("<missing>"),
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("handlers=[{}]", body)
+    };
+
+    let mut out = vec![routes, handlers, "diagnostics=[".to_string()];
+    for d in &ir.diagnostics {
+        let file_name = d
+            .source
+            .as_ref()
+            .and_then(|s| Path::new(&s.file).file_name())
+            .and_then(|v| v.to_str())
+            .unwrap_or("<missing>");
+        out.push(format!(
+            "  {{level={},code={},message={},source.file={}}},",
+            d.level, d.code, d.message, file_name
+        ));
+    }
+    out.push("]".to_string());
+    out.push(String::new());
+    out.join("\n")
+}
+
+#[test]
+fn diagnostics_contract_golden_duplicate_unsupported_patterns() {
+    let actual = render_contract("duplicate-diagnostics-fastify.fixture.txt");
+    let expected = fs::read_to_string(fixture_path("duplicate-diagnostics-fastify.golden.txt"))
+        .expect("golden file must exist");
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn diagnostics_contract_golden_dynamic_import_warning() {
+    let actual = render_contract("dynamic-import-fastify.fixture.txt");
+    let expected = fs::read_to_string(fixture_path("dynamic-import-fastify.golden.txt"))
+        .expect("golden file must exist");
+    assert_eq!(actual, expected);
+}


### PR DESCRIPTION
## Summary
- Hardened analyzer IR/diagnostics contract for issue #73 by locking edge-case behavior with golden tests.
- Added failing-first contract tests (RED) for:
  - duplicate unsupported patterns producing duplicate diagnostics
  - dynamic import diagnostic message contract
- Implemented minimal GREEN fix:
  - deterministic diagnostic deduplication by `(level, code, message, source.file)` while preserving order
  - strengthened `DYNAMIC_IMPORT_DETECTED` guidance message for actionable contract text
- REFACTOR kept minimal/surgical in diagnostics module and final IR assembly path.

## Test Evidence
Full required checks executed and passed:
- `pnpm install --frozen-lockfile`
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run build`
- `pnpm run test`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --all-targets`
- `./scripts/smoke-m1.sh`

Additionally validated targeted RED->GREEN cycle:
- `cargo test -p analyzer-rust --test ir_diagnostics_golden`

## Scope / Files
- `packages/analyzer-rust/src/diagnostics.rs`
- `packages/analyzer-rust/src/lib.rs`
- `packages/analyzer-rust/tests/ir_diagnostics_golden.rs`
- `packages/analyzer-rust/tests/fixtures/duplicate-diagnostics-fastify.fixture.txt`
- `packages/analyzer-rust/tests/fixtures/duplicate-diagnostics-fastify.golden.txt`
- `packages/analyzer-rust/tests/fixtures/dynamic-import-fastify.fixture.txt`
- `packages/analyzer-rust/tests/fixtures/dynamic-import-fastify.golden.txt`

Closes #73
