### PR TITLE
docs: add observability + failure triage playbook (M3 #76)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A long-term TypeScript/JavaScript → Go compiler project built around tsdown ar
 - Testing strategy: [`docs/specs/TESTING_STRATEGY.md`](docs/specs/TESTING_STRATEGY.md)
 - M1 release gate (canonical): [`docs/specs/M1_RELEASE_GATE.md`](docs/specs/M1_RELEASE_GATE.md)
 - Release workflow/versioning policy: [`docs/specs/RELEASE_WORKFLOW.md`](docs/specs/RELEASE_WORKFLOW.md)
+- Observability / failure triage playbook: [`docs/operations/FAILURE_TRIAGE_PLAYBOOK.md`](docs/operations/FAILURE_TRIAGE_PLAYBOOK.md)
 
 ## Quick Start
 ```bash

--- a/docs/operations/FAILURE_TRIAGE_PLAYBOOK.md
+++ b/docs/operations/FAILURE_TRIAGE_PLAYBOOK.md
@@ -1,0 +1,121 @@
+# Failure Triage Playbook (Observability)
+
+This playbook standardizes how we classify failures, collect evidence, and drive deterministic fixes for local + CI runs.
+
+## Scope
+- CI workflow failures (`.github/workflows/ci.yml`)
+- Local verification failures
+- M1 smoke path failures (`./scripts/smoke-m1.sh`)
+
+## 1) Structured Failure Categories
+
+Use one primary category per incident. Add secondary tags only when needed.
+
+| Category | Signal / Symptom | Typical Root Cause | First Action |
+| --- | --- | --- | --- |
+| `ENV-TOOLCHAIN` | command not found, wrong version, setup mismatch | missing Node/pnpm/Rust/Go/curl, incompatible runtime | run preflight and verify versions/paths |
+| `JS-QUALITY` | `pnpm run lint` / `pnpm run format:check` fails | code style, formatting drift | run reported command locally and apply fixes |
+| `TS-BUILD` | `pnpm run build` fails | TS compile/type/config regression | capture first compiler error + owning package |
+| `JS-TEST` | `pnpm run test` fails | unit/integration behavior regression | rerun failing test with focused command |
+| `RUST-FMT` | `cargo fmt --all --check` fails | rustfmt drift | run `cargo fmt --all` and re-check |
+| `RUST-CLIPPY` | `cargo clippy ... -D warnings` fails | lint warning promoted to error | fix warnings, avoid allow-by-default bypass |
+| `RUST-TEST` | `cargo test --workspace --all-targets` fails | behavior/panic/contract mismatch | rerun failing crate/test with full output |
+| `SMOKE-BUILD` | smoke script fails before process starts | launcher/env/build artifact issue | inspect script diagnostics + build output |
+| `SMOKE-RUNTIME` | binary starts but `/health` check fails | runtime port/route/body mismatch or startup crash | inspect server log + `dist-go/main.go` snippet |
+| `CI-INFRA` | flaky network/cache/action runner issue | transient GitHub Actions problem | retry once, then isolate from product regressions |
+
+## 2) Triage Flow (Required)
+
+1. **Classify** into one primary category from the table.
+2. **Capture evidence** before changing code:
+   - failing command
+   - exact error excerpt (first meaningful stack/error block)
+   - environment snapshot (`node -v`, `pnpm -v`, `cargo --version`, `go version` when relevant)
+3. **Reproduce locally** with the same command used by CI.
+4. **Minimize scope** to a single package/crate/test when possible.
+5. **Fix at source** (no fallback policy bypass, no silent ignores).
+6. **Re-run full gate** (all required commands) before push.
+7. **Document** in PR description using the incident template below.
+
+### Incident Template (PR comment/body)
+
+```md
+- Category: <one of the structured categories>
+- Symptom: <what failed>
+- Reproduction: <exact command>
+- Root cause: <short technical cause>
+- Fix: <what changed>
+- Verification: <commands re-run + results>
+```
+
+## 3) Actionable Command Matrix (CI ↔ Local)
+
+Run from repo root unless specified.
+
+```bash
+pnpm install --frozen-lockfile
+pnpm run lint
+pnpm run format:check
+pnpm run build
+pnpm run test
+cargo fmt --all --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace --all-targets
+./scripts/smoke-m1.sh
+```
+
+## 4) CI Failure Debugging Guide
+
+### A. `test` job (quality/build/test/rust)
+- Identify the **first** failing step in Actions logs.
+- Reproduce only that command locally.
+- If failure is version-sensitive, compare local versions with CI (`Node 22`, stable Rust, Go 1.22.x in smoke job).
+- For Rust lint/test noise, prefer crate-level repro after first failure is found:
+  - `cargo clippy -p <crate> --all-targets -- -D warnings`
+  - `cargo test -p <crate> -- --nocapture`
+
+### B. `smoke-executable` job
+- Re-run `./scripts/smoke-m1.sh` locally.
+- Use built-in diagnostics:
+  - `.tmp-smoke-m1-server.log` tail (runtime failures)
+  - `examples/fastify-min/dist-go/main.go` head (emission sanity)
+  - printed env summary (`TSGODOWN_RUST_ENGINE_BIN`, ports, paths)
+- Confirm launcher executable:
+  - `test -x ./scripts/rust-engine-launcher.sh`
+- If port conflict is suspected locally:
+  - `SMOKE_PORT=18081 ./scripts/smoke-m1.sh`
+
+## 5) Smoke-Specific Failure Recipes
+
+### `SMOKE-BUILD`
+Symptoms: no `dist-go/main.go`, launcher not executable, CLI build step exits non-zero.
+
+Checklist:
+1. `pnpm run build`
+2. `cargo build -p engine-core`
+3. `echo "$TSGODOWN_RUST_ENGINE_BIN"` and verify executable if explicitly set.
+4. Re-run smoke script and read first failing block.
+
+### `SMOKE-RUNTIME`
+Symptoms: non-200 health code, body mismatch, server exits early.
+
+Checklist:
+1. `tail -n 120 .tmp-smoke-m1-server.log`
+2. Inspect generated Go: `sed -n '1,160p' examples/fastify-min/dist-go/main.go`
+3. Build/run manually:
+   - `cd examples/fastify-min/dist-go`
+   - `go build -o tsgodown-local .`
+   - `PORT=18080 ./tsgodown-local`
+4. Validate endpoint: `curl -i http://127.0.0.1:18080/health`
+
+## 6) Escalation Rules
+- If classified as `CI-INFRA` and reproducibility is absent locally, retry once.
+- If still failing, note as infra-suspect in PR and attach logs.
+- Do not merge with unresolved `SMOKE-*` or `RUST-*` failures.
+
+## 7) Definition of Done for Failure Closure
+- Primary category assigned
+- Root cause identified
+- Fix merged with no fallback-policy regression
+- Full command matrix passes locally
+- CI green on updated branch

--- a/docs/specs/TESTING_STRATEGY.md
+++ b/docs/specs/TESTING_STRATEGY.md
@@ -58,13 +58,17 @@ Note: the gate is limited to execution-path verification and does not cover inte
 - analyzer-rust does not emit capability policy diagnostics (`CAPABILITY_*`).
 
 ## Required checks per PR/turn
-- `npm run build` (or `pnpm run build`)
-- `npm run test` (or `pnpm run test`)
-- For Rust-related changes:
-  - `cargo fmt --all --check`
-  - `cargo clippy --workspace --all-targets -- -D warnings`
-  - `cargo test --workspace --all-targets`
+- `pnpm install --frozen-lockfile`
+- `pnpm run lint`
+- `pnpm run format:check`
+- `pnpm run build`
+- `pnpm run test`
+- `cargo fmt --all --check`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo test --workspace --all-targets`
+- `./scripts/smoke-m1.sh`
 
 ## Failure handling
 - Do not report features as complete when tests fail.
 - Report the 3-item set: failure cause / reproduction command / mitigation plan.
+- Classify and triage using [`docs/operations/FAILURE_TRIAGE_PLAYBOOK.md`](../operations/FAILURE_TRIAGE_PLAYBOOK.md).


### PR DESCRIPTION
## Summary\n- add an observability/failure-triage playbook with structured failure categories\n- define a deterministic triage flow + PR incident template\n- add actionable CI and smoke debugging recipes (including smoke build/runtime failure paths)\n- link the playbook from README documentation map\n- align TESTING_STRATEGY required checks with current CI + smoke gate and link to the playbook\n\n## Validation\n- pnpm install --frozen-lockfile\n- pnpm run lint\n- pnpm run format:check\n- pnpm run build\n- pnpm run test\n- cargo fmt --all --check\n- cargo clippy --workspace --all-targets -- -D warnings\n- cargo test --workspace --all-targets\n- ./scripts/smoke-m1.sh\n\nCloses #76