### PR TITLE
feat(m3): extend runtime executable fixture coverage and deterministic smoke assertions

### DIFF
--- a/docs/specs/TESTING_STRATEGY.md
+++ b/docs/specs/TESTING_STRATEGY.md
@@ -38,6 +38,18 @@ Verification items:
 
 Note: the gate is limited to execution-path verification and does not cover internal implementation details of `analyzer-rust` / `emitter-go`.
 
+## M3 runtime correctness/stability extension
+- Runtime executable-fixture coverage is extended beyond the M1/M2 happy-path checks.
+- Primary test location: `packages/cli/test/commands.e2e.test.ts`
+- Key acceptance tests:
+  - `M2 acceptance: TS fixture routes are reachable in generated Go runtime`
+  - `M3 acceptance: runtime method/path matrix fixture remains deterministic`
+- Deterministic assertions must include:
+  - method-aware route checks (`GET`, `POST`, `PUT`)
+  - scaffold TODO body checks for named handlers
+  - negative path behavior (`405 Method Not Allowed`, `404 page not found`)
+- `scripts/smoke-m1.sh` must validate deterministic route behavior (`/health`, `/users`, `/missing`) instead of single-endpoint liveness only.
+
 ## analyzer-rust boundary contract (M1)
 - Keep `packages/analyzer-rust/tests/contract_parity_regression.rs` as the fixed SSoT contract test for analyzer-rust.
 - Fix supported and unsupported boundaries using fixture-based tests.

--- a/packages/cli/test/commands.e2e.test.ts
+++ b/packages/cli/test/commands.e2e.test.ts
@@ -217,14 +217,27 @@ function ensureGoRuntimeModule(goDir: string) {
   initializedGoRuntimeDirs.add(goDir);
 }
 
+type GoRouteExpectation = {
+  routePath: string;
+  method?: string;
+  expectedStatus?: number;
+  expectedBodyFragment?: string;
+};
+
 async function assertGoRunRoute(
   goDir: string,
-  routePath: string,
-  expectedBodyFragment: string,
+  expectation: GoRouteExpectation,
 ) {
   if (!hasGoToolchain) {
     return;
   }
+
+  const {
+    routePath,
+    method = "GET",
+    expectedStatus = 501,
+    expectedBodyFragment,
+  } = expectation;
 
   ensureGoRuntimeModule(goDir);
 
@@ -247,6 +260,7 @@ async function assertGoRunRoute(
     while (Date.now() < deadline) {
       try {
         const response = await fetch(`http://127.0.0.1:${port}${routePath}`, {
+          method,
           signal: AbortSignal.timeout(1000),
         });
         status = response.status;
@@ -260,10 +274,13 @@ async function assertGoRunRoute(
 
     assert.equal(
       status,
-      501,
-      `server did not become ready for ${routePath}; lastError=${String(lastError)}`,
+      expectedStatus,
+      `server did not become ready for ${method} ${routePath}; lastError=${String(lastError)}`,
     );
-    assert.match(body, new RegExp(expectedBodyFragment));
+
+    if (expectedBodyFragment) {
+      assert.match(body, new RegExp(expectedBodyFragment));
+    }
   } finally {
     if (child.exitCode === null && !child.killed) {
       child.kill("SIGTERM");
@@ -889,16 +906,60 @@ test("M2 acceptance: TS fixture routes are reachable in generated Go runtime", a
   assert.equal(fs.existsSync(goPath), true);
 
   const goDir = path.dirname(goPath);
-  await assertGoRunRoute(
-    goDir,
-    "/health",
-    "TODO implement handler health for GET /health",
-  );
-  await assertGoRunRoute(
-    goDir,
-    "/users",
-    "TODO implement handler users for GET /users",
-  );
+  await assertGoRunRoute(goDir, {
+    routePath: "/health",
+    expectedBodyFragment: "TODO implement handler health for GET /health",
+  });
+  await assertGoRunRoute(goDir, {
+    routePath: "/users",
+    expectedBodyFragment: "TODO implement handler users for GET /users",
+  });
+});
+
+test("M3 acceptance: runtime method/path matrix fixture remains deterministic", async () => {
+  const cwd = setupProjectFromFixture("runtime-method-matrix");
+  const rustLauncher = resolveRustEngineLauncherScript();
+  const engineCoreBin = resolveEngineCoreBin();
+
+  const result = runCli(cwd, "build", {
+    ...process.env,
+    TSGODOWN_RUST_ENGINE_BIN: rustLauncher,
+    TSGODOWN_ENGINE_CORE_BIN: engineCoreBin,
+  });
+
+  assert.equal(result.status, 0, `build failed: ${result.stderr}`);
+
+  const goPath = path.join(cwd, "dist-go", "main.go");
+  assert.equal(fs.existsSync(goPath), true);
+
+  const goDir = path.dirname(goPath);
+  await assertGoRunRoute(goDir, {
+    routePath: "/health",
+    expectedBodyFragment: "TODO implement handler health for GET /health",
+  });
+  await assertGoRunRoute(goDir, {
+    routePath: "/users",
+    method: "POST",
+    expectedBodyFragment: "TODO implement handler createUser for POST /users",
+  });
+  await assertGoRunRoute(goDir, {
+    routePath: "/users/:id",
+    method: "PUT",
+    expectedBodyFragment:
+      "TODO implement handler updateUser for PUT /users/:id",
+  });
+
+  await assertGoRunRoute(goDir, {
+    routePath: "/users",
+    method: "GET",
+    expectedStatus: 405,
+    expectedBodyFragment: "Method Not Allowed",
+  });
+  await assertGoRunRoute(goDir, {
+    routePath: "/missing",
+    expectedStatus: 404,
+    expectedBodyFragment: "404 page not found",
+  });
 });
 
 test("rust-only fixture matrix surfaces deterministic contract error path", () => {

--- a/packages/cli/test/fixtures/projects/runtime-method-matrix/src/index.ts
+++ b/packages/cli/test/fixtures/projects/runtime-method-matrix/src/index.ts
@@ -1,0 +1,19 @@
+import Fastify from "fastify";
+
+const app = Fastify();
+
+function health() {
+  return { ok: true };
+}
+
+function createUser() {
+  return { id: "u1" };
+}
+
+function updateUser() {
+  return { ok: true };
+}
+
+app.get("/health", health);
+app.post("/users", createUser);
+app.put("/users/:id", updateUser);

--- a/packages/cli/test/fixtures/projects/runtime-method-matrix/tsgodown.config.ts
+++ b/packages/cli/test/fixtures/projects/runtime-method-matrix/tsgodown.config.ts
@@ -1,0 +1,1 @@
+export default { entry: "src/index.ts", outDir: "dist-go" };

--- a/scripts/rust-engine-launcher.mjs
+++ b/scripts/rust-engine-launcher.mjs
@@ -37,9 +37,9 @@ function renderGoMainScaffold(routes) {
     '\tfmt.Println("tsgodown-fastify-min-ready")',
     "\tmux := http.NewServeMux()",
     ...routes.flatMap((route) => [
-      `\tmux.HandleFunc("GET ${route.path}", func(w http.ResponseWriter, _ *http.Request) {`,
+      `\tmux.HandleFunc("${route.method} ${route.path}", func(w http.ResponseWriter, _ *http.Request) {`,
       "\t\tw.WriteHeader(http.StatusNotImplemented)",
-      `\t\tfmt.Fprintln(w, "TODO implement handler ${route.handler} for GET ${route.path}")`,
+      `\t\tfmt.Fprintln(w, "TODO implement handler ${route.handler} for ${route.method} ${route.path}")`,
       "\t})",
     ]),
     "\t_ = http.ListenAndServe(resolveListenAddr(), mux)",
@@ -49,22 +49,32 @@ function renderGoMainScaffold(routes) {
 }
 
 function parseRoutesFromSource(source) {
+  const supportedMethods = ["GET", "POST", "PUT", "DELETE", "PATCH"];
   const routeMatches = [
     ...source.matchAll(
-      /\b(?:fastify|app)\.get\(\s*['"`]([^'"`]+)['"`]\s*,\s*([A-Za-z_$][\w$]*)/g,
+      /\b(?:fastify|app)\.(get|post|put|delete|patch)\(\s*['"`]([^'"`]+)['"`]\s*,\s*([A-Za-z_$][\w$]*)/gi,
     ),
   ];
 
-  const routes = routeMatches.map((match) => ({
-    path: match[1],
-    handler: match[2],
-  }));
+  const routes = routeMatches
+    .map((match) => {
+      const method = (match[1] || "GET").toUpperCase();
+      if (!supportedMethods.includes(method)) {
+        return null;
+      }
+      return {
+        method,
+        path: match[2],
+        handler: match[3],
+      };
+    })
+    .filter(Boolean);
 
   if (routes.length > 0) {
     return routes;
   }
 
-  return [{ path: "/health", handler: "health" }];
+  return [{ method: "GET", path: "/health", handler: "health" }];
 }
 
 function fail(message, details) {

--- a/scripts/smoke-m1.sh
+++ b/scripts/smoke-m1.sh
@@ -6,7 +6,7 @@ EXAMPLE_DIR="${ROOT_DIR}/examples/fastify-min"
 DIST_GO_DIR="${EXAMPLE_DIR}/dist-go"
 PORT="${SMOKE_PORT:-18080}"
 HEALTH_URL="http://127.0.0.1:${PORT}/health"
-EXPECTED_BODY="${SMOKE_EXPECTED_BODY:-ok}"
+EXPECTED_HEALTH_BODY="${SMOKE_EXPECTED_HEALTH_BODY:-TODO implement handler health for GET /health}"
 SERVER_LOG="${ROOT_DIR}/.tmp-smoke-m1-server.log"
 ENGINE_LAUNCHER="${ROOT_DIR}/.tmp-smoke-m1-engine-launcher.sh"
 
@@ -104,15 +104,27 @@ const GO_MAIN = [
   "import (",
   "\t\"fmt\"",
   "\t\"net/http\"",
+  "\t\"os\"",
   ")",
   "",
   "func main() {",
-  "\tfmt.Println(\"tsgodown-fastify-min-ready\")",
-  "\thttp.HandleFunc(\"GET /health\", func(w http.ResponseWriter, _ *http.Request) {",
-  "\t\tw.WriteHeader(http.StatusOK)",
-  "\t\tfmt.Fprintln(w, \"ok\")",
+  "\tmux := http.NewServeMux()",
+  "\tmux.HandleFunc(\"GET /health\", func(w http.ResponseWriter, _ *http.Request) {",
+  "\t\tw.Header().Set(\"Content-Type\", \"text/plain; charset=utf-8\")",
+  "\t\tw.WriteHeader(http.StatusNotImplemented)",
+  "\t\tfmt.Fprintln(w, \"TODO implement handler health for GET /health\")",
   "\t})",
-  "\t_ = http.ListenAndServe(\":18080\", nil)",
+  "\tmux.HandleFunc(\"GET /users\", func(w http.ResponseWriter, _ *http.Request) {",
+  "\t\tw.Header().Set(\"Content-Type\", \"text/plain; charset=utf-8\")",
+  "\t\tw.WriteHeader(http.StatusNotImplemented)",
+  "\t\tfmt.Fprintln(w, \"TODO implement handler users for GET /users\")",
+  "\t})",
+  "\taddr := \":18080\"",
+  "\tif port := os.Getenv(\"PORT\"); port != \"\" {",
+  "\t\taddr = \":\" + port",
+  "\t}",
+  "\tfmt.Println(\"tsgodown-fastify-min-ready\")",
+  "\t_ = http.ListenAndServe(addr, mux)",
   "}",
   "",
 ].join("\n");
@@ -195,19 +207,37 @@ for _ in {1..50}; do
   sleep 0.2
 done
 
-HTTP_CODE="$(curl -sS -o /tmp/smoke-m1-health.body -w "%{http_code}" "${HEALTH_URL}")"
-BODY="$(cat /tmp/smoke-m1-health.body)"
-BODY_TRIMMED="$(printf "%s" "${BODY}" | tr -d '\r\n')"
+assert_route() {
+  local method="$1"
+  local path="$2"
+  local expected_status="$3"
+  local expected_body_fragment="$4"
+  local tmp_body
+  tmp_body="$(mktemp /tmp/smoke-m1-route.XXXXXX)"
 
-if [[ "${HTTP_CODE}" != "200" ]]; then
-  red "[smoke-m1] health check failed: expected status=200 got status=${HTTP_CODE}"
-  exit 1
-fi
+  local http_code
+  http_code="$(curl -sS -X "${method}" -o "${tmp_body}" -w "%{http_code}" "http://127.0.0.1:${PORT}${path}")"
+  local body
+  body="$(cat "${tmp_body}")"
+  local body_trimmed
+  body_trimmed="$(printf "%s" "${body}" | tr -d '\r\n')"
+  rm -f "${tmp_body}"
 
-if [[ "${BODY_TRIMMED}" != "${EXPECTED_BODY}" ]]; then
-  red "[smoke-m1] health check body mismatch: expected='${EXPECTED_BODY}' got='${BODY_TRIMMED}'"
-  exit 1
-fi
+  if [[ "${http_code}" != "${expected_status}" ]]; then
+    red "[smoke-m1] ${method} ${path} status mismatch: expected=${expected_status} got=${http_code}"
+    exit 1
+  fi
+
+  if [[ -n "${expected_body_fragment}" ]] && [[ "${body_trimmed}" != *"${expected_body_fragment}"* ]]; then
+    red "[smoke-m1] ${method} ${path} body mismatch: expected fragment='${expected_body_fragment}' got='${body_trimmed}'"
+    exit 1
+  fi
+
+  log "asserted ${method} ${path} -> ${http_code} '${body_trimmed}'"
+}
+
+assert_route "GET" "/health" "501" "${EXPECTED_HEALTH_BODY}"
+assert_route "GET" "/users" "501" "TODO implement handler users for GET /users"
+assert_route "GET" "/missing" "404" "404 page not found"
 
 green "[smoke-m1] PASS"
-log "health status=${HTTP_CODE} body='${BODY_TRIMMED}'"


### PR DESCRIPTION
## Summary
Implements M3 A4 runtime correctness/stability enhancement by extending executable fixture coverage and strengthening deterministic smoke/runtime assertions beyond the existing M1/M2 path.

### What changed
- Added new executable fixture project:
  - `packages/cli/test/fixtures/projects/runtime-method-matrix`
- Extended CLI E2E runtime assertions:
  - Added `M3 acceptance: runtime method/path matrix fixture remains deterministic`
  - Added method-aware assertions (`GET`, `POST`, `PUT`)
  - Added deterministic negative assertions (`405 Method Not Allowed`, `404 page not found`)
  - Generalized `assertGoRunRoute` helper for method/status/body assertions
- Enhanced launcher runtime scaffold correctness:
  - `scripts/rust-engine-launcher.mjs` now parses and emits method-aware route scaffolds for `get/post/put/delete/patch`
- Strengthened deterministic smoke checks:
  - `scripts/smoke-m1.sh` now validates `/health`, `/users`, and `/missing` behavior deterministically (not just single liveness)
  - Updated local fallback smoke launcher output to match deterministic scaffold expectations
- Documentation update:
  - Added M3 runtime correctness/stability extension section in `docs/specs/TESTING_STRATEGY.md`

## TDD notes
- Added failing M3 acceptance/runtime assertions first (method/path matrix + negative cases)
- Implemented minimal launcher/runtime behavior changes to satisfy tests
- Kept deterministic assertions explicit in both E2E and smoke script

## Issue mapping (M3)
- This work maps to **#76** (observability/failure-triage track) because it improves deterministic runtime failure/smoke signals and triage quality for executable fixtures.
- Issue comment attached: https://github.com/jingjing2222/tsgodown/issues/76#issuecomment-3912273210
- Refs #76

## Validation run
- `pnpm install --frozen-lockfile`
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run build`
- `pnpm run test`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --all-targets`
- `./scripts/smoke-m1.sh`
