### PR TITLE
feat: add performance baseline and regression guard scaffolding (M3 #75)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,11 @@ A long-term TypeScript/JavaScript → Go compiler project built around tsdown ar
 - Testing strategy: [`docs/specs/TESTING_STRATEGY.md`](docs/specs/TESTING_STRATEGY.md)
 - M1 release gate (canonical): [`docs/specs/M1_RELEASE_GATE.md`](docs/specs/M1_RELEASE_GATE.md)
 - Release workflow/versioning policy: [`docs/specs/RELEASE_WORKFLOW.md`](docs/specs/RELEASE_WORKFLOW.md)
+<<<<<<< HEAD
 - Observability / failure triage playbook: [`docs/operations/FAILURE_TRIAGE_PLAYBOOK.md`](docs/operations/FAILURE_TRIAGE_PLAYBOOK.md)
+=======
+- Performance baseline scaffold: [`docs/specs/PERFORMANCE_BASELINE.md`](docs/specs/PERFORMANCE_BASELINE.md)
+>>>>>>> 2acab0c (feat(m3-75): add perf baseline scenarios and regression guard scaffold)
 
 ## Quick Start
 ```bash
@@ -54,6 +58,7 @@ If setup is wrong, the launcher fails fast with actionable errors (missing execu
 - `pnpm run lint`
 - `pnpm run format:check`
 - `pnpm run test:tdd`
+- `pnpm run perf:baseline`
 
 ## M1 Local Smoke Verification (Apple Silicon / M1 path)
 Run the one-command local smoke script from repo root:

--- a/docs/perf/baseline.json
+++ b/docs/perf/baseline.json
@@ -1,0 +1,18 @@
+{
+  "schemaVersion": 1,
+  "generatedAt": "1970-01-01T00:00:00.000Z",
+  "scenarios": {
+    "cli-build-fastify-min": {
+      "medianMs": null
+    },
+    "cli-check-multi-file": {
+      "medianMs": null
+    },
+    "cli-report-route-object-variants": {
+      "medianMs": null
+    },
+    "cli-stages-nested-register-prefix": {
+      "medianMs": null
+    }
+  }
+}

--- a/docs/specs/PERFORMANCE_BASELINE.md
+++ b/docs/specs/PERFORMANCE_BASELINE.md
@@ -1,0 +1,53 @@
+# Performance Baseline & Regression Guard (M3 #75)
+
+## Goal
+Provide a repeatable baseline/perf-regression scaffold for CLI orchestration latency.
+
+## Scenarios
+Current baseline scenarios (defined in `packages/cli/src/perf-baseline.ts`):
+- `cli-build-fastify-min`
+- `cli-check-multi-file`
+- `cli-report-route-object-variants`
+- `cli-stages-nested-register-prefix`
+
+Each scenario specifies:
+- fixture project
+- command (`build`/`check`/`report`/`stages`)
+- warmup run count
+- sample run count
+- p95 threshold (ms)
+- regression tolerance (%) against baseline median
+
+## Measurement command
+From repo root:
+
+```bash
+pnpm run perf:baseline
+```
+
+Behavior:
+- runs all scenarios
+- writes report JSON to `artifacts/perf/report.json`
+- compares current median against `docs/perf/baseline.json` (if baseline median is set)
+- exits non-zero on threshold failure or regression failure
+
+## Updating baseline
+After intentional performance improvements (or accepted budget changes):
+
+```bash
+pnpm run perf:baseline -- --update-baseline
+```
+
+This rewrites `docs/perf/baseline.json` with measured medians.
+
+## Report format
+`artifacts/perf/report.json` contains:
+- run metadata (`generatedAt`, `host`, `platform`)
+- per-scenario samples and summary stats (`mean`, `median`, `p95`, `min`, `max`)
+- threshold check result
+- baseline median and regression delta (%/ms)
+- final boolean status (`ok`)
+
+## Notes
+- This is scaffolding for M3 and currently uses a deterministic Rust-engine stub to isolate CLI/pipeline orchestration overhead.
+- Once CI hardware targets and stable runtime envelopes are finalized, set concrete baseline medians in `docs/perf/baseline.json` and gate PRs on non-regression.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "lint": "biome lint .",
     "format:check": "biome check . --linter-enabled=false",
     "format": "biome format --write .",
-    "gate:m1": "./scripts/m1-release-gate.sh"
+    "gate:m1": "./scripts/m1-release-gate.sh",
+    "perf:baseline": "tsx scripts/perf-baseline.ts"
   },
   "devDependencies": {
     "@types/node": "^24.3.0",

--- a/packages/cli/src/perf-baseline.ts
+++ b/packages/cli/src/perf-baseline.ts
@@ -1,0 +1,117 @@
+export interface PerfScenario {
+  id: string;
+  fixture: string;
+  command: "build" | "check" | "report" | "stages";
+  warmupRuns: number;
+  sampleRuns: number;
+  thresholdMs: number;
+  regressionTolerancePct: number;
+}
+
+export interface PerfStats {
+  meanMs: number;
+  medianMs: number;
+  p95Ms: number;
+  minMs: number;
+  maxMs: number;
+}
+
+export interface RegressionCheck {
+  ok: boolean;
+  deltaMs: number;
+  deltaPct: number;
+}
+
+export const PERF_SCENARIOS: PerfScenario[] = [
+  {
+    id: "cli-build-fastify-min",
+    fixture: "fastify-min",
+    command: "build",
+    warmupRuns: 1,
+    sampleRuns: 5,
+    thresholdMs: 1500,
+    regressionTolerancePct: 20,
+  },
+  {
+    id: "cli-check-multi-file",
+    fixture: "multi-file",
+    command: "check",
+    warmupRuns: 1,
+    sampleRuns: 5,
+    thresholdMs: 1200,
+    regressionTolerancePct: 20,
+  },
+  {
+    id: "cli-report-route-object-variants",
+    fixture: "route-object-variants",
+    command: "report",
+    warmupRuns: 1,
+    sampleRuns: 5,
+    thresholdMs: 1200,
+    regressionTolerancePct: 20,
+  },
+  {
+    id: "cli-stages-nested-register-prefix",
+    fixture: "nested-register-prefix",
+    command: "stages",
+    warmupRuns: 1,
+    sampleRuns: 5,
+    thresholdMs: 1200,
+    regressionTolerancePct: 20,
+  },
+];
+
+export function summarizeMs(samples: number[]): PerfStats {
+  if (samples.length === 0) {
+    throw new Error("samples must not be empty");
+  }
+
+  const sorted = [...samples].sort((a, b) => a - b);
+  const meanMs =
+    samples.reduce((acc, value) => acc + value, 0) / samples.length;
+  const medianMs = percentile(sorted, 0.5);
+  const p95Ms = percentile(sorted, 0.95);
+
+  return {
+    meanMs,
+    medianMs,
+    p95Ms,
+    minMs: sorted[0],
+    maxMs: sorted[sorted.length - 1],
+  };
+}
+
+export function evaluateRegression(
+  baselineMedianMs: number,
+  currentMedianMs: number,
+  tolerancePct: number,
+): RegressionCheck {
+  if (baselineMedianMs <= 0) {
+    return { ok: true, deltaMs: 0, deltaPct: 0 };
+  }
+
+  const deltaMs = currentMedianMs - baselineMedianMs;
+  const deltaPct = (deltaMs / baselineMedianMs) * 100;
+
+  return {
+    ok: deltaPct <= tolerancePct,
+    deltaMs,
+    deltaPct,
+  };
+}
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 1) {
+    return sorted[0];
+  }
+
+  const idx = (sorted.length - 1) * p;
+  const lo = Math.floor(idx);
+  const hi = Math.ceil(idx);
+  if (lo === hi) {
+    return sorted[lo];
+  }
+
+  const weight = idx - lo;
+  return sorted[lo] * (1 - weight) + sorted[hi] * weight;
+}

--- a/packages/cli/test/perf-baseline.test.ts
+++ b/packages/cli/test/perf-baseline.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  PERF_SCENARIOS,
+  evaluateRegression,
+  summarizeMs,
+} from "../src/perf-baseline.js";
+
+test("PERF_SCENARIOS defines stable scenario scaffolding", () => {
+  assert.ok(PERF_SCENARIOS.length >= 4);
+
+  const ids = new Set(PERF_SCENARIOS.map((scenario) => scenario.id));
+  assert.equal(ids.size, PERF_SCENARIOS.length);
+
+  for (const scenario of PERF_SCENARIOS) {
+    assert.ok(scenario.thresholdMs > 0);
+    assert.ok(scenario.sampleRuns > 0);
+    assert.ok(scenario.regressionTolerancePct >= 0);
+  }
+});
+
+test("summarizeMs calculates median and p95 from run samples", () => {
+  const stats = summarizeMs([100, 110, 90, 130, 120]);
+
+  assert.equal(stats.minMs, 90);
+  assert.equal(stats.maxMs, 130);
+  assert.equal(stats.medianMs, 110);
+  assert.equal(stats.p95Ms, 128);
+  assert.equal(stats.meanMs, 110);
+});
+
+test("evaluateRegression passes within tolerance and fails above it", () => {
+  const pass = evaluateRegression(100, 119, 20);
+  assert.equal(pass.ok, true);
+  assert.equal(pass.deltaMs, 19);
+  assert.equal(pass.deltaPct, 19);
+
+  const fail = evaluateRegression(100, 125, 20);
+  assert.equal(fail.ok, false);
+  assert.equal(fail.deltaMs, 25);
+  assert.equal(fail.deltaPct, 25);
+});

--- a/scripts/perf-baseline.ts
+++ b/scripts/perf-baseline.ts
@@ -1,0 +1,227 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  PERF_SCENARIOS,
+  type PerfScenario,
+  evaluateRegression,
+  summarizeMs,
+} from "../packages/cli/src/perf-baseline.js";
+
+interface BaselineEntry {
+  medianMs: number | null;
+}
+
+interface BaselineFile {
+  schemaVersion: 1;
+  generatedAt: string;
+  scenarios: Record<string, BaselineEntry>;
+}
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const cliEntry = path.join(repoRoot, "packages", "cli", "dist", "index.js");
+const fixturesDir = path.join(
+  repoRoot,
+  "packages",
+  "cli",
+  "test",
+  "fixtures",
+  "projects",
+);
+const baselinePath = path.join(repoRoot, "docs", "perf", "baseline.json");
+const reportPath = path.join(repoRoot, "artifacts", "perf", "report.json");
+
+const updateBaseline = process.argv.includes("--update-baseline");
+
+main();
+
+function main() {
+  ensureCliBuildExists();
+
+  const launcherPath = createRustEngineLauncher();
+  const baseline = readBaseline();
+
+  const report: {
+    generatedAt: string;
+    host: string;
+    platform: string;
+    scenarios: Array<Record<string, unknown>>;
+  } = {
+    generatedAt: new Date().toISOString(),
+    host: os.hostname(),
+    platform: `${process.platform}-${process.arch}`,
+    scenarios: [],
+  };
+
+  let hasFailure = false;
+
+  for (const scenario of PERF_SCENARIOS) {
+    const samples = runScenario(scenario, launcherPath);
+    const stats = summarizeMs(samples);
+    const baselineMedian = baseline?.scenarios[scenario.id]?.medianMs ?? null;
+
+    const thresholdOk = stats.p95Ms <= scenario.thresholdMs;
+    const regression =
+      baselineMedian === null
+        ? { ok: true, deltaMs: 0, deltaPct: 0 }
+        : evaluateRegression(
+            baselineMedian,
+            stats.medianMs,
+            scenario.regressionTolerancePct,
+          );
+
+    const scenarioOk = thresholdOk && regression.ok;
+    if (!scenarioOk) {
+      hasFailure = true;
+    }
+
+    console.log(
+      [
+        `[perf] ${scenario.id}`,
+        `median=${stats.medianMs.toFixed(2)}ms`,
+        `p95=${stats.p95Ms.toFixed(2)}ms`,
+        `threshold<=${scenario.thresholdMs}ms ${thresholdOk ? "OK" : "FAIL"}`,
+        baselineMedian === null
+          ? "baseline=n/a"
+          : `delta=${regression.deltaPct.toFixed(2)}% (<=${scenario.regressionTolerancePct}% ${regression.ok ? "OK" : "FAIL"})`,
+      ].join(" | "),
+    );
+
+    report.scenarios.push({
+      id: scenario.id,
+      fixture: scenario.fixture,
+      command: scenario.command,
+      samplesMs: samples,
+      stats,
+      thresholdMs: scenario.thresholdMs,
+      thresholdOk,
+      baselineMedianMs: baselineMedian,
+      regressionTolerancePct: scenario.regressionTolerancePct,
+      regression,
+      ok: scenarioOk,
+    });
+  }
+
+  fs.mkdirSync(path.dirname(reportPath), { recursive: true });
+  fs.writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`);
+
+  if (updateBaseline) {
+    writeBaseline(report);
+    console.log(
+      `[perf] baseline updated: ${path.relative(repoRoot, baselinePath)}`,
+    );
+  }
+
+  console.log(`[perf] report written: ${path.relative(repoRoot, reportPath)}`);
+
+  if (hasFailure) {
+    process.exitCode = 1;
+  }
+}
+
+function runScenario(scenario: PerfScenario, launcherPath: string): number[] {
+  const cwd = path.join(fixturesDir, scenario.fixture);
+  const samples: number[] = [];
+
+  for (let i = 0; i < scenario.warmupRuns + scenario.sampleRuns; i++) {
+    const start = process.hrtime.bigint();
+    const result = spawnSync(
+      process.execPath,
+      [cliEntry, scenario.command, "--json"],
+      {
+        cwd,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          TSGODOWN_RUST_ENGINE_BIN: launcherPath,
+        },
+      },
+    );
+
+    if (result.status !== 0) {
+      throw new Error(
+        `[perf] scenario=${scenario.id} command failed status=${result.status}\n${result.stderr || result.stdout}`,
+      );
+    }
+
+    if (i >= scenario.warmupRuns) {
+      const elapsedMs = Number(process.hrtime.bigint() - start) / 1_000_000;
+      samples.push(elapsedMs);
+    }
+  }
+
+  return samples;
+}
+
+function ensureCliBuildExists() {
+  if (!fs.existsSync(cliEntry)) {
+    throw new Error(
+      "packages/cli/dist/index.js not found. Run `pnpm run build` first.",
+    );
+  }
+}
+
+function readBaseline(): BaselineFile | null {
+  if (!fs.existsSync(baselinePath)) {
+    return null;
+  }
+
+  return JSON.parse(fs.readFileSync(baselinePath, "utf8")) as BaselineFile;
+}
+
+function writeBaseline(report: {
+  generatedAt: string;
+  scenarios: Array<Record<string, unknown>>;
+}) {
+  const scenarios: Record<string, BaselineEntry> = {};
+
+  for (const row of report.scenarios) {
+    scenarios[String(row.id)] = {
+      medianMs: Number((row.stats as { medianMs: number }).medianMs.toFixed(2)),
+    };
+  }
+
+  const baseline: BaselineFile = {
+    schemaVersion: 1,
+    generatedAt: report.generatedAt,
+    scenarios,
+  };
+
+  fs.mkdirSync(path.dirname(baselinePath), { recursive: true });
+  fs.writeFileSync(baselinePath, `${JSON.stringify(baseline, null, 2)}\n`);
+}
+
+function createRustEngineLauncher(): string {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "tsgodown-perf-"));
+  const stubPath = path.join(tempDir, "rust-stub.mjs");
+
+  fs.writeFileSync(
+    stubPath,
+    [
+      "for await (const _ of process.stdin) { /* drain */ }",
+      "const response = {",
+      "  ok: true,",
+      "  diagnostics: ['engine=rust-binary-stub'],",
+      "  manifest: {",
+      "    buildId: '1122334455667788',",
+      "    entries: ['src/index.ts'],",
+      "    bundles: [{ file: 'dist/index.mjs', map: 'dist/index.mjs.map', format: 'esm', exports: [] }],",
+      "    types: ['dist/index.d.ts'],",
+      "    tsconfigPath: 'tsconfig.json'",
+      "  }",
+      "};",
+      "process.stdout.write(JSON.stringify(response));",
+    ].join("\n"),
+  );
+
+  const launcherPath = path.join(tempDir, "rust-launcher.sh");
+  fs.writeFileSync(
+    launcherPath,
+    `#!/usr/bin/env bash\nexec ${JSON.stringify(process.execPath)} ${JSON.stringify(stubPath)}\n`,
+  );
+  fs.chmodSync(launcherPath, 0o755);
+
+  return launcherPath;
+}


### PR DESCRIPTION
## Summary
- add performance benchmark scenario definitions for CLI orchestration paths
- add `scripts/perf-baseline.ts` to run benchmarks, emit JSON report, and enforce threshold/regression guard checks
- add baseline scaffold file at `docs/perf/baseline.json` and documentation for thresholds/reporting format
- add unit tests for perf scenario/summary/regression logic
- expose script via `pnpm run perf:baseline`

## Scenarios
- `cli-build-fastify-min`
- `cli-check-multi-file`
- `cli-report-route-object-variants`
- `cli-stages-nested-register-prefix`

## Regression guard behavior
- per-scenario p95 threshold gate
- median regression gate against baseline median with tolerance percentage
- non-zero exit when either gate fails

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run build`
- `pnpm run test`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --all-targets`
- `./scripts/smoke-m1.sh`

Closes #75
