### PR TITLE
feat(emitter-go): deterministic method-aware Go runtime routing

### DIFF
--- a/packages/emitter-go/src/index.ts
+++ b/packages/emitter-go/src/index.ts
@@ -9,6 +9,7 @@ import {
   renderResolveListenAddr,
   renderRoute,
   renderRouteRegistry,
+  renderRuntimeRouter,
 } from "./render/index";
 
 export function emitGoProject(ir: ProgramIR, outDir: string) {
@@ -18,6 +19,7 @@ export function emitGoProject(ir: ProgramIR, outDir: string) {
   lines.push("package main", "");
   lines.push(...renderGoImports());
   lines.push(...renderDiagnosticsComments(ir.diagnostics));
+  lines.push(...renderRuntimeRouter());
   lines.push(...renderRouteRegistry(ir.routes));
   lines.push(...renderResolveListenAddr());
   lines.push(...renderMainFunction());

--- a/packages/emitter-go/src/render/index.ts
+++ b/packages/emitter-go/src/render/index.ts
@@ -4,5 +4,6 @@ export {
   renderMainFunction,
   renderResolveListenAddr,
   renderRouteRegistry,
+  renderRuntimeRouter,
 } from "./server-bootstrap-rendering";
 export { renderRoute } from "./template-rendering";

--- a/packages/emitter-go/src/render/route-normalization.ts
+++ b/packages/emitter-go/src/render/route-normalization.ts
@@ -13,7 +13,7 @@ export function normalizeRoutePath(pathname: string): string {
   return trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
 }
 
-function toServeMuxPath(pathname: string): string {
+export function toServeMuxPath(pathname: string): string {
   return normalizeRoutePath(pathname).replaceAll(
     /:([A-Za-z_][A-Za-z0-9_]*)/g,
     "{$1}",

--- a/packages/emitter-go/src/render/server-bootstrap-rendering.ts
+++ b/packages/emitter-go/src/render/server-bootstrap-rendering.ts
@@ -8,6 +8,7 @@ export function renderGoImports(): string[] {
     '\t"fmt"',
     '\t"net/http"',
     '\t"os"',
+    '\t"sort"',
     '\t"strings"',
     '\t"time"',
     ")",
@@ -15,8 +16,65 @@ export function renderGoImports(): string[] {
   ];
 }
 
+export function renderRuntimeRouter(): string[] {
+  return [
+    "type runtimeRouter struct {",
+    "\tmethodMux *http.ServeMux",
+    "\tpathMux *http.ServeMux",
+    "\tmethodsByPathPattern map[string]map[string]struct{}",
+    "\tpathPatternRegistered map[string]struct{}",
+    "}",
+    "",
+    "func newRuntimeRouter() *runtimeRouter {",
+    "\treturn &runtimeRouter{",
+    "\t\tmethodMux:             http.NewServeMux(),",
+    "\t\tpathMux:               http.NewServeMux(),",
+    "\t\tmethodsByPathPattern:  map[string]map[string]struct{}{},",
+    "\t\tpathPatternRegistered: map[string]struct{}{},",
+    "\t}",
+    "}",
+    "",
+    "func (r *runtimeRouter) handle(method string, pathPattern string, handler http.HandlerFunc) {",
+    '\tr.methodMux.HandleFunc(method+" "+pathPattern, handler)',
+    "\tif _, ok := r.pathPatternRegistered[pathPattern]; !ok {",
+    "\t\tr.pathMux.HandleFunc(pathPattern, func(http.ResponseWriter, *http.Request) {})",
+    "\t\tr.pathPatternRegistered[pathPattern] = struct{}{}",
+    "\t}",
+    "\tmethodSet, ok := r.methodsByPathPattern[pathPattern]",
+    "\tif !ok {",
+    "\t\tmethodSet = map[string]struct{}{}",
+    "\t\tr.methodsByPathPattern[pathPattern] = methodSet",
+    "\t}",
+    "\tmethodSet[method] = struct{}{}",
+    "}",
+    "",
+    "func (r *runtimeRouter) ServeHTTP(w http.ResponseWriter, req *http.Request) {",
+    "\thandler, methodPattern := r.methodMux.Handler(req)",
+    '\tif methodPattern != "" {',
+    "\t\thandler.ServeHTTP(w, req)",
+    "\t\treturn",
+    "\t}",
+    "",
+    "\t_, pathPattern := r.pathMux.Handler(req)",
+    '\tif pathPattern != "" {',
+    "\t\tallow := make([]string, 0, len(r.methodsByPathPattern[pathPattern]))",
+    "\t\tfor method := range r.methodsByPathPattern[pathPattern] {",
+    "\t\t\tallow = append(allow, method)",
+    "\t\t}",
+    "\t\tsort.Strings(allow)",
+    '\t\tw.Header().Set("Allow", strings.Join(allow, ", "))',
+    "\t\thttp.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)",
+    "\t\treturn",
+    "\t}",
+    "",
+    "\thttp.NotFound(w, req)",
+    "}",
+    "",
+  ];
+}
+
 export function renderRouteRegistry(routes: RouteIR[]): string[] {
-  const lines = ["func registerRoutes(mux *http.ServeMux) {"];
+  const lines = ["func registerRoutes(router *runtimeRouter) {"];
   for (const [index, route] of routes.entries()) {
     lines.push(renderRouteRegistration(route, index));
   }
@@ -45,13 +103,13 @@ export function renderResolveListenAddr(): string[] {
 export function renderMainFunction(): string[] {
   return [
     "func main() {",
-    "\tmux := http.NewServeMux()",
-    "\tregisterRoutes(mux)",
+    "\trouter := newRuntimeRouter()",
+    "\tregisterRoutes(router)",
     "\taddr := resolveListenAddr()",
     '\tfmt.Println("tsgodown scaffold listening on", addr)',
     "\tserver := &http.Server{",
     "\t\tAddr:              addr,",
-    "\t\tHandler:           mux,",
+    "\t\tHandler:           router,",
     "\t\tReadHeaderTimeout: 5 * time.Second,",
     "\t}",
     "\tif err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {",

--- a/packages/emitter-go/src/render/template-rendering.ts
+++ b/packages/emitter-go/src/render/template-rendering.ts
@@ -4,6 +4,7 @@ import {
   extractPathParamNames,
   normalizeHttpMethod,
   normalizeRoutePath,
+  toServeMuxPath,
   toServeMuxPattern,
 } from "./route-normalization";
 
@@ -140,5 +141,5 @@ export function renderRoute(
 }
 
 export function renderRouteRegistration(route: RouteIR, index: number): string {
-  return `\tmux.HandleFunc(${quoteGo(toServeMuxPattern(route))}, ${routeHandlerName(index)})`;
+  return `\trouter.handle(${quoteGo(normalizeHttpMethod(route.method))}, ${quoteGo(toServeMuxPath(route.path))}, ${routeHandlerName(index)})`;
 }

--- a/packages/emitter-go/test/emit-go.test.ts
+++ b/packages/emitter-go/test/emit-go.test.ts
@@ -52,9 +52,18 @@ test("emitGoProject emits deterministic main.go scaffold with method-aware route
 
   const emitted = fs.readFileSync(path.join(outDir, "main.go"), "utf8");
 
-  assert.match(emitted, /func registerRoutes\(mux \*http\.ServeMux\) \{/);
-  assert.match(emitted, /mux\.HandleFunc\("GET \/health", route0\)/);
-  assert.match(emitted, /mux\.HandleFunc\("POST \/users\/\{id\}", route1\)/);
+  assert.match(emitted, /func registerRoutes\(router \*runtimeRouter\) \{/);
+  assert.match(emitted, /router\.handle\("GET", "\/health", route0\)/);
+  assert.match(emitted, /router\.handle\("POST", "\/users\/\{id\}", route1\)/);
+  assert.match(emitted, /type runtimeRouter struct \{/);
+  assert.match(
+    emitted,
+    /func \(r \*runtimeRouter\) ServeHTTP\(w http\.ResponseWriter, req \*http\.Request\) \{/,
+  );
+  assert.match(
+    emitted,
+    /w\.Header\(\)\.Set\("Allow", strings\.Join\(allow, ", "\)\)/,
+  );
   assert.doesNotMatch(emitted, /if req\.Method != http\.MethodGet \{/);
   assert.doesNotMatch(emitted, /if req\.Method != http\.MethodPost \{/);
   assert.match(emitted, /\/\/ Route metadata:/);
@@ -143,7 +152,7 @@ test("emitGoProject normalizes route methods and extracts both colon and braces 
 
   assert.match(
     emitted,
-    /mux\.HandleFunc\("GET \/users\/\{userId\}\/orders\/\{orderId\}", route0\)/,
+    /router\.handle\("GET", "\/users\/\{userId\}\/orders\/\{orderId\}", route0\)/,
   );
   assert.match(emitted, /userId := req\.PathValue\("userId"\)/);
   assert.match(emitted, /orderId := req\.PathValue\("orderId"\)/);
@@ -170,7 +179,7 @@ test("emitGoProject falls back to GET for empty route methods to keep scaffold b
 
   const emitted = fs.readFileSync(path.join(outDir, "main.go"), "utf8");
 
-  assert.match(emitted, /mux\.HandleFunc\("GET \/health", route0\)/);
+  assert.match(emitted, /router\.handle\("GET", "\/health", route0\)/);
   assert.match(
     emitted,
     /TODO\(tsgodown\): Implement handler "fallbackMethod" for GET \/health\./,
@@ -285,6 +294,36 @@ test(
   },
 );
 
+function shutdownServer(server: ReturnType<typeof spawn>) {
+  if (server.exitCode === null && !server.killed) {
+    server.kill("SIGTERM");
+  }
+
+  return new Promise<void>((resolve) => {
+    if (server.exitCode !== null) {
+      resolve();
+      return;
+    }
+
+    const forceKillTimer = setTimeout(() => {
+      if (server.exitCode === null) {
+        server.kill("SIGKILL");
+      }
+    }, 1500);
+
+    const settleTimer = setTimeout(() => {
+      clearTimeout(forceKillTimer);
+      resolve();
+    }, 5000);
+
+    server.once("close", () => {
+      clearTimeout(forceKillTimer);
+      clearTimeout(settleTimer);
+      resolve();
+    });
+  });
+}
+
 test(
   "emitGoProject smoke: generated server can boot and serve not-implemented route",
   { skip: !runGoSmoke },
@@ -348,33 +387,82 @@ test(
         /TODO implement handler health for GET \/health/,
       );
     } finally {
-      if (server.exitCode === null && !server.killed) {
-        server.kill("SIGTERM");
+      await shutdownServer(server);
+    }
+  },
+);
+
+test(
+  "emitGoProject smoke: runtime returns deterministic 404/405 for complex method/path matching",
+  { skip: !runGoSmoke },
+  async () => {
+    const outDir = createOutDir();
+    const port = String(20000 + Math.floor(Math.random() * 1000));
+
+    emitGoProject(
+      {
+        modules: [],
+        handlers: [
+          { id: "showUser", params: [], async: false },
+          { id: "deleteUser", params: [], async: false },
+        ],
+        diagnostics: [],
+        routes: [
+          { method: "GET", path: "/users/:id", handlerRef: "showUser" },
+          { method: "DELETE", path: "/users/:id", handlerRef: "deleteUser" },
+        ],
+      },
+      outDir,
+    );
+
+    const modInit = spawnSync(
+      "go",
+      ["mod", "init", "example.com/tsgodown-runtime-status"],
+      {
+        cwd: outDir,
+        encoding: "utf8",
+      },
+    );
+    assert.equal(
+      modInit.status,
+      0,
+      `go mod init failed in ${outDir}\nstdout:\n${modInit.stdout}\nstderr:\n${modInit.stderr}`,
+    );
+
+    const server = spawn("go", ["run", "."], {
+      cwd: outDir,
+      env: { ...process.env, PORT: port },
+      stdio: "ignore",
+    });
+
+    const base = `http://127.0.0.1:${port}`;
+    const deadline = Date.now() + 10_000;
+
+    try {
+      while (Date.now() < deadline) {
+        try {
+          const warm = await fetch(`${base}/users/123`, {
+            signal: AbortSignal.timeout(1000),
+          });
+          if (warm.status > 0) break;
+        } catch {
+          await new Promise((resolve) => setTimeout(resolve, 200));
+        }
       }
 
-      await new Promise<void>((resolve) => {
-        if (server.exitCode !== null) {
-          resolve();
-          return;
-        }
-
-        const forceKillTimer = setTimeout(() => {
-          if (server.exitCode === null) {
-            server.kill("SIGKILL");
-          }
-        }, 1500);
-
-        const settleTimer = setTimeout(() => {
-          clearTimeout(forceKillTimer);
-          resolve();
-        }, 5000);
-
-        server.once("close", () => {
-          clearTimeout(forceKillTimer);
-          clearTimeout(settleTimer);
-          resolve();
-        });
+      const methodNotAllowed = await fetch(`${base}/users/123`, {
+        method: "POST",
+        signal: AbortSignal.timeout(1000),
       });
+      assert.equal(methodNotAllowed.status, 405);
+      assert.equal(methodNotAllowed.headers.get("allow"), "DELETE, GET");
+
+      const notFound = await fetch(`${base}/unknown/123`, {
+        signal: AbortSignal.timeout(1000),
+      });
+      assert.equal(notFound.status, 404);
+    } finally {
+      await shutdownServer(server);
     }
   },
 );

--- a/packages/emitter-go/test/fixtures/empty-method-fallback-and-diagnostics.golden.go
+++ b/packages/emitter-go/test/fixtures/empty-method-fallback-and-diagnostics.golden.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"sort"
 	"strings"
 	"time"
 )
@@ -14,8 +15,60 @@ import (
 //   at src/server.ts:9:2
 // Action: fix diagnostics in source and regenerate. Emitter does not own policy decisions.
 
-func registerRoutes(mux *http.ServeMux) {
-	mux.HandleFunc("GET /health", route0)
+type runtimeRouter struct {
+	methodMux *http.ServeMux
+	pathMux *http.ServeMux
+	methodsByPathPattern map[string]map[string]struct{}
+	pathPatternRegistered map[string]struct{}
+}
+
+func newRuntimeRouter() *runtimeRouter {
+	return &runtimeRouter{
+		methodMux:             http.NewServeMux(),
+		pathMux:               http.NewServeMux(),
+		methodsByPathPattern:  map[string]map[string]struct{}{},
+		pathPatternRegistered: map[string]struct{}{},
+	}
+}
+
+func (r *runtimeRouter) handle(method string, pathPattern string, handler http.HandlerFunc) {
+	r.methodMux.HandleFunc(method+" "+pathPattern, handler)
+	if _, ok := r.pathPatternRegistered[pathPattern]; !ok {
+		r.pathMux.HandleFunc(pathPattern, func(http.ResponseWriter, *http.Request) {})
+		r.pathPatternRegistered[pathPattern] = struct{}{}
+	}
+	methodSet, ok := r.methodsByPathPattern[pathPattern]
+	if !ok {
+		methodSet = map[string]struct{}{}
+		r.methodsByPathPattern[pathPattern] = methodSet
+	}
+	methodSet[method] = struct{}{}
+}
+
+func (r *runtimeRouter) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	handler, methodPattern := r.methodMux.Handler(req)
+	if methodPattern != "" {
+		handler.ServeHTTP(w, req)
+		return
+	}
+
+	_, pathPattern := r.pathMux.Handler(req)
+	if pathPattern != "" {
+		allow := make([]string, 0, len(r.methodsByPathPattern[pathPattern]))
+		for method := range r.methodsByPathPattern[pathPattern] {
+			allow = append(allow, method)
+		}
+		sort.Strings(allow)
+		w.Header().Set("Allow", strings.Join(allow, ", "))
+		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+		return
+	}
+
+	http.NotFound(w, req)
+}
+
+func registerRoutes(router *runtimeRouter) {
+	router.handle("GET", "/health", route0)
 }
 
 func resolveListenAddr() string {
@@ -32,13 +85,13 @@ func resolveListenAddr() string {
 }
 
 func main() {
-	mux := http.NewServeMux()
-	registerRoutes(mux)
+	router := newRuntimeRouter()
+	registerRoutes(router)
 	addr := resolveListenAddr()
 	fmt.Println("tsgodown scaffold listening on", addr)
 	server := &http.Server{
 		Addr:              addr,
-		Handler:           mux,
+		Handler:           router,
 		ReadHeaderTimeout: 5 * time.Second,
 	}
 	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {

--- a/packages/emitter-go/test/fixtures/go-unsafe-path-params.golden.go
+++ b/packages/emitter-go/test/fixtures/go-unsafe-path-params.golden.go
@@ -4,12 +4,65 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"sort"
 	"strings"
 	"time"
 )
 
-func registerRoutes(mux *http.ServeMux) {
-	mux.HandleFunc("GET /things/{type}/{req}/{w}/{pathParamType}", route0)
+type runtimeRouter struct {
+	methodMux *http.ServeMux
+	pathMux *http.ServeMux
+	methodsByPathPattern map[string]map[string]struct{}
+	pathPatternRegistered map[string]struct{}
+}
+
+func newRuntimeRouter() *runtimeRouter {
+	return &runtimeRouter{
+		methodMux:             http.NewServeMux(),
+		pathMux:               http.NewServeMux(),
+		methodsByPathPattern:  map[string]map[string]struct{}{},
+		pathPatternRegistered: map[string]struct{}{},
+	}
+}
+
+func (r *runtimeRouter) handle(method string, pathPattern string, handler http.HandlerFunc) {
+	r.methodMux.HandleFunc(method+" "+pathPattern, handler)
+	if _, ok := r.pathPatternRegistered[pathPattern]; !ok {
+		r.pathMux.HandleFunc(pathPattern, func(http.ResponseWriter, *http.Request) {})
+		r.pathPatternRegistered[pathPattern] = struct{}{}
+	}
+	methodSet, ok := r.methodsByPathPattern[pathPattern]
+	if !ok {
+		methodSet = map[string]struct{}{}
+		r.methodsByPathPattern[pathPattern] = methodSet
+	}
+	methodSet[method] = struct{}{}
+}
+
+func (r *runtimeRouter) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	handler, methodPattern := r.methodMux.Handler(req)
+	if methodPattern != "" {
+		handler.ServeHTTP(w, req)
+		return
+	}
+
+	_, pathPattern := r.pathMux.Handler(req)
+	if pathPattern != "" {
+		allow := make([]string, 0, len(r.methodsByPathPattern[pathPattern]))
+		for method := range r.methodsByPathPattern[pathPattern] {
+			allow = append(allow, method)
+		}
+		sort.Strings(allow)
+		w.Header().Set("Allow", strings.Join(allow, ", "))
+		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+		return
+	}
+
+	http.NotFound(w, req)
+}
+
+func registerRoutes(router *runtimeRouter) {
+	router.handle("GET", "/things/{type}/{req}/{w}/{pathParamType}", route0)
 }
 
 func resolveListenAddr() string {
@@ -26,13 +79,13 @@ func resolveListenAddr() string {
 }
 
 func main() {
-	mux := http.NewServeMux()
-	registerRoutes(mux)
+	router := newRuntimeRouter()
+	registerRoutes(router)
 	addr := resolveListenAddr()
 	fmt.Println("tsgodown scaffold listening on", addr)
 	server := &http.Server{
 		Addr:              addr,
-		Handler:           mux,
+		Handler:           router,
 		ReadHeaderTimeout: 5 * time.Second,
 	}
 	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {

--- a/packages/emitter-go/test/fixtures/nested-restish-route.golden.go
+++ b/packages/emitter-go/test/fixtures/nested-restish-route.golden.go
@@ -4,12 +4,65 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"sort"
 	"strings"
 	"time"
 )
 
-func registerRoutes(mux *http.ServeMux) {
-	mux.HandleFunc("PATCH /api/v2/users/{id}/devices/{deviceId}", route0)
+type runtimeRouter struct {
+	methodMux *http.ServeMux
+	pathMux *http.ServeMux
+	methodsByPathPattern map[string]map[string]struct{}
+	pathPatternRegistered map[string]struct{}
+}
+
+func newRuntimeRouter() *runtimeRouter {
+	return &runtimeRouter{
+		methodMux:             http.NewServeMux(),
+		pathMux:               http.NewServeMux(),
+		methodsByPathPattern:  map[string]map[string]struct{}{},
+		pathPatternRegistered: map[string]struct{}{},
+	}
+}
+
+func (r *runtimeRouter) handle(method string, pathPattern string, handler http.HandlerFunc) {
+	r.methodMux.HandleFunc(method+" "+pathPattern, handler)
+	if _, ok := r.pathPatternRegistered[pathPattern]; !ok {
+		r.pathMux.HandleFunc(pathPattern, func(http.ResponseWriter, *http.Request) {})
+		r.pathPatternRegistered[pathPattern] = struct{}{}
+	}
+	methodSet, ok := r.methodsByPathPattern[pathPattern]
+	if !ok {
+		methodSet = map[string]struct{}{}
+		r.methodsByPathPattern[pathPattern] = methodSet
+	}
+	methodSet[method] = struct{}{}
+}
+
+func (r *runtimeRouter) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	handler, methodPattern := r.methodMux.Handler(req)
+	if methodPattern != "" {
+		handler.ServeHTTP(w, req)
+		return
+	}
+
+	_, pathPattern := r.pathMux.Handler(req)
+	if pathPattern != "" {
+		allow := make([]string, 0, len(r.methodsByPathPattern[pathPattern]))
+		for method := range r.methodsByPathPattern[pathPattern] {
+			allow = append(allow, method)
+		}
+		sort.Strings(allow)
+		w.Header().Set("Allow", strings.Join(allow, ", "))
+		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+		return
+	}
+
+	http.NotFound(w, req)
+}
+
+func registerRoutes(router *runtimeRouter) {
+	router.handle("PATCH", "/api/v2/users/{id}/devices/{deviceId}", route0)
 }
 
 func resolveListenAddr() string {
@@ -26,13 +79,13 @@ func resolveListenAddr() string {
 }
 
 func main() {
-	mux := http.NewServeMux()
-	registerRoutes(mux)
+	router := newRuntimeRouter()
+	registerRoutes(router)
 	addr := resolveListenAddr()
 	fmt.Println("tsgodown scaffold listening on", addr)
 	server := &http.Server{
 		Addr:              addr,
-		Handler:           mux,
+		Handler:           router,
 		ReadHeaderTimeout: 5 * time.Second,
 	}
 	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {

--- a/packages/emitter-go/test/fixtures/sample-ir.golden.go
+++ b/packages/emitter-go/test/fixtures/sample-ir.golden.go
@@ -4,13 +4,66 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"sort"
 	"strings"
 	"time"
 )
 
-func registerRoutes(mux *http.ServeMux) {
-	mux.HandleFunc("GET /health", route0)
-	mux.HandleFunc("POST /users/{id}", route1)
+type runtimeRouter struct {
+	methodMux *http.ServeMux
+	pathMux *http.ServeMux
+	methodsByPathPattern map[string]map[string]struct{}
+	pathPatternRegistered map[string]struct{}
+}
+
+func newRuntimeRouter() *runtimeRouter {
+	return &runtimeRouter{
+		methodMux:             http.NewServeMux(),
+		pathMux:               http.NewServeMux(),
+		methodsByPathPattern:  map[string]map[string]struct{}{},
+		pathPatternRegistered: map[string]struct{}{},
+	}
+}
+
+func (r *runtimeRouter) handle(method string, pathPattern string, handler http.HandlerFunc) {
+	r.methodMux.HandleFunc(method+" "+pathPattern, handler)
+	if _, ok := r.pathPatternRegistered[pathPattern]; !ok {
+		r.pathMux.HandleFunc(pathPattern, func(http.ResponseWriter, *http.Request) {})
+		r.pathPatternRegistered[pathPattern] = struct{}{}
+	}
+	methodSet, ok := r.methodsByPathPattern[pathPattern]
+	if !ok {
+		methodSet = map[string]struct{}{}
+		r.methodsByPathPattern[pathPattern] = methodSet
+	}
+	methodSet[method] = struct{}{}
+}
+
+func (r *runtimeRouter) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	handler, methodPattern := r.methodMux.Handler(req)
+	if methodPattern != "" {
+		handler.ServeHTTP(w, req)
+		return
+	}
+
+	_, pathPattern := r.pathMux.Handler(req)
+	if pathPattern != "" {
+		allow := make([]string, 0, len(r.methodsByPathPattern[pathPattern]))
+		for method := range r.methodsByPathPattern[pathPattern] {
+			allow = append(allow, method)
+		}
+		sort.Strings(allow)
+		w.Header().Set("Allow", strings.Join(allow, ", "))
+		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+		return
+	}
+
+	http.NotFound(w, req)
+}
+
+func registerRoutes(router *runtimeRouter) {
+	router.handle("GET", "/health", route0)
+	router.handle("POST", "/users/{id}", route1)
 }
 
 func resolveListenAddr() string {
@@ -27,13 +80,13 @@ func resolveListenAddr() string {
 }
 
 func main() {
-	mux := http.NewServeMux()
-	registerRoutes(mux)
+	router := newRuntimeRouter()
+	registerRoutes(router)
 	addr := resolveListenAddr()
 	fmt.Println("tsgodown scaffold listening on", addr)
 	server := &http.Server{
 		Addr:              addr,
-		Handler:           mux,
+		Handler:           router,
 		ReadHeaderTimeout: 5 * time.Second,
 	}
 	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {


### PR DESCRIPTION
## Summary
Improve generated Go runtime scaffold to better reflect complex Fastify routing behavior:

- add a method-aware runtime router wrapper (`runtimeRouter`) instead of wiring routes directly to `http.ServeMux`
- keep path parameter binding behavior consistent with normalized ServeMux path patterns
- enforce deterministic runtime status handling:
  - **405 Method Not Allowed** when path matches but method does not
  - **404 Not Found** when no path match exists
- keep `Allow` header deterministic via sorted methods

## Before vs After
### Before
- Routes were registered directly via `mux.HandleFunc("METHOD /path", handler)`.
- 404/405 behavior depended on default mux behavior (including implicit method nuances like `HEAD` with `GET`).
- No explicit runtime-level deterministic policy for method-mismatch vs missing-path cases.

### After
- Routes are registered via `router.handle(method, pathPattern, handler)`.
- Runtime now uses:
  - `methodMux` for method+path dispatch,
  - `pathMux` for path-only existence checks,
  - `methodsByPathPattern` for stable `Allow` response generation.
- Explicit deterministic behavior:
  - matched path + unsupported method => 405 + sorted `Allow`
  - unmatched path => 404

## TDD
Added/updated tests first to codify expected behavior:

- emitter output contract tests now assert runtime router scaffold and method-aware registration calls
- new smoke test: `emitGoProject smoke: runtime returns deterministic 404/405 for complex method/path matching`
- refreshed golden fixtures for representative IR inputs

## Validation
Executed full required checks:

- `pnpm install --frozen-lockfile`
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run build`
- `pnpm run test`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --all-targets`
- `./scripts/smoke-m1.sh`

All passed.
