### PR TITLE
feat(analyzer-rust): extract complex Fastify route handlers

### DIFF
--- a/packages/analyzer-rust/src/defs.rs
+++ b/packages/analyzer-rust/src/defs.rs
@@ -140,6 +140,22 @@ pub(crate) fn collect_handler_definitions(src: &str) -> HashMap<String, HandlerD
         );
     }
 
+    let var_expr_arrow_re = Regex::new(
+        r"(?m)(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*(?::\s*[^=]+?)?\s*=\s*(async\s+)?(?:\(([^)]*)\)|([A-Za-z_$][\w$]*))\s*(?::\s*[^=;]+)?=>\s*[^\s\{]",
+    )
+    .unwrap();
+    for cap in var_expr_arrow_re.captures_iter(src) {
+        let params_src = cap
+            .get(3)
+            .or_else(|| cap.get(4))
+            .map(|m| m.as_str())
+            .unwrap_or("");
+        map.entry(cap[1].to_string()).or_insert_with(|| HandlerDef {
+            params: split_params(params_src),
+            is_async: cap.get(2).is_some(),
+        });
+    }
+
     collect_object_literal_handlers(src, &mut map);
     collect_class_instance_handlers(src, &mut map);
 
@@ -157,10 +173,16 @@ fn collect_object_literal_handlers(src: &str, map: &mut HashMap<String, HandlerD
         };
 
         for member in split_top_level(&body, ',') {
-            let Some((key, def)) = parse_object_member_handler(&member) else {
+            if let Some((key, def)) = parse_object_member_handler(&member) {
+                map.insert(format!("{}.{}", obj_name, key), def);
                 continue;
-            };
-            map.insert(format!("{}.{}", obj_name, key), def);
+            }
+
+            if let Some((key, target_ref)) = parse_object_member_reference(&member) {
+                if let Some(def) = map.get(&target_ref).cloned() {
+                    map.insert(format!("{}.{}", obj_name, key), def);
+                }
+            }
         }
     }
 }
@@ -216,6 +238,28 @@ fn parse_object_member_handler(member: &str) -> Option<(String, HandlerDef)> {
             },
         )
     })
+}
+
+fn parse_object_member_reference(member: &str) -> Option<(String, String)> {
+    let t = member.trim();
+    if t.is_empty() {
+        return None;
+    }
+
+    let re_shorthand =
+        Regex::new(r#"^([A-Za-z_$][\w$]*|"[A-Za-z_$][\w$]*"|'[A-Za-z_$][\w$]*')$"#).unwrap();
+    if let Some(cap) = re_shorthand.captures(t) {
+        let key = normalize_prop_key(&cap[1]);
+        return Some((key.clone(), key));
+    }
+
+    let re_ref = Regex::new(
+        r#"^([A-Za-z_$][\w$]*|"[A-Za-z_$][\w$]*"|'[A-Za-z_$][\w$]*')\s*:\s*([A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*)$"#,
+    )
+    .unwrap();
+    re_ref
+        .captures(t)
+        .map(|cap| (normalize_prop_key(&cap[1]), cap[2].trim().to_string()))
 }
 
 fn collect_class_instance_handlers(src: &str, map: &mut HashMap<String, HandlerDef>) {

--- a/packages/analyzer-rust/src/traversal.rs
+++ b/packages/analyzer-rust/src/traversal.rs
@@ -19,9 +19,8 @@ pub(crate) fn analyze_scope(
     diagnostics: &mut Vec<DiagnosticIR>,
 ) {
     let mut idx = 0usize;
-    while let Some(pos) = body[idx..].find(&format!("{}.", instance_name)) {
-        let start = idx + pos;
-        let tail = &body[start + instance_name.len() + 1..];
+    while let Some((start, dot_idx)) = find_instance_dot(body, idx, instance_name) {
+        let tail = &body[dot_idx + 1..];
 
         if let Some(consumed) = analyze_call_chain(
             tail,
@@ -34,12 +33,45 @@ pub(crate) fn analyze_scope(
             handlers,
             diagnostics,
         ) {
-            idx = start + instance_name.len() + 1 + consumed;
+            idx = dot_idx + 1 + consumed;
             continue;
         }
 
         idx = start + 1;
     }
+}
+
+fn find_instance_dot(body: &str, from: usize, instance_name: &str) -> Option<(usize, usize)> {
+    let mut search_from = from;
+    while let Some(rel) = body[search_from..].find(instance_name) {
+        let start = search_from + rel;
+        let end = start + instance_name.len();
+
+        let prev_ok = if start == 0 {
+            true
+        } else {
+            !is_ident_char(body.as_bytes()[start - 1])
+        };
+        if !prev_ok {
+            search_from = start + 1;
+            continue;
+        }
+
+        let mut i = end;
+        while i < body.len() && body.as_bytes()[i].is_ascii_whitespace() {
+            i += 1;
+        }
+        if i < body.len() && body.as_bytes()[i] == b'.' {
+            return Some((start, i));
+        }
+
+        search_from = start + 1;
+    }
+    None
+}
+
+fn is_ident_char(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_' || b == b'$'
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/packages/analyzer-rust/tests/fastify_ast_analyzer.rs
+++ b/packages/analyzer-rust/tests/fastify_ast_analyzer.rs
@@ -373,6 +373,71 @@ fn extracts_handlers_from_object_literals_and_class_instances() {
 }
 
 #[test]
+fn extracts_complex_realworld_routes_with_stable_handler_refs() {
+    let (file, src) = fixture("complex-fastify-realworld.fixture.txt");
+    let ir = analyze_fastify_entry(&file, &src);
+
+    assert_eq!(
+        ir.routes
+            .iter()
+            .map(|r| (r.method.as_str(), r.path.as_str(), r.handler_ref.as_str()))
+            .collect::<Vec<_>>(),
+        vec![
+            ("GET", "/tenants/:tenantId/users", "userHandlers.listUsers"),
+            ("POST", "/tenants/:tenantId/users", "userHandlers.create"),
+            (
+                "PUT",
+                "/tenants/:tenantId/users/:userId",
+                "userHandlers.update",
+            ),
+            ("DELETE", "/tenants/:tenantId/users/:userId", "removeUser"),
+            (
+                "PATCH",
+                "/tenants/:tenantId/users/:userId/profile/:profileId",
+                "controller.detail",
+            ),
+        ]
+    );
+
+    assert_eq!(
+        ir.handlers
+            .iter()
+            .map(|h| {
+                (
+                    h.id.as_str(),
+                    h.params
+                        .iter()
+                        .map(|p| (p.name.as_str(), p.role.as_str()))
+                        .collect::<Vec<_>>(),
+                    h.r#async,
+                )
+            })
+            .collect::<Vec<_>>(),
+        vec![
+            (
+                "userHandlers.listUsers",
+                vec![("req", "request"), ("reply", "response")],
+                true,
+            ),
+            (
+                "userHandlers.create",
+                vec![("request", "request"), ("response", "response")],
+                false,
+            ),
+            ("userHandlers.update", vec![("req", "request")], true),
+            (
+                "removeUser",
+                vec![("req", "request"), ("reply", "response")],
+                false,
+            ),
+            ("controller.detail", vec![("request", "request")], true),
+        ]
+    );
+
+    assert!(ir.diagnostics.is_empty());
+}
+
+#[test]
 fn emits_deterministic_boundary_diagnostics_for_unsupported_route_object_patterns() {
     let (file, src) = fixture("unsupported-route-object-fastify.fixture.txt");
     let ir = analyze_fastify_entry(&file, &src);

--- a/packages/analyzer-rust/tests/fixtures/complex-fastify-realworld.fixture.txt
+++ b/packages/analyzer-rust/tests/fixtures/complex-fastify-realworld.fixture.txt
@@ -1,0 +1,38 @@
+import Fastify from "fastify";
+
+const app = Fastify();
+
+async function listUsers(req, reply) {
+  return reply.send([]);
+}
+
+function createUser(request, response) {
+  return response.send({ ok: true });
+}
+
+const updateUser = async (req) => req.params;
+
+function removeUser(req, reply) {
+  return reply.code(204).send();
+}
+
+class UserController {
+  async detail(request) {
+    return { id: request.params.id };
+  }
+}
+
+const controller = new UserController();
+
+const userHandlers = {
+  listUsers,
+  create: createUser,
+  update: updateUser,
+};
+
+app
+  .get("/tenants/:tenantId/users", userHandlers.listUsers)
+  .post("/tenants/:tenantId/users", userHandlers.create)
+  .put("/tenants/:tenantId/users/:userId", userHandlers.update)
+  .delete("/tenants/:tenantId/users/:userId", removeUser)
+  .patch("/tenants/:tenantId/users/:userId/profile/:profileId", controller.detail);


### PR DESCRIPTION
## Summary\n- extend Rust handler definition extraction to support typed expression-bodied arrow handlers and object member references\n- harden instance call-chain traversal to avoid false positives on partial identifier matches\n- add a complex real-world Fastify fixture and regression test that locks stable route->handler mapping and handler param roles\n\n## Verification\n- pnpm install --frozen-lockfile\n- pnpm run lint\n- pnpm run format:check\n- pnpm run build\n- pnpm run test\n- cargo fmt --all --check\n- cargo clippy --workspace --all-targets -- -D warnings\n- cargo test --workspace --all-targets\n- ./scripts/smoke-m1.sh