### PR TITLE
feat(analyzer-rust): harden fastify complex extraction

### DIFF
--- a/packages/analyzer-rust/src/ast.rs
+++ b/packages/analyzer-rust/src/ast.rs
@@ -157,6 +157,22 @@ pub(crate) fn extract_object_string_prop(obj: &str, key: &str) -> Option<String>
     re.captures(obj).and_then(|c| extract_quoted_string(&c[1]))
 }
 
+pub(crate) fn extract_object_string_array_prop(obj: &str, key: &str) -> Vec<String> {
+    let pattern = format!(
+        r#"(?s)(?:\b{}\b|"{}")\s*:\s*\[(.*?)\]"#,
+        regex::escape(key),
+        regex::escape(key)
+    );
+    let re = Regex::new(&pattern).unwrap();
+    let Some(captures) = re.captures(obj) else {
+        return vec![];
+    };
+    split_top_level(&captures[1], ',')
+        .into_iter()
+        .filter_map(|part| extract_quoted_string(&part))
+        .collect()
+}
+
 pub(crate) fn extract_object_handler_ref(obj: &str, key: &str) -> Option<String> {
     let pattern = format!(
         r#"(?s)(?:\b{}\b|"{}")\s*:\s*([^,}}]+)"#,
@@ -166,4 +182,69 @@ pub(crate) fn extract_object_handler_ref(obj: &str, key: &str) -> Option<String>
     let re = Regex::new(&pattern).unwrap();
     let expr = re.captures(obj).map(|c| c[1].trim().to_string())?;
     extract_handler_ref(&expr)
+}
+
+pub(crate) fn find_if_block_ranges(src: &str) -> Vec<(usize, usize)> {
+    let bytes = src.as_bytes();
+    let mut out = vec![];
+    let mut i = 0usize;
+
+    while i + 2 <= bytes.len() {
+        if i + 1 < bytes.len()
+            && bytes[i] == b'i'
+            && bytes[i + 1] == b'f'
+            && (i == 0 || !is_ident_char(bytes[i - 1]))
+            && (i + 2 == bytes.len() || !is_ident_char(bytes[i + 2]))
+        {
+            let mut j = i + 2;
+            while j < bytes.len() && bytes[j].is_ascii_whitespace() {
+                j += 1;
+            }
+            if j >= bytes.len() || bytes[j] != b'(' {
+                i += 2;
+                continue;
+            }
+            let Some((_, cond_consumed)) = capture_balanced(&src[j + 1..], '(', ')') else {
+                i += 2;
+                continue;
+            };
+            j = j + 1 + cond_consumed;
+            while j < bytes.len() && bytes[j].is_ascii_whitespace() {
+                j += 1;
+            }
+            if j < bytes.len() && bytes[j] == b'{' {
+                if let Some((_, body_consumed)) = capture_balanced(&src[j + 1..], '{', '}') {
+                    out.push((j + 1, j + body_consumed));
+                    j = j + 1 + body_consumed;
+                }
+            }
+
+            while j < bytes.len() && bytes[j].is_ascii_whitespace() {
+                j += 1;
+            }
+            if j + 4 <= bytes.len() && &src[j..j + 4] == "else" {
+                let mut k = j + 4;
+                while k < bytes.len() && bytes[k].is_ascii_whitespace() {
+                    k += 1;
+                }
+                if k < bytes.len() && bytes[k] == b'{' {
+                    if let Some((_, else_consumed)) = capture_balanced(&src[k + 1..], '{', '}') {
+                        out.push((k + 1, k + else_consumed));
+                        j = k + 1 + else_consumed;
+                    }
+                }
+            }
+
+            i = j;
+            continue;
+        }
+
+        i += 1;
+    }
+
+    out
+}
+
+fn is_ident_char(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_' || b == b'$'
 }

--- a/packages/analyzer-rust/src/routes.rs
+++ b/packages/analyzer-rust/src/routes.rs
@@ -1,8 +1,8 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::ast::{
-    extract_handler_ref, extract_object_handler_ref, extract_object_string_prop,
-    extract_quoted_string, first_object_literal, split_top_level,
+    extract_handler_ref, extract_object_handler_ref, extract_object_string_array_prop,
+    extract_object_string_prop, extract_quoted_string, first_object_literal, split_top_level,
 };
 use crate::defs::HandlerDef;
 use crate::diagnostics::diag;
@@ -81,34 +81,46 @@ pub(crate) fn extract_route_object(
     };
 
     let raw_method = extract_object_string_prop(&obj, "method");
-    let method = raw_method.as_deref().map(|m| m.to_ascii_uppercase());
+    let raw_method_array = extract_object_string_array_prop(&obj, "method");
     let path = extract_object_string_prop(&obj, "url")
         .or_else(|| extract_object_string_prop(&obj, "path"));
     let handler_ref = extract_object_handler_ref(&obj, "handler");
 
     let supported = HashSet::from(["GET", "POST", "PUT", "DELETE", "PATCH"]);
-    let Some(method) = method else {
+
+    let methods = if let Some(method) = raw_method {
+        vec![method]
+    } else if !raw_method_array.is_empty() {
+        raw_method_array
+    } else {
         diagnostics.push(diag(
             file,
             "ANALYZER_UNSUPPORTED_ROUTE_OBJECT_METHOD",
             &format!(
-                "unsupported route object method in {}.route({{...}}): missing string 'method'. Supported methods: GET|POST|PUT|DELETE|PATCH.",
+                "unsupported route object method in {}.route({{...}}): missing string 'method' or non-empty string array. Supported methods: GET|POST|PUT|DELETE|PATCH.",
                 instance_name
             ),
         ));
         return;
     };
-    if !supported.contains(method.as_str()) {
-        diagnostics.push(diag(
-            file,
-            "ANALYZER_UNSUPPORTED_ROUTE_OBJECT_METHOD",
-            &format!(
-                "unsupported route object method in {}.route({{...}}): '{}'. Supported methods: GET|POST|PUT|DELETE|PATCH.",
-                instance_name,
-                raw_method.unwrap_or_else(|| "<unknown>".to_string())
-            ),
-        ));
-        return;
+
+    let methods = methods
+        .iter()
+        .map(|m| (m.clone(), m.to_ascii_uppercase()))
+        .collect::<Vec<_>>();
+
+    for (raw, upper) in &methods {
+        if !supported.contains(upper.as_str()) {
+            diagnostics.push(diag(
+                file,
+                "ANALYZER_UNSUPPORTED_ROUTE_OBJECT_METHOD",
+                &format!(
+                    "unsupported route object method in {}.route({{...}}): '{}'. Supported methods: GET|POST|PUT|DELETE|PATCH.",
+                    instance_name, raw
+                ),
+            ));
+            return;
+        }
     }
 
     let Some(path) = path else {
@@ -135,11 +147,13 @@ pub(crate) fn extract_route_object(
         return;
     };
 
-    routes.push(RouteIR {
-        method,
-        path: join_path(prefix, &path),
-        handler_ref: handler_ref.clone(),
-    });
+    for (_, method) in methods {
+        routes.push(RouteIR {
+            method,
+            path: join_path(prefix, &path),
+            handler_ref: handler_ref.clone(),
+        });
+    }
     upsert_handler(handlers, handler_defs, &handler_ref);
 }
 

--- a/packages/analyzer-rust/src/traversal.rs
+++ b/packages/analyzer-rust/src/traversal.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
 
-use crate::ast::capture_call_args;
+use crate::ast::{capture_call_args, find_if_block_ranges};
 use crate::defs::{HandlerDef, PluginDef};
+use crate::diagnostics::diag;
 use crate::ir::{DiagnosticIR, HandlerIR, RouteIR};
 use crate::register::analyze_register_call;
 use crate::routes::{extract_route_object, extract_shorthand_route};
@@ -18,9 +19,28 @@ pub(crate) fn analyze_scope(
     handlers: &mut Vec<HandlerIR>,
     diagnostics: &mut Vec<DiagnosticIR>,
 ) {
+    let conditional_ranges = find_if_block_ranges(body);
     let mut idx = 0usize;
     while let Some((start, dot_idx)) = find_instance_dot(body, idx, instance_name) {
         let tail = &body[dot_idx + 1..];
+
+        if conditional_ranges
+            .iter()
+            .any(|(from, to)| dot_idx >= *from && dot_idx < *to)
+        {
+            if let Some(method) = first_supported_method(tail) {
+                diagnostics.push(diag(
+                    file,
+                    "ANALYZER_UNSUPPORTED_CONDITIONAL_ROUTE",
+                    &format!(
+                        "conditional route registration in if-block is unsupported for deterministic extraction ({}.{}(...)). Move route declaration to top-level plugin scope.",
+                        instance_name, method
+                    ),
+                ));
+            }
+            idx = start + 1;
+            continue;
+        }
 
         if let Some(consumed) = analyze_call_chain(
             tail,
@@ -72,6 +92,12 @@ fn find_instance_dot(body: &str, from: usize, instance_name: &str) -> Option<(us
 
 fn is_ident_char(b: u8) -> bool {
     b.is_ascii_alphanumeric() || b == b'_' || b == b'$'
+}
+
+fn first_supported_method(chain: &str) -> Option<&'static str> {
+    ["get", "post", "put", "delete", "patch", "route", "register"]
+        .iter()
+        .find_map(|method| capture_call_args(chain, method).map(|_| *method))
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/packages/analyzer-rust/tests/contract_parity_regression.rs
+++ b/packages/analyzer-rust/tests/contract_parity_regression.rs
@@ -186,6 +186,21 @@ fn contract_fixtures() -> Vec<ContractFixture> {
             expected_diag_codes: vec![],
         },
         ContractFixture {
+            name: "route-object-method-array-fastify.fixture.txt",
+            expected_routes: vec![
+                ("PUT", "/things/:id", "replaceThing"),
+                ("PATCH", "/things/:id", "replaceThing"),
+            ],
+            expected_handlers: vec![("replaceThing", vec![], false, "unknown")],
+            expected_diag_codes: vec![],
+        },
+        ContractFixture {
+            name: "conditional-routes-fastify.fixture.txt",
+            expected_routes: vec![("GET", "/always", "alwaysOn")],
+            expected_handlers: vec![("alwaysOn", vec![], false, "unknown")],
+            expected_diag_codes: vec!["ANALYZER_UNSUPPORTED_CONDITIONAL_ROUTE"],
+        },
+        ContractFixture {
             name: "unsupported-fastify.fixture.txt",
             expected_routes: vec![],
             expected_handlers: vec![],

--- a/packages/analyzer-rust/tests/fastify_ast_analyzer.rs
+++ b/packages/analyzer-rust/tests/fastify_ast_analyzer.rs
@@ -471,7 +471,7 @@ fn emits_deterministic_boundary_diagnostics_for_unsupported_route_object_pattern
             ),
             (
                 "ANALYZER_UNSUPPORTED_ROUTE_OBJECT_METHOD",
-                "unsupported route object method in fastify.route({...}): missing string 'method'. Supported methods: GET|POST|PUT|DELETE|PATCH.",
+                "unsupported route object method in fastify.route({...}): missing string 'method' or non-empty string array. Supported methods: GET|POST|PUT|DELETE|PATCH.",
                 "warn",
                 file.as_str(),
             ),
@@ -495,4 +495,53 @@ fn emits_deterministic_boundary_diagnostics_for_unsupported_route_object_pattern
             ),
         ]
     );
+}
+
+#[test]
+fn supports_route_object_method_array_extraction() {
+    let (file, src) = fixture("route-object-method-array-fastify.fixture.txt");
+    let ir = analyze_fastify_entry(&file, &src);
+
+    assert_eq!(
+        ir.routes
+            .iter()
+            .map(|r| (r.method.as_str(), r.path.as_str(), r.handler_ref.as_str()))
+            .collect::<Vec<_>>(),
+        vec![
+            ("PUT", "/things/:id", "replaceThing"),
+            ("PATCH", "/things/:id", "replaceThing"),
+        ]
+    );
+    assert!(ir.diagnostics.is_empty());
+}
+
+#[test]
+fn emits_deterministic_diagnostics_and_skips_routes_in_if_blocks() {
+    let (file, src) = fixture("conditional-routes-fastify.fixture.txt");
+    let ir = analyze_fastify_entry(&file, &src);
+
+    assert_eq!(
+        ir.routes
+            .iter()
+            .map(|r| (r.method.as_str(), r.path.as_str(), r.handler_ref.as_str()))
+            .collect::<Vec<_>>(),
+        vec![("GET", "/always", "alwaysOn")]
+    );
+
+    assert_eq!(
+        ir.diagnostics
+            .iter()
+            .map(|d| (d.code.as_str(), d.level.as_str(), d.message.as_str()))
+            .collect::<Vec<_>>(),
+        vec![(
+            "ANALYZER_UNSUPPORTED_CONDITIONAL_ROUTE",
+            "warn",
+            "conditional route registration in if-block is unsupported for deterministic extraction (fastify.get(...)). Move route declaration to top-level plugin scope.",
+        )]
+    );
+
+    assert!(ir
+        .diagnostics
+        .iter()
+        .all(|d| d.source.as_ref().map(|s| s.file.as_str()) == Some(file.as_str())));
 }

--- a/packages/analyzer-rust/tests/fixtures/conditional-routes-fastify.fixture.txt
+++ b/packages/analyzer-rust/tests/fixtures/conditional-routes-fastify.fixture.txt
@@ -1,0 +1,14 @@
+import Fastify from "fastify";
+
+const fastify = Fastify();
+const isEnabled = process.env.ENABLED === "1";
+
+function alwaysOn() {}
+function conditionalGet() {}
+function conditionalPost() {}
+
+fastify.get("/always", alwaysOn);
+
+if (isEnabled) {
+  fastify.get("/conditional", conditionalGet).post("/conditional", conditionalPost);
+}

--- a/packages/analyzer-rust/tests/fixtures/route-object-method-array-fastify.fixture.txt
+++ b/packages/analyzer-rust/tests/fixtures/route-object-method-array-fastify.fixture.txt
@@ -1,0 +1,7 @@
+import Fastify from "fastify";
+
+const fastify = Fastify();
+
+function replaceThing() {}
+
+fastify.route({ method: ["PUT", "PATCH"], url: "/things/:id", handler: replaceThing });

--- a/packages/analyzer-rust/tests/fixtures/unsupported-route-object-fastify.fixture.txt
+++ b/packages/analyzer-rust/tests/fixtures/unsupported-route-object-fastify.fixture.txt
@@ -3,6 +3,7 @@ import Fastify from "fastify";
 const fastify = Fastify();
 const routeConfig = { method: "GET", url: "/from-config", handler: listFromConfig };
 const dynamicPath = "/dynamic";
+const methodName = "GET";
 
 function listUsers() {}
 function listAdmins() {}
@@ -11,5 +12,6 @@ function listAudits() {}
 fastify.route(routeConfig);
 fastify.route({ url: "/users", handler: listUsers });
 fastify.route({ method: "OPTIONS", url: "/admins", handler: listAdmins });
+fastify.route({ method: methodName, url: "/from-variable-method", handler: listUsers });
 fastify.route({ method: "GET", url: dynamicPath, handler: listAudits });
 fastify.route({ method: "POST", url: "/inline", handler: async () => {} });


### PR DESCRIPTION
## What
- Hardened Fastify extraction in `packages/analyzer-rust` for complex patterns:
  - Route-object extraction for `app.route({ method, url/path, handler })`
  - Route-object method array support: `method: ["PUT", "PATCH"]`
  - Prefix composition through nested `register(..., { prefix })` scopes
  - Deterministic diagnostics for unsupported/dynamic route-object method/path/handler patterns
  - Deterministic policy for conditional routes: routes inside `if`/`else` blocks are skipped and diagnosed with `ANALYZER_UNSUPPORTED_CONDITIONAL_ROUTE`
- Added/updated fixtures and tests to lock behavior and ordering:
  - `route-object-method-array-fastify.fixture.txt`
  - `conditional-routes-fastify.fixture.txt`
  - Updated `unsupported-route-object-fastify.fixture.txt` for dynamic method diagnostic coverage
  - Extended `fastify_ast_analyzer.rs` and `contract_parity_regression.rs`

## Why
- Prevent silent route drops in Fastify complex extraction paths.
- Make unsupported dynamic/conditional patterns explicit and deterministic for downstream pipelines.
- Keep analyzer behavior stable under TDD with contract parity + deterministic diagnostics ordering.

## Test
- `pnpm install --frozen-lockfile`
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run build`
- `pnpm run test`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --all-targets`
- `./scripts/smoke-m1.sh`
