### PR TITLE
test(analyzer-rust): add fastify unsupported diagnostic fixture matrix

### DIFF
--- a/.pr-body-fastify-unsupported-fixture-matrix.md
+++ b/.pr-body-fastify-unsupported-fixture-matrix.md
@@ -1,0 +1,39 @@
+## Summary
+
+Add a deterministic fixture matrix for Fastify unsupported diagnostics in analyzer-rust.
+
+- Added bad/fixed fixture pairs for each Fastify unsupported diagnostic code.
+- Introduced a documented naming scheme for unsupported fixture pairs.
+- Added a deterministic matrix test that validates:
+  - bad fixtures emit exactly the expected unsupported diagnostic code
+  - fixed fixtures emit no diagnostics and extract stable routes
+- Linked diagnostics spec to the fixture matrix documentation.
+
+## Fixture matrix
+
+| code | bad fixture | fixed fixture | test file |
+|---|---|---|---|
+| `ANALYZER_UNSUPPORTED_CONDITIONAL_ROUTE` | `fastify-unsupported-conditional-route.bad.fixture.txt` | `fastify-unsupported-conditional-route.fixed.fixture.txt` | `packages/analyzer-rust/tests/fastify_ast_analyzer.rs` |
+| `ANALYZER_UNSUPPORTED_REGISTER_CALLBACK` | `fastify-unsupported-register-callback.bad.fixture.txt` | `fastify-unsupported-register-callback.fixed.fixture.txt` | `packages/analyzer-rust/tests/fastify_ast_analyzer.rs` |
+| `ANALYZER_UNSUPPORTED_DYNAMIC_PATH` | `fastify-unsupported-dynamic-path.bad.fixture.txt` | `fastify-unsupported-dynamic-path.fixed.fixture.txt` | `packages/analyzer-rust/tests/fastify_ast_analyzer.rs` |
+| `ANALYZER_UNSUPPORTED_INLINE_HANDLER` | `fastify-unsupported-inline-handler.bad.fixture.txt` | `fastify-unsupported-inline-handler.fixed.fixture.txt` | `packages/analyzer-rust/tests/fastify_ast_analyzer.rs` |
+| `ANALYZER_UNSUPPORTED_ROUTE_OBJECT_SHAPE` | `fastify-unsupported-route-object-shape.bad.fixture.txt` | `fastify-unsupported-route-object-shape.fixed.fixture.txt` | `packages/analyzer-rust/tests/fastify_ast_analyzer.rs` |
+| `ANALYZER_UNSUPPORTED_ROUTE_OBJECT_METHOD` | `fastify-unsupported-route-object-method.bad.fixture.txt` | `fastify-unsupported-route-object-method.fixed.fixture.txt` | `packages/analyzer-rust/tests/fastify_ast_analyzer.rs` |
+| `ANALYZER_UNSUPPORTED_DYNAMIC_PATH` (route object variant) | `fastify-unsupported-route-object-path.bad.fixture.txt` | `fastify-unsupported-route-object-path.fixed.fixture.txt` | `packages/analyzer-rust/tests/fastify_ast_analyzer.rs` |
+| `ANALYZER_UNSUPPORTED_INLINE_HANDLER` (route object variant) | `fastify-unsupported-route-object-handler.bad.fixture.txt` | `fastify-unsupported-route-object-handler.fixed.fixture.txt` | `packages/analyzer-rust/tests/fastify_ast_analyzer.rs` |
+
+## Additional unsupported diagnostics
+
+No additional `ANALYZER_UNSUPPORTED_*` Fastify diagnostics were found beyond those documented in `docs/specs/DIAGNOSTICS.md`.
+
+## Verification
+
+- `pnpm install --frozen-lockfile`
+- `pnpm run lint`
+- `pnpm run format:check`
+- `pnpm run build`
+- `pnpm run test`
+- `cargo fmt --all --check`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo test --workspace --all-targets`
+- `./scripts/smoke-m1.sh`

--- a/docs/specs/DIAGNOSTICS.md
+++ b/docs/specs/DIAGNOSTICS.md
@@ -223,3 +223,19 @@ fastify.route({ method: ["GET", "POST"], url: "/users", handler: usersHandler })
 **Rationale**
 
 Route-object methods must be present and limited to currently supported HTTP methods for deterministic extraction and emission.
+
+---
+
+## Fixture matrix for unsupported diagnostics
+
+Deterministic bad/fixed fixture pairs live in:
+
+- `packages/analyzer-rust/tests/fixtures/FASTIFY_UNSUPPORTED_FIXTURE_MATRIX.md`
+
+Naming convention:
+
+- `fastify-unsupported-<topic>.bad.fixture.txt`
+- `fastify-unsupported-<topic>.fixed.fixture.txt`
+
+These pairs are consumed by `packages/analyzer-rust/tests/fastify_ast_analyzer.rs` in
+`fixture_matrix_for_fastify_unsupported_diagnostics_bad_and_fixed_pairs`.

--- a/packages/analyzer-rust/tests/fastify_ast_analyzer.rs
+++ b/packages/analyzer-rust/tests/fastify_ast_analyzer.rs
@@ -12,6 +12,14 @@ fn fixture(name: &str) -> (String, String) {
     (path.to_string_lossy().to_string(), src)
 }
 
+#[derive(Clone, Debug)]
+struct UnsupportedFixtureCase {
+    code: &'static str,
+    bad_fixture: &'static str,
+    fixed_fixture: &'static str,
+    expected_fixed_routes: Vec<(&'static str, &'static str, &'static str)>,
+}
+
 #[test]
 fn extracts_method_path_handler_from_shorthand_and_route_object() {
     let (file, src) = fixture("basic-fastify.fixture.txt");
@@ -544,4 +552,97 @@ fn emits_deterministic_diagnostics_and_skips_routes_in_if_blocks() {
         .diagnostics
         .iter()
         .all(|d| d.source.as_ref().map(|s| s.file.as_str()) == Some(file.as_str())));
+}
+
+#[test]
+fn fixture_matrix_for_fastify_unsupported_diagnostics_bad_and_fixed_pairs() {
+    let cases = vec![
+        UnsupportedFixtureCase {
+            code: "ANALYZER_UNSUPPORTED_CONDITIONAL_ROUTE",
+            bad_fixture: "fastify-unsupported-conditional-route.bad.fixture.txt",
+            fixed_fixture: "fastify-unsupported-conditional-route.fixed.fixture.txt",
+            expected_fixed_routes: vec![("GET", "/health", "health")],
+        },
+        UnsupportedFixtureCase {
+            code: "ANALYZER_UNSUPPORTED_REGISTER_CALLBACK",
+            bad_fixture: "fastify-unsupported-register-callback.bad.fixture.txt",
+            fixed_fixture: "fastify-unsupported-register-callback.fixed.fixture.txt",
+            expected_fixed_routes: vec![("GET", "/users", "listUsers")],
+        },
+        UnsupportedFixtureCase {
+            code: "ANALYZER_UNSUPPORTED_DYNAMIC_PATH",
+            bad_fixture: "fastify-unsupported-dynamic-path.bad.fixture.txt",
+            fixed_fixture: "fastify-unsupported-dynamic-path.fixed.fixture.txt",
+            expected_fixed_routes: vec![("GET", "/users/:id", "getUser")],
+        },
+        UnsupportedFixtureCase {
+            code: "ANALYZER_UNSUPPORTED_INLINE_HANDLER",
+            bad_fixture: "fastify-unsupported-inline-handler.bad.fixture.txt",
+            fixed_fixture: "fastify-unsupported-inline-handler.fixed.fixture.txt",
+            expected_fixed_routes: vec![("POST", "/users", "createUser")],
+        },
+        UnsupportedFixtureCase {
+            code: "ANALYZER_UNSUPPORTED_ROUTE_OBJECT_SHAPE",
+            bad_fixture: "fastify-unsupported-route-object-shape.bad.fixture.txt",
+            fixed_fixture: "fastify-unsupported-route-object-shape.fixed.fixture.txt",
+            expected_fixed_routes: vec![("GET", "/users", "listUsers")],
+        },
+        UnsupportedFixtureCase {
+            code: "ANALYZER_UNSUPPORTED_ROUTE_OBJECT_METHOD",
+            bad_fixture: "fastify-unsupported-route-object-method.bad.fixture.txt",
+            fixed_fixture: "fastify-unsupported-route-object-method.fixed.fixture.txt",
+            expected_fixed_routes: vec![("GET", "/users", "listUsers")],
+        },
+        UnsupportedFixtureCase {
+            code: "ANALYZER_UNSUPPORTED_DYNAMIC_PATH",
+            bad_fixture: "fastify-unsupported-route-object-path.bad.fixture.txt",
+            fixed_fixture: "fastify-unsupported-route-object-path.fixed.fixture.txt",
+            expected_fixed_routes: vec![("GET", "/users/:id", "getUser")],
+        },
+        UnsupportedFixtureCase {
+            code: "ANALYZER_UNSUPPORTED_INLINE_HANDLER",
+            bad_fixture: "fastify-unsupported-route-object-handler.bad.fixture.txt",
+            fixed_fixture: "fastify-unsupported-route-object-handler.fixed.fixture.txt",
+            expected_fixed_routes: vec![("POST", "/users", "createUser")],
+        },
+    ];
+
+    for case in cases {
+        let (bad_file, bad_src) = fixture(case.bad_fixture);
+        let bad_ir = analyze_fastify_entry(&bad_file, &bad_src);
+
+        let mut bad_codes = bad_ir
+            .diagnostics
+            .iter()
+            .map(|d| d.code.as_str())
+            .collect::<Vec<_>>();
+        bad_codes.sort();
+
+        assert_eq!(
+            bad_codes,
+            vec![case.code],
+            "unexpected diagnostics for bad fixture: {}",
+            case.bad_fixture,
+        );
+
+        let (fixed_file, fixed_src) = fixture(case.fixed_fixture);
+        let fixed_ir = analyze_fastify_entry(&fixed_file, &fixed_src);
+
+        assert_eq!(
+            fixed_ir
+                .routes
+                .iter()
+                .map(|r| (r.method.as_str(), r.path.as_str(), r.handler_ref.as_str()))
+                .collect::<Vec<_>>(),
+            case.expected_fixed_routes,
+            "route extraction drifted for fixed fixture: {}",
+            case.fixed_fixture,
+        );
+
+        assert!(
+            fixed_ir.diagnostics.is_empty(),
+            "fixed fixture should not emit diagnostics: {}",
+            case.fixed_fixture,
+        );
+    }
 }

--- a/packages/analyzer-rust/tests/fixtures/FASTIFY_UNSUPPORTED_FIXTURE_MATRIX.md
+++ b/packages/analyzer-rust/tests/fixtures/FASTIFY_UNSUPPORTED_FIXTURE_MATRIX.md
@@ -1,0 +1,44 @@
+# Fastify unsupported diagnostic fixture matrix
+
+This fixture set provides deterministic **bad/fixed pairs** for unsupported Fastify diagnostics.
+
+## Naming scheme
+
+- `fastify-unsupported-<topic>.bad.fixture.txt`
+- `fastify-unsupported-<topic>.fixed.fixture.txt`
+
+Where:
+- `<topic>` maps to one unsupported boundary (or a route-object variant of the same code).
+- `.bad.` fixture must emit one deterministic unsupported diagnostic.
+- `.fixed.` fixture must emit no diagnostics and should extract stable routes.
+
+## Pair mapping
+
+- `ANALYZER_UNSUPPORTED_CONDITIONAL_ROUTE`
+  - `fastify-unsupported-conditional-route.bad.fixture.txt`
+  - `fastify-unsupported-conditional-route.fixed.fixture.txt`
+- `ANALYZER_UNSUPPORTED_REGISTER_CALLBACK`
+  - `fastify-unsupported-register-callback.bad.fixture.txt`
+  - `fastify-unsupported-register-callback.fixed.fixture.txt`
+- `ANALYZER_UNSUPPORTED_DYNAMIC_PATH` (shorthand)
+  - `fastify-unsupported-dynamic-path.bad.fixture.txt`
+  - `fastify-unsupported-dynamic-path.fixed.fixture.txt`
+- `ANALYZER_UNSUPPORTED_INLINE_HANDLER` (shorthand)
+  - `fastify-unsupported-inline-handler.bad.fixture.txt`
+  - `fastify-unsupported-inline-handler.fixed.fixture.txt`
+- `ANALYZER_UNSUPPORTED_ROUTE_OBJECT_SHAPE`
+  - `fastify-unsupported-route-object-shape.bad.fixture.txt`
+  - `fastify-unsupported-route-object-shape.fixed.fixture.txt`
+- `ANALYZER_UNSUPPORTED_ROUTE_OBJECT_METHOD`
+  - `fastify-unsupported-route-object-method.bad.fixture.txt`
+  - `fastify-unsupported-route-object-method.fixed.fixture.txt`
+- `ANALYZER_UNSUPPORTED_DYNAMIC_PATH` (route object)
+  - `fastify-unsupported-route-object-path.bad.fixture.txt`
+  - `fastify-unsupported-route-object-path.fixed.fixture.txt`
+- `ANALYZER_UNSUPPORTED_INLINE_HANDLER` (route object)
+  - `fastify-unsupported-route-object-handler.bad.fixture.txt`
+  - `fastify-unsupported-route-object-handler.fixed.fixture.txt`
+
+The matrix is consumed by:
+- `packages/analyzer-rust/tests/fastify_ast_analyzer.rs`
+  - `fixture_matrix_for_fastify_unsupported_diagnostics_bad_and_fixed_pairs`

--- a/packages/analyzer-rust/tests/fixtures/fastify-unsupported-conditional-route.bad.fixture.txt
+++ b/packages/analyzer-rust/tests/fixtures/fastify-unsupported-conditional-route.bad.fixture.txt
@@ -1,0 +1,9 @@
+import Fastify from "fastify";
+
+const fastify = Fastify();
+
+function health() {}
+
+if (process.env.NODE_ENV === "development") {
+  fastify.get("/health", health);
+}

--- a/packages/analyzer-rust/tests/fixtures/fastify-unsupported-conditional-route.fixed.fixture.txt
+++ b/packages/analyzer-rust/tests/fixtures/fastify-unsupported-conditional-route.fixed.fixture.txt
@@ -1,0 +1,7 @@
+import Fastify from "fastify";
+
+const fastify = Fastify();
+
+function health() {}
+
+fastify.get("/health", health);

--- a/packages/analyzer-rust/tests/fixtures/fastify-unsupported-dynamic-path.bad.fixture.txt
+++ b/packages/analyzer-rust/tests/fixtures/fastify-unsupported-dynamic-path.bad.fixture.txt
@@ -1,0 +1,8 @@
+import Fastify from "fastify";
+
+const fastify = Fastify();
+const dynamicPath = "/users/:id";
+
+function getUser() {}
+
+fastify.get(dynamicPath, getUser);

--- a/packages/analyzer-rust/tests/fixtures/fastify-unsupported-dynamic-path.fixed.fixture.txt
+++ b/packages/analyzer-rust/tests/fixtures/fastify-unsupported-dynamic-path.fixed.fixture.txt
@@ -1,0 +1,7 @@
+import Fastify from "fastify";
+
+const fastify = Fastify();
+
+function getUser() {}
+
+fastify.get("/users/:id", getUser);

--- a/packages/analyzer-rust/tests/fixtures/fastify-unsupported-inline-handler.bad.fixture.txt
+++ b/packages/analyzer-rust/tests/fixtures/fastify-unsupported-inline-handler.bad.fixture.txt
@@ -1,0 +1,5 @@
+import Fastify from "fastify";
+
+const fastify = Fastify();
+
+fastify.post("/users", async () => {});

--- a/packages/analyzer-rust/tests/fixtures/fastify-unsupported-inline-handler.fixed.fixture.txt
+++ b/packages/analyzer-rust/tests/fixtures/fastify-unsupported-inline-handler.fixed.fixture.txt
@@ -1,0 +1,7 @@
+import Fastify from "fastify";
+
+const fastify = Fastify();
+
+async function createUser() {}
+
+fastify.post("/users", createUser);

--- a/packages/analyzer-rust/tests/fixtures/fastify-unsupported-register-callback.bad.fixture.txt
+++ b/packages/analyzer-rust/tests/fixtures/fastify-unsupported-register-callback.bad.fixture.txt
@@ -1,0 +1,12 @@
+import Fastify from "fastify";
+
+const fastify = Fastify();
+
+function listUsers() {}
+function makePlugin() {
+  return function usersPlugin(plugin: any) {
+    plugin.get("/users", listUsers);
+  };
+}
+
+fastify.register(makePlugin());

--- a/packages/analyzer-rust/tests/fixtures/fastify-unsupported-register-callback.fixed.fixture.txt
+++ b/packages/analyzer-rust/tests/fixtures/fastify-unsupported-register-callback.fixed.fixture.txt
@@ -1,0 +1,10 @@
+import Fastify from "fastify";
+
+const fastify = Fastify();
+
+function listUsers() {}
+function usersPlugin(plugin) {
+  plugin.get("/users", listUsers);
+}
+
+fastify.register(usersPlugin);

--- a/packages/analyzer-rust/tests/fixtures/fastify-unsupported-route-object-handler.bad.fixture.txt
+++ b/packages/analyzer-rust/tests/fixtures/fastify-unsupported-route-object-handler.bad.fixture.txt
@@ -1,0 +1,5 @@
+import Fastify from "fastify";
+
+const fastify = Fastify();
+
+fastify.route({ method: "POST", url: "/users", handler: async () => {} });

--- a/packages/analyzer-rust/tests/fixtures/fastify-unsupported-route-object-handler.fixed.fixture.txt
+++ b/packages/analyzer-rust/tests/fixtures/fastify-unsupported-route-object-handler.fixed.fixture.txt
@@ -1,0 +1,7 @@
+import Fastify from "fastify";
+
+const fastify = Fastify();
+
+async function createUser() {}
+
+fastify.route({ method: "POST", url: "/users", handler: createUser });

--- a/packages/analyzer-rust/tests/fixtures/fastify-unsupported-route-object-method.bad.fixture.txt
+++ b/packages/analyzer-rust/tests/fixtures/fastify-unsupported-route-object-method.bad.fixture.txt
@@ -1,0 +1,7 @@
+import Fastify from "fastify";
+
+const fastify = Fastify();
+
+function listUsers() {}
+
+fastify.route({ url: "/users", handler: listUsers });

--- a/packages/analyzer-rust/tests/fixtures/fastify-unsupported-route-object-method.fixed.fixture.txt
+++ b/packages/analyzer-rust/tests/fixtures/fastify-unsupported-route-object-method.fixed.fixture.txt
@@ -1,0 +1,7 @@
+import Fastify from "fastify";
+
+const fastify = Fastify();
+
+function listUsers() {}
+
+fastify.route({ method: "GET", url: "/users", handler: listUsers });

--- a/packages/analyzer-rust/tests/fixtures/fastify-unsupported-route-object-path.bad.fixture.txt
+++ b/packages/analyzer-rust/tests/fixtures/fastify-unsupported-route-object-path.bad.fixture.txt
@@ -1,0 +1,8 @@
+import Fastify from "fastify";
+
+const fastify = Fastify();
+const dynamicPath = "/users/:id";
+
+function getUser() {}
+
+fastify.route({ method: "GET", url: dynamicPath, handler: getUser });

--- a/packages/analyzer-rust/tests/fixtures/fastify-unsupported-route-object-path.fixed.fixture.txt
+++ b/packages/analyzer-rust/tests/fixtures/fastify-unsupported-route-object-path.fixed.fixture.txt
@@ -1,0 +1,7 @@
+import Fastify from "fastify";
+
+const fastify = Fastify();
+
+function getUser() {}
+
+fastify.route({ method: "GET", url: "/users/:id", handler: getUser });

--- a/packages/analyzer-rust/tests/fixtures/fastify-unsupported-route-object-shape.bad.fixture.txt
+++ b/packages/analyzer-rust/tests/fixtures/fastify-unsupported-route-object-shape.bad.fixture.txt
@@ -1,0 +1,8 @@
+import Fastify from "fastify";
+
+const fastify = Fastify();
+
+function listUsers() {}
+
+const routeDef = { method: "GET", url: "/users", handler: listUsers };
+fastify.route(routeDef);

--- a/packages/analyzer-rust/tests/fixtures/fastify-unsupported-route-object-shape.fixed.fixture.txt
+++ b/packages/analyzer-rust/tests/fixtures/fastify-unsupported-route-object-shape.fixed.fixture.txt
@@ -1,0 +1,7 @@
+import Fastify from "fastify";
+
+const fastify = Fastify();
+
+function listUsers() {}
+
+fastify.route({ method: "GET", url: "/users", handler: listUsers });


### PR DESCRIPTION
## Summary

Add a deterministic fixture matrix for Fastify unsupported diagnostics in analyzer-rust.

- Added bad/fixed fixture pairs for each Fastify unsupported diagnostic code.
- Introduced a documented naming scheme for unsupported fixture pairs.
- Added a deterministic matrix test that validates:
  - bad fixtures emit exactly the expected unsupported diagnostic code
  - fixed fixtures emit no diagnostics and extract stable routes
- Linked diagnostics spec to the fixture matrix documentation.

## Fixture matrix

| code | bad fixture | fixed fixture | test file |
|---|---|---|---|
| `ANALYZER_UNSUPPORTED_CONDITIONAL_ROUTE` | `fastify-unsupported-conditional-route.bad.fixture.txt` | `fastify-unsupported-conditional-route.fixed.fixture.txt` | `packages/analyzer-rust/tests/fastify_ast_analyzer.rs` |
| `ANALYZER_UNSUPPORTED_REGISTER_CALLBACK` | `fastify-unsupported-register-callback.bad.fixture.txt` | `fastify-unsupported-register-callback.fixed.fixture.txt` | `packages/analyzer-rust/tests/fastify_ast_analyzer.rs` |
| `ANALYZER_UNSUPPORTED_DYNAMIC_PATH` | `fastify-unsupported-dynamic-path.bad.fixture.txt` | `fastify-unsupported-dynamic-path.fixed.fixture.txt` | `packages/analyzer-rust/tests/fastify_ast_analyzer.rs` |
| `ANALYZER_UNSUPPORTED_INLINE_HANDLER` | `fastify-unsupported-inline-handler.bad.fixture.txt` | `fastify-unsupported-inline-handler.fixed.fixture.txt` | `packages/analyzer-rust/tests/fastify_ast_analyzer.rs` |
| `ANALYZER_UNSUPPORTED_ROUTE_OBJECT_SHAPE` | `fastify-unsupported-route-object-shape.bad.fixture.txt` | `fastify-unsupported-route-object-shape.fixed.fixture.txt` | `packages/analyzer-rust/tests/fastify_ast_analyzer.rs` |
| `ANALYZER_UNSUPPORTED_ROUTE_OBJECT_METHOD` | `fastify-unsupported-route-object-method.bad.fixture.txt` | `fastify-unsupported-route-object-method.fixed.fixture.txt` | `packages/analyzer-rust/tests/fastify_ast_analyzer.rs` |
| `ANALYZER_UNSUPPORTED_DYNAMIC_PATH` (route object variant) | `fastify-unsupported-route-object-path.bad.fixture.txt` | `fastify-unsupported-route-object-path.fixed.fixture.txt` | `packages/analyzer-rust/tests/fastify_ast_analyzer.rs` |
| `ANALYZER_UNSUPPORTED_INLINE_HANDLER` (route object variant) | `fastify-unsupported-route-object-handler.bad.fixture.txt` | `fastify-unsupported-route-object-handler.fixed.fixture.txt` | `packages/analyzer-rust/tests/fastify_ast_analyzer.rs` |

## Additional unsupported diagnostics

No additional `ANALYZER_UNSUPPORTED_*` Fastify diagnostics were found beyond those documented in `docs/specs/DIAGNOSTICS.md`.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run build`
- `pnpm run test`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --all-targets`
- `./scripts/smoke-m1.sh`