### PR TITLE
ci: gate fastify diagnostics docs sync with analyzer-rust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Biome format check
         run: pnpm run format:check
 
+      - name: Check diagnostics/docs sync
+        run: pnpm run docs:diagnostics:sync
+
       - name: Build
         run: pnpm run build
 

--- a/.pr-body-diagnostics-sync-gate.md
+++ b/.pr-body-diagnostics-sync-gate.md
@@ -1,0 +1,45 @@
+## Summary
+
+- add `scripts/check-fastify-diagnostics-sync.mjs` to validate docs/spec diagnostics against analyzer-rust `diag(...)` sources
+- add CI gate (`pnpm run docs:diagnostics:sync`) in `.github/workflows/ci.yml`
+- add managed docs inventory `docs/specs/FASTIFY_UNSUPPORTED_INVENTORY.md`
+- add auto-managed diagnostic message block in `docs/specs/DIAGNOSTICS.md`
+- add auto-managed diagnostic code list linkage block in `docs/specs/FASTIFY_SUPPORT_MATRIX.md`
+- add npm scripts:
+  - `docs:diagnostics:sync`
+  - `docs:diagnostics:sync:write`
+
+## Why
+
+Prevent drift between analyzer-rust diagnostic reality and spec docs, and fail fast in CI with actionable remediation steps.
+
+## Example failure output
+
+```text
+✖ Fastify diagnostics/docs sync check failed.
+
+- docs/specs/DIAGNOSTICS.md
+  Managed diagnostic-message block is out of sync with analyzer-rust.
+  Hint: run `node scripts/check-fastify-diagnostics-sync.mjs --write` then inspect git diff.
+- docs/specs/FASTIFY_UNSUPPORTED_INVENTORY.md
+  Inventory file does not match analyzer-rust diagnostics snapshot.
+  Hint: run `node scripts/check-fastify-diagnostics-sync.mjs --write`.
+
+Actionable next steps:
+  1) node scripts/check-fastify-diagnostics-sync.mjs --write
+  2) git diff docs/specs scripts/check-fastify-diagnostics-sync.mjs
+  3) pnpm run format && pnpm run format:check
+```
+
+## Validation run
+
+- `pnpm install --frozen-lockfile`
+- `pnpm run lint`
+- `pnpm run format:check`
+- `pnpm run docs:diagnostics:sync`
+- `pnpm run build`
+- `pnpm run test`
+- `cargo fmt --all --check`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo test --workspace --all-targets`
+- `./scripts/smoke-m1.sh`

--- a/docs/specs/DIAGNOSTICS.md
+++ b/docs/specs/DIAGNOSTICS.md
@@ -13,6 +13,26 @@ The following codes are emitted when Fastify route extraction cannot proceed det
 
 ---
 
+## Canonical diagnostic messages (verbatim)
+
+These lines are managed by `scripts/check-fastify-diagnostics-sync.mjs` and must match `packages/analyzer-rust` exactly.
+
+<!-- AUTO-GENERATED:DIAGNOSTIC_MESSAGES:START -->
+- `ANALYZER_UNRESOLVED_PLUGIN`: `register plugin '{}' could not be resolved in current file. Ensure plugin is declared in the same file or use an inline callback.`
+- `ANALYZER_UNSUPPORTED_CONDITIONAL_ROUTE`: `conditional route registration in if-block is unsupported for deterministic extraction ({}.{}(...)). Move route declaration to top-level plugin scope.`
+- `ANALYZER_UNSUPPORTED_DYNAMIC_PATH`: `unsupported dynamic path in {}.{}(...). Use string literal path (e.g. '/users/:id') for IR extraction.`
+- `ANALYZER_UNSUPPORTED_DYNAMIC_PATH`: `unsupported route object path in {}.route({{...}}). Provide string literal 'url' or 'path' (e.g. '/users/:id').`
+- `ANALYZER_UNSUPPORTED_INLINE_HANDLER`: `unsupported non-reference handler in {}.{}('{}', handler). Extract handler to a named function and pass its identifier.`
+- `ANALYZER_UNSUPPORTED_INLINE_HANDLER`: `unsupported route object handler in {}.route({{...}}). Provide named handler reference in 'handler' field.`
+- `ANALYZER_UNSUPPORTED_REGISTER_CALLBACK`: `unsupported register callback pattern on {}.register(...). Use inline function(plugin) {{ ... }} or named local plugin reference.`
+- `ANALYZER_UNSUPPORTED_ROUTE_OBJECT_METHOD`: `unsupported route object method in {}.route({{...}}): '{}'. Supported methods: GET|POST|PUT|DELETE|PATCH.`
+- `ANALYZER_UNSUPPORTED_ROUTE_OBJECT_METHOD`: `unsupported route object method in {}.route({{...}}): missing string 'method' or non-empty string array. Supported methods: GET|POST|PUT|DELETE|PATCH.`
+- `ANALYZER_UNSUPPORTED_ROUTE_OBJECT_SHAPE`: `unsupported route object pattern in {}.route(...). Provide an inline object literal (e.g. {{ method: 'GET', url: '/users', handler: listUsers }}).`
+- `DYNAMIC_IMPORT_DETECTED`: `dynamic import detected; use static import declarations for deterministic IR extraction.`
+<!-- AUTO-GENERATED:DIAGNOSTIC_MESSAGES:END -->
+
+---
+
 ### `ANALYZER_UNSUPPORTED_CONDITIONAL_ROUTE`
 
 **Current message shape**
@@ -239,3 +259,65 @@ Naming convention:
 
 These pairs are consumed by `packages/analyzer-rust/tests/fastify_ast_analyzer.rs` in
 `fixture_matrix_for_fastify_unsupported_diagnostics_bad_and_fixed_pairs`.
+
+---
+
+### `ANALYZER_UNRESOLVED_PLUGIN`
+
+**Current message shape**
+
+`register plugin '<pluginRef>' could not be resolved in current file. Ensure plugin is declared in the same file or use an inline callback.`
+
+**Bad**
+
+```ts
+import usersPlugin from "./users-plugin";
+fastify.register(usersPlugin);
+```
+
+**Fixed**
+
+```ts
+function usersPlugin(plugin: any) {
+  plugin.get("/users", listUsers);
+}
+
+fastify.register(usersPlugin);
+```
+
+_or_
+
+```ts
+fastify.register(function (plugin) {
+  plugin.get("/users", listUsers);
+});
+```
+
+**Rationale**
+
+Current plugin resolution is file-local for deterministic static extraction.
+
+---
+
+### `DYNAMIC_IMPORT_DETECTED`
+
+**Current message shape**
+
+`dynamic import detected; use static import declarations for deterministic IR extraction.`
+
+**Bad**
+
+```ts
+const moduleName = "./plugin";
+const plugin = await import(moduleName);
+```
+
+**Fixed**
+
+```ts
+import * as plugin from "./plugin";
+```
+
+**Rationale**
+
+Dynamic imports can alter module graph resolution at runtime and break deterministic analysis.

--- a/docs/specs/FASTIFY_SUPPORT_MATRIX.md
+++ b/docs/specs/FASTIFY_SUPPORT_MATRIX.md
@@ -228,6 +228,21 @@ If feature gating is needed, keep route declaration deterministic and gate behav
 
 ## 4) Governance
 
+### 4.1 Diagnostic code inventory linkage
+
+The full code+message inventory is maintained in `docs/specs/FASTIFY_UNSUPPORTED_INVENTORY.md`.
+
+<!-- AUTO-GENERATED:DIAGNOSTIC_CODES:START -->
+- `ANALYZER_UNRESOLVED_PLUGIN`
+- `ANALYZER_UNSUPPORTED_CONDITIONAL_ROUTE`
+- `ANALYZER_UNSUPPORTED_DYNAMIC_PATH`
+- `ANALYZER_UNSUPPORTED_INLINE_HANDLER`
+- `ANALYZER_UNSUPPORTED_REGISTER_CALLBACK`
+- `ANALYZER_UNSUPPORTED_ROUTE_OBJECT_METHOD`
+- `ANALYZER_UNSUPPORTED_ROUTE_OBJECT_SHAPE`
+- `DYNAMIC_IMPORT_DETECTED`
+<!-- AUTO-GENERATED:DIAGNOSTIC_CODES:END -->
+
 - This file is the **single source of truth** for Fastify analyzer mapping status.
 - If extractor behavior changes, update this file in the same PR as tests/implementation.
 - Keep diagnostic code spellings exact and stable.

--- a/docs/specs/FASTIFY_UNSUPPORTED_INVENTORY.md
+++ b/docs/specs/FASTIFY_UNSUPPORTED_INVENTORY.md
@@ -1,0 +1,24 @@
+# FASTIFY_UNSUPPORTED_INVENTORY
+
+Canonical inventory of diagnostics emitted by `packages/analyzer-rust` (codes + verbatim message templates).
+
+This file is auto-managed by `scripts/check-fastify-diagnostics-sync.mjs`.
+
+| Code | Message template (verbatim) | Source file(s) |
+| --- | --- | --- |
+| `ANALYZER_UNRESOLVED_PLUGIN` | `register plugin '{}' could not be resolved in current file. Ensure plugin is declared in the same file or use an inline callback.` | `packages/analyzer-rust/src/register.rs` |
+| `ANALYZER_UNSUPPORTED_CONDITIONAL_ROUTE` | `conditional route registration in if-block is unsupported for deterministic extraction ({}.{}(...)). Move route declaration to top-level plugin scope.` | `packages/analyzer-rust/src/traversal.rs` |
+| `ANALYZER_UNSUPPORTED_DYNAMIC_PATH` | `unsupported dynamic path in {}.{}(...). Use string literal path (e.g. '/users/:id') for IR extraction.` | `packages/analyzer-rust/src/routes.rs` |
+| `ANALYZER_UNSUPPORTED_DYNAMIC_PATH` | `unsupported route object path in {}.route({{...}}). Provide string literal 'url' or 'path' (e.g. '/users/:id').` | `packages/analyzer-rust/src/routes.rs` |
+| `ANALYZER_UNSUPPORTED_INLINE_HANDLER` | `unsupported non-reference handler in {}.{}('{}', handler). Extract handler to a named function and pass its identifier.` | `packages/analyzer-rust/src/routes.rs` |
+| `ANALYZER_UNSUPPORTED_INLINE_HANDLER` | `unsupported route object handler in {}.route({{...}}). Provide named handler reference in 'handler' field.` | `packages/analyzer-rust/src/routes.rs` |
+| `ANALYZER_UNSUPPORTED_REGISTER_CALLBACK` | `unsupported register callback pattern on {}.register(...). Use inline function(plugin) {{ ... }} or named local plugin reference.` | `packages/analyzer-rust/src/register.rs` |
+| `ANALYZER_UNSUPPORTED_ROUTE_OBJECT_METHOD` | `unsupported route object method in {}.route({{...}}): '{}'. Supported methods: GET\|POST\|PUT\|DELETE\|PATCH.` | `packages/analyzer-rust/src/routes.rs` |
+| `ANALYZER_UNSUPPORTED_ROUTE_OBJECT_METHOD` | `unsupported route object method in {}.route({{...}}): missing string 'method' or non-empty string array. Supported methods: GET\|POST\|PUT\|DELETE\|PATCH.` | `packages/analyzer-rust/src/routes.rs` |
+| `ANALYZER_UNSUPPORTED_ROUTE_OBJECT_SHAPE` | `unsupported route object pattern in {}.route(...). Provide an inline object literal (e.g. {{ method: 'GET', url: '/users', handler: listUsers }}).` | `packages/analyzer-rust/src/routes.rs` |
+| `DYNAMIC_IMPORT_DETECTED` | `dynamic import detected; use static import declarations for deterministic IR extraction.` | `packages/analyzer-rust/src/lib.rs` |
+
+## Regeneration
+
+- Check only: `node scripts/check-fastify-diagnostics-sync.mjs`
+- Rewrite docs blocks + inventory: `node scripts/check-fastify-diagnostics-sync.mjs --write`

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "format": "biome format --write .",
     "gate:m1": "./scripts/m1-release-gate.sh",
     "perf:baseline": "tsx scripts/perf-baseline.ts",
-    "devx:fastify-complex": "./scripts/devx-fastify-complex.sh"
+    "devx:fastify-complex": "./scripts/devx-fastify-complex.sh",
+    "docs:diagnostics:sync": "node scripts/check-fastify-diagnostics-sync.mjs",
+    "docs:diagnostics:sync:write": "node scripts/check-fastify-diagnostics-sync.mjs --write"
   },
   "devDependencies": {
     "@types/node": "^24.3.0",

--- a/scripts/check-fastify-diagnostics-sync.mjs
+++ b/scripts/check-fastify-diagnostics-sync.mjs
@@ -1,0 +1,323 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from "node:fs";
+import { globSync } from "node:fs";
+import path from "node:path";
+
+const repoRoot = process.cwd();
+const rustGlob = "packages/analyzer-rust/src/**/*.rs";
+const diagnosticsDocPath = path.join(repoRoot, "docs/specs/DIAGNOSTICS.md");
+const matrixDocPath = path.join(
+  repoRoot,
+  "docs/specs/FASTIFY_SUPPORT_MATRIX.md",
+);
+const inventoryDocPath = path.join(
+  repoRoot,
+  "docs/specs/FASTIFY_UNSUPPORTED_INVENTORY.md",
+);
+
+const WRITE = process.argv.includes("--write");
+
+const diagnosticsBlockMarkers = {
+  start: "<!-- AUTO-GENERATED:DIAGNOSTIC_MESSAGES:START -->",
+  end: "<!-- AUTO-GENERATED:DIAGNOSTIC_MESSAGES:END -->",
+};
+
+const matrixCodesMarkers = {
+  start: "<!-- AUTO-GENERATED:DIAGNOSTIC_CODES:START -->",
+  end: "<!-- AUTO-GENERATED:DIAGNOSTIC_CODES:END -->",
+};
+
+function splitTopLevelArgs(input) {
+  const out = [];
+  let buf = "";
+  let depthParen = 0;
+  let depthBrace = 0;
+  let depthBracket = 0;
+  let inString = false;
+  let quote = "";
+  let escaping = false;
+
+  for (const ch of input) {
+    buf += ch;
+
+    if (inString) {
+      if (escaping) {
+        escaping = false;
+      } else if (ch === "\\") {
+        escaping = true;
+      } else if (ch === quote) {
+        inString = false;
+        quote = "";
+      }
+      continue;
+    }
+
+    if (ch === '"' || ch === "'") {
+      inString = true;
+      quote = ch;
+      continue;
+    }
+
+    if (ch === "(") depthParen += 1;
+    else if (ch === ")") depthParen -= 1;
+    else if (ch === "{") depthBrace += 1;
+    else if (ch === "}") depthBrace -= 1;
+    else if (ch === "[") depthBracket += 1;
+    else if (ch === "]") depthBracket -= 1;
+
+    if (
+      ch === "," &&
+      depthParen === 0 &&
+      depthBrace === 0 &&
+      depthBracket === 0
+    ) {
+      out.push(buf.slice(0, -1).trim());
+      buf = "";
+    }
+  }
+
+  if (buf.trim()) out.push(buf.trim());
+  return out;
+}
+
+function decodeRustStringLiteral(lit) {
+  const trimmed = lit.trim();
+  const match = trimmed.match(/^"([\s\S]*)"$/);
+  if (!match) return trimmed;
+  return JSON.parse(
+    `"${match[1].replace(/\\/g, "\\\\").replace(/\"/g, '\\"')}"`,
+  )
+    .replace(/\\n/g, "\n")
+    .replace(/\\t/g, "\t");
+}
+
+function extractMessageTemplate(messageExpr) {
+  const expr = messageExpr.trim();
+  if (expr.startsWith("&format!(") || expr.startsWith("format!(")) {
+    const firstQuote = expr.indexOf('"');
+    if (firstQuote === -1) return expr;
+    let i = firstQuote + 1;
+    let escaped = false;
+    while (i < expr.length) {
+      const ch = expr[i];
+      if (escaped) {
+        escaped = false;
+      } else if (ch === "\\") {
+        escaped = true;
+      } else if (ch === '"') {
+        break;
+      }
+      i += 1;
+    }
+    return decodeRustStringLiteral(expr.slice(firstQuote, i + 1));
+  }
+  return decodeRustStringLiteral(expr);
+}
+
+function extractDiagCalls(content) {
+  const entries = [];
+  let i = 0;
+  while (i < content.length) {
+    const start = content.indexOf("diag(", i);
+    if (start === -1) break;
+
+    let j = start + "diag(".length;
+    let depth = 1;
+    let inString = false;
+    let quote = "";
+    let escaping = false;
+
+    while (j < content.length && depth > 0) {
+      const ch = content[j];
+      if (inString) {
+        if (escaping) {
+          escaping = false;
+        } else if (ch === "\\") {
+          escaping = true;
+        } else if (ch === quote) {
+          inString = false;
+          quote = "";
+        }
+      } else if (ch === '"' || ch === "'") {
+        inString = true;
+        quote = ch;
+      } else if (ch === "(") {
+        depth += 1;
+      } else if (ch === ")") {
+        depth -= 1;
+      }
+      j += 1;
+    }
+
+    const inner = content.slice(start + "diag(".length, j - 1);
+    const args = splitTopLevelArgs(inner);
+    if (args.length >= 3) {
+      const code = decodeRustStringLiteral(args[1]);
+      if (!/^[A-Z][A-Z0-9_]+$/.test(code)) {
+        i = j;
+        continue;
+      }
+      const message = extractMessageTemplate(args[2]);
+      entries.push({ code, message });
+    }
+    i = j;
+  }
+  return entries;
+}
+
+function normalizeDocsCode(s) {
+  return s.replace(/\r\n/g, "\n");
+}
+
+function replaceManagedBlock(content, markers, replacementBody) {
+  const startIdx = content.indexOf(markers.start);
+  const endIdx = content.indexOf(markers.end);
+  if (startIdx === -1 || endIdx === -1 || endIdx < startIdx) {
+    throw new Error(
+      `Missing managed block markers: ${markers.start} ... ${markers.end}`,
+    );
+  }
+  const before = content.slice(0, startIdx + markers.start.length);
+  const after = content.slice(endIdx);
+  return `${before}\n${replacementBody.trimEnd()}\n${after}`;
+}
+
+const rustFiles = globSync(rustGlob, { cwd: repoRoot });
+if (rustFiles.length === 0) {
+  console.error(`No Rust files found for glob: ${rustGlob}`);
+  process.exit(1);
+}
+
+const variantMap = new Map();
+for (const rel of rustFiles) {
+  const abs = path.join(repoRoot, rel);
+  const text = readFileSync(abs, "utf8");
+  const calls = extractDiagCalls(text);
+  for (const call of calls) {
+    const key = `${call.code}::${call.message}`;
+    if (!variantMap.has(key)) {
+      variantMap.set(key, { ...call, sources: [rel] });
+    } else {
+      variantMap.get(key).sources.push(rel);
+    }
+  }
+}
+
+const diagnostics = [...variantMap.values()].sort((a, b) => {
+  if (a.code !== b.code) return a.code.localeCompare(b.code);
+  return a.message.localeCompare(b.message);
+});
+
+const uniqueCodes = [...new Set(diagnostics.map((d) => d.code))].sort();
+
+const diagBody = diagnostics
+  .map((d) => `- \`${d.code}\`: \`${d.message}\``)
+  .join("\n");
+
+const matrixCodesBody = uniqueCodes.map((code) => `- \`${code}\``).join("\n");
+
+const inventoryLines = [
+  "# FASTIFY_UNSUPPORTED_INVENTORY",
+  "",
+  "Canonical inventory of diagnostics emitted by `packages/analyzer-rust` (codes + verbatim message templates).",
+  "",
+  "This file is auto-managed by `scripts/check-fastify-diagnostics-sync.mjs`.",
+  "",
+  "| Code | Message template (verbatim) | Source file(s) |",
+  "| --- | --- | --- |",
+  ...diagnostics.map((d) => {
+    const src = [...new Set(d.sources)].sort().join(", ");
+    const msg = d.message.replace(/\|/g, "\\|");
+    return `| \`${d.code}\` | \`${msg}\` | \`${src}\` |`;
+  }),
+  "",
+  "## Regeneration",
+  "",
+  "- Check only: `node scripts/check-fastify-diagnostics-sync.mjs`",
+  "- Rewrite docs blocks + inventory: `node scripts/check-fastify-diagnostics-sync.mjs --write`",
+  "",
+].join("\n");
+
+const diagnosticsDoc = normalizeDocsCode(
+  readFileSync(diagnosticsDocPath, "utf8"),
+);
+const matrixDoc = normalizeDocsCode(readFileSync(matrixDocPath, "utf8"));
+const currentInventory = (() => {
+  try {
+    return normalizeDocsCode(readFileSync(inventoryDocPath, "utf8"));
+  } catch {
+    return "";
+  }
+})();
+
+const desiredDiagnosticsDoc = replaceManagedBlock(
+  diagnosticsDoc,
+  diagnosticsBlockMarkers,
+  diagBody,
+);
+const desiredMatrixDoc = replaceManagedBlock(
+  matrixDoc,
+  matrixCodesMarkers,
+  matrixCodesBody,
+);
+const desiredInventory = `${inventoryLines}`;
+
+const problems = [];
+
+function recordMismatch(label, hintLines) {
+  problems.push({ label, hintLines });
+}
+
+if (desiredDiagnosticsDoc !== diagnosticsDoc) {
+  if (WRITE) {
+    writeFileSync(diagnosticsDocPath, desiredDiagnosticsDoc, "utf8");
+  } else {
+    recordMismatch("docs/specs/DIAGNOSTICS.md", [
+      "Managed diagnostic-message block is out of sync with analyzer-rust.",
+      "Hint: run `node scripts/check-fastify-diagnostics-sync.mjs --write` then inspect git diff.",
+    ]);
+  }
+}
+
+if (desiredMatrixDoc !== matrixDoc) {
+  if (WRITE) {
+    writeFileSync(matrixDocPath, desiredMatrixDoc, "utf8");
+  } else {
+    recordMismatch("docs/specs/FASTIFY_SUPPORT_MATRIX.md", [
+      "Managed diagnostic-code list is out of sync with analyzer-rust.",
+      "Hint: run `node scripts/check-fastify-diagnostics-sync.mjs --write` and ensure each code is documented in context.",
+    ]);
+  }
+}
+
+if (desiredInventory !== currentInventory) {
+  if (WRITE) {
+    writeFileSync(inventoryDocPath, desiredInventory, "utf8");
+  } else {
+    recordMismatch("docs/specs/FASTIFY_UNSUPPORTED_INVENTORY.md", [
+      "Inventory file does not match analyzer-rust diagnostics snapshot.",
+      "Hint: run `node scripts/check-fastify-diagnostics-sync.mjs --write`.",
+    ]);
+  }
+}
+
+if (problems.length > 0) {
+  console.error("✖ Fastify diagnostics/docs sync check failed.\n");
+  for (const problem of problems) {
+    console.error(`- ${problem.label}`);
+    for (const hint of problem.hintLines) {
+      console.error(`  ${hint}`);
+    }
+  }
+  console.error("\nActionable next steps:");
+  console.error("  1) node scripts/check-fastify-diagnostics-sync.mjs --write");
+  console.error(
+    "  2) git diff docs/specs scripts/check-fastify-diagnostics-sync.mjs",
+  );
+  console.error("  3) pnpm run format && pnpm run format:check");
+  process.exit(1);
+}
+
+console.log(
+  `✔ Fastify diagnostics/docs are in sync (${uniqueCodes.length} codes, ${diagnostics.length} message variants).`,
+);


### PR DESCRIPTION
## Summary

- add `scripts/check-fastify-diagnostics-sync.mjs` to validate docs/spec diagnostics against analyzer-rust `diag(...)` sources
- add CI gate (`pnpm run docs:diagnostics:sync`) in `.github/workflows/ci.yml`
- add managed docs inventory `docs/specs/FASTIFY_UNSUPPORTED_INVENTORY.md`
- add auto-managed diagnostic message block in `docs/specs/DIAGNOSTICS.md`
- add auto-managed diagnostic code list linkage block in `docs/specs/FASTIFY_SUPPORT_MATRIX.md`
- add npm scripts:
  - `docs:diagnostics:sync`
  - `docs:diagnostics:sync:write`

## Why

Prevent drift between analyzer-rust diagnostic reality and spec docs, and fail fast in CI with actionable remediation steps.

## Example failure output

```text
✖ Fastify diagnostics/docs sync check failed.

- docs/specs/DIAGNOSTICS.md
  Managed diagnostic-message block is out of sync with analyzer-rust.
  Hint: run `node scripts/check-fastify-diagnostics-sync.mjs --write` then inspect git diff.
- docs/specs/FASTIFY_UNSUPPORTED_INVENTORY.md
  Inventory file does not match analyzer-rust diagnostics snapshot.
  Hint: run `node scripts/check-fastify-diagnostics-sync.mjs --write`.

Actionable next steps:
  1) node scripts/check-fastify-diagnostics-sync.mjs --write
  2) git diff docs/specs scripts/check-fastify-diagnostics-sync.mjs
  3) pnpm run format && pnpm run format:check
```

## Validation run

- `pnpm install --frozen-lockfile`
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run docs:diagnostics:sync`
- `pnpm run build`
- `pnpm run test`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --all-targets`
- `./scripts/smoke-m1.sh`