### PR TITLE
feat(ci): enforce Fastify support-state transitions in docs sync gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Biome format check
         run: pnpm run format:check
 
-      - name: Check diagnostics/docs sync
+      - name: Check diagnostics/docs sync + support-state coherence
         run: pnpm run docs:diagnostics:sync
 
       - name: Build

--- a/docs/specs/FASTIFY_SUPPORT_MATRIX.md
+++ b/docs/specs/FASTIFY_SUPPORT_MATRIX.md
@@ -238,6 +238,58 @@ fastify.get('/beta', betaHandler)
 
 If feature gating is needed, keep route declaration deterministic and gate behavior inside handler/service logic.
 
+## 3.6 `ANALYZER_UNSUPPORTED_REGISTER_CALLBACK`
+
+When it triggers:
+- `.register(...)` callback/plugin reference is not an inline function or same-file named plugin reference resolvable by analyzer.
+
+Why unsupported:
+- Current plugin resolution boundary is intentionally static and file-local.
+
+Recommended rewrite:
+
+```ts
+// ❌ unsupported
+const pluginFactory = makePlugin()
+fastify.register(pluginFactory)
+
+// ✅ supported
+function usersPlugin(plugin) {
+  plugin.get('/users', listUsers)
+}
+fastify.register(usersPlugin)
+```
+
+or
+
+```ts
+fastify.register(function (plugin) {
+  plugin.get('/users', listUsers)
+})
+```
+
+## 3.7 `ANALYZER_UNRESOLVED_PLUGIN`
+
+When it triggers:
+- `register(<pluginRef>)` references a plugin not declared/resolvable in the same file under current static analysis boundary.
+
+Why unsupported:
+- Cross-file/dynamic plugin resolution is currently outside deterministic extraction scope.
+
+Recommended rewrite:
+
+```ts
+// ❌ unsupported
+import usersPlugin from './users-plugin'
+fastify.register(usersPlugin)
+
+// ✅ supported (current boundary)
+function usersPlugin(plugin) {
+  plugin.get('/users', listUsers)
+}
+fastify.register(usersPlugin)
+```
+
 ---
 
 ## 4) Governance

--- a/scripts/check-fastify-diagnostics-sync.mjs
+++ b/scripts/check-fastify-diagnostics-sync.mjs
@@ -182,6 +182,21 @@ function replaceManagedBlock(content, markers, replacementBody) {
   return `${before}\n${replacementBody.trimEnd()}\n${after}`;
 }
 
+function listBacktickedCodes(content, regex) {
+  const out = [];
+  for (const match of content.matchAll(regex)) {
+    const code = match[1];
+    if (code && /^[A-Z][A-Z0-9_]+$/.test(code)) {
+      out.push(code);
+    }
+  }
+  return [...new Set(out)].sort();
+}
+
+function formatCodeList(codes) {
+  return codes.map((code) => `\`${code}\``).join(", ");
+}
+
 const rustFiles = globSync(rustGlob, { cwd: repoRoot });
 if (rustFiles.length === 0) {
   console.error(`No Rust files found for glob: ${rustGlob}`);
@@ -299,6 +314,70 @@ if (desiredInventory !== currentInventory) {
       "Hint: run `node scripts/check-fastify-diagnostics-sync.mjs --write`.",
     ]);
   }
+}
+
+const analyzerUnsupportedCodes = new Set(
+  uniqueCodes.filter((code) => code.startsWith("ANALYZER_")),
+);
+const matrixUnsupportedCodes = new Set(
+  listBacktickedCodes(
+    matrixDoc,
+    /^##\s+3\.\d+\s+`([A-Z][A-Z0-9_]+)`\s*$/gm,
+  ).filter((code) => code.startsWith("ANALYZER_")),
+);
+const diagnosticsUnsupportedCodes = new Set(
+  listBacktickedCodes(
+    diagnosticsDoc,
+    /^###\s+`([A-Z][A-Z0-9_]+)`\s*$/gm,
+  ).filter((code) => code.startsWith("ANALYZER_")),
+);
+
+const transitionedToSupported = [...matrixUnsupportedCodes]
+  .filter((code) => !analyzerUnsupportedCodes.has(code))
+  .sort();
+const transitionedToSupportedInDiagnostics = [...diagnosticsUnsupportedCodes]
+  .filter((code) => !analyzerUnsupportedCodes.has(code))
+  .sort();
+
+const transitionedToUnsupportedMissingInMatrix = [...analyzerUnsupportedCodes]
+  .filter((code) => !matrixUnsupportedCodes.has(code))
+  .sort();
+const transitionedToUnsupportedMissingInDiagnostics = [
+  ...analyzerUnsupportedCodes,
+]
+  .filter((code) => !diagnosticsUnsupportedCodes.has(code))
+  .sort();
+
+if (
+  transitionedToSupported.length > 0 ||
+  transitionedToSupportedInDiagnostics.length > 0 ||
+  transitionedToUnsupportedMissingInMatrix.length > 0 ||
+  transitionedToUnsupportedMissingInDiagnostics.length > 0
+) {
+  recordMismatch("support-status coherence (matrix/diagnostics/inventory)", [
+    "Detected unsupported↔supported state drift across docs/specs/FASTIFY_SUPPORT_MATRIX.md, docs/specs/DIAGNOSTICS.md, and docs/specs/FASTIFY_UNSUPPORTED_INVENTORY.md.",
+    ...(transitionedToSupported.length > 0
+      ? [
+          `FASTIFY_SUPPORT_MATRIX still marks these as unsupported, but analyzer no longer emits them (likely unsupported -> supported): ${formatCodeList(transitionedToSupported)}.`,
+        ]
+      : []),
+    ...(transitionedToSupportedInDiagnostics.length > 0
+      ? [
+          `DIAGNOSTICS still documents these unsupported sections, but analyzer no longer emits them (likely unsupported -> supported): ${formatCodeList(transitionedToSupportedInDiagnostics)}.`,
+        ]
+      : []),
+    ...(transitionedToUnsupportedMissingInMatrix.length > 0
+      ? [
+          `Analyzer emits these unsupported diagnostics, but FASTIFY_SUPPORT_MATRIX has no unsupported section for them (likely supported -> unsupported): ${formatCodeList(transitionedToUnsupportedMissingInMatrix)}.`,
+        ]
+      : []),
+    ...(transitionedToUnsupportedMissingInDiagnostics.length > 0
+      ? [
+          `Analyzer emits these unsupported diagnostics, but DIAGNOSTICS has no dedicated section for them (likely supported -> unsupported): ${formatCodeList(transitionedToUnsupportedMissingInDiagnostics)}.`,
+        ]
+      : []),
+    "Remediation: when support status changes, update section 3.x in FASTIFY_SUPPORT_MATRIX and add/remove matching `### ` code sections in DIAGNOSTICS in the same PR.",
+  ]);
 }
 
 if (problems.length > 0) {


### PR DESCRIPTION
## Summary
- extend `scripts/check-fastify-diagnostics-sync.mjs` to validate **support-state coherence** (not just message/code parity)
- detect status drift across:
  - `docs/specs/FASTIFY_SUPPORT_MATRIX.md`
  - `docs/specs/DIAGNOSTICS.md`
  - `docs/specs/FASTIFY_UNSUPPORTED_INVENTORY.md`
- improve CI clarity by renaming the gate step to include support-state coherence
- fill missing Fastify unsupported sections in `FASTIFY_SUPPORT_MATRIX.md` for:
  - `ANALYZER_UNSUPPORTED_REGISTER_CALLBACK`
  - `ANALYZER_UNRESOLVED_PLUGIN`

## What the new gate enforces
For Fastify analyzer diagnostics (`ANALYZER_*`):
- if analyzer emits an unsupported code, both docs must have matching unsupported sections
  - Matrix section header format: `## 3.x \`CODE\``
  - Diagnostics section header format: `### \`CODE\``
- if docs still claim a code is unsupported but analyzer no longer emits it, fail with explicit unsupported -> supported drift output

## Sample failure output
```text
✖ Fastify diagnostics/docs sync check failed.

- support-status coherence (matrix/diagnostics/inventory)
  Detected unsupported↔supported state drift across docs/specs/FASTIFY_SUPPORT_MATRIX.md, docs/specs/DIAGNOSTICS.md, and docs/specs/FASTIFY_UNSUPPORTED_INVENTORY.md.
  Analyzer emits these unsupported diagnostics, but FASTIFY_SUPPORT_MATRIX has no unsupported section for them (likely supported -> unsupported): `ANALYZER_UNRESOLVED_PLUGIN`, `ANALYZER_UNSUPPORTED_REGISTER_CALLBACK`.
  Remediation: when support status changes, update section 3.x in FASTIFY_SUPPORT_MATRIX and add/remove matching `### ` code sections in DIAGNOSTICS in the same PR.
```

## Remediation steps
1. Run:
   - `node scripts/check-fastify-diagnostics-sync.mjs --write`
2. Update support-status docs in same PR:
   - add/remove `## 3.x \`CODE\`` in `FASTIFY_SUPPORT_MATRIX.md`
   - add/remove `### \`CODE\`` in `DIAGNOSTICS.md`
3. Re-run checks:
   - `pnpm run docs:diagnostics:sync`
   - `pnpm run format && pnpm run format:check`

## CI
- `.github/workflows/ci.yml`
  - step renamed to: `Check diagnostics/docs sync + support-state coherence`

## Validation run
- ✅ `pnpm run lint`
- ✅ `pnpm run format:check`
- ✅ `pnpm run docs:diagnostics:sync`
- ✅ `pnpm run build`
- ⚠️ `pnpm run test` (fails in current branch due to unrelated pre-existing emitter-go smoke expectation mismatch: expected 405, got 404)
- ✅ `cargo fmt --all --check`
- ✅ `cargo clippy --workspace --all-targets -- -D warnings`
- ✅ `cargo test --workspace --all-targets`
