### PR TITLE
test: strengthen Fastify runtime contract coverage

### DIFF
--- a/packages/cli/test/commands.e2e.test.ts
+++ b/packages/cli/test/commands.e2e.test.ts
@@ -1036,6 +1036,82 @@ test("M2 acceptance: fastify-supported-complex fixture preserves method contract
   });
 });
 
+test("M3 regression: fastify-supported-complex keeps method/path scaffold stable", async () => {
+  const cwd = setupProjectFromFixture("fastify-supported-complex");
+  const rustLauncher = resolveRustEngineLauncherScript();
+  const engineCoreBin = resolveEngineCoreBin();
+
+  const result = runCli(cwd, "build", {
+    ...process.env,
+    TSGODOWN_RUST_ENGINE_BIN: rustLauncher,
+    TSGODOWN_ENGINE_CORE_BIN: engineCoreBin,
+  });
+
+  assert.equal(result.status, 0, `build failed: ${result.stderr}`);
+
+  const goPath = path.join(cwd, "dist-go", "main.go");
+  assert.equal(fs.existsSync(goPath), true);
+
+  const goMain = fs.readFileSync(goPath, "utf8");
+  assert.match(goMain, /HandleFunc\("GET \/health"/);
+  assert.match(goMain, /HandleFunc\("POST \/users"/);
+  assert.match(goMain, /HandleFunc\("PATCH \/users\/\{id\}"/);
+  assert.match(goMain, /HandleFunc\("DELETE \/users\/\{id\}"/);
+
+  const goDir = path.dirname(goPath);
+  await assertGoRunRequest(goDir, {
+    method: "HEAD",
+    routePath: "/users/abc-123",
+    expectedStatus: 405,
+    expectedAllowHeader: "DELETE, PATCH",
+  });
+  await assertGoRunRequest(goDir, {
+    method: "GET",
+    routePath: "/missing",
+    expectedStatus: 404,
+    expectedBodyFragment: "404 page not found",
+  });
+});
+
+test("M3 regression: runtime-method-matrix fixture keeps 404/405/Allow stable", async () => {
+  const cwd = setupProjectFromFixture("runtime-method-matrix");
+  const rustLauncher = resolveRustEngineLauncherScript();
+  const engineCoreBin = resolveEngineCoreBin();
+
+  const result = runCli(cwd, "build", {
+    ...process.env,
+    TSGODOWN_RUST_ENGINE_BIN: rustLauncher,
+    TSGODOWN_ENGINE_CORE_BIN: engineCoreBin,
+  });
+
+  assert.equal(result.status, 0, `build failed: ${result.stderr}`);
+
+  const goPath = path.join(cwd, "dist-go", "main.go");
+  assert.equal(fs.existsSync(goPath), true);
+
+  const goDir = path.dirname(goPath);
+  await assertGoRunRequest(goDir, {
+    method: "PUT",
+    routePath: "/users/alpha",
+    expectedStatus: 501,
+    expectedBodyFragment:
+      "TODO implement handler updateUser for PUT /users/:id",
+  });
+  await assertGoRunRequest(goDir, {
+    method: "GET",
+    routePath: "/users/alpha",
+    expectedStatus: 405,
+    expectedAllowHeader: "PUT",
+    expectedBodyFragment: "Method Not Allowed",
+  });
+  await assertGoRunRequest(goDir, {
+    method: "GET",
+    routePath: "/missing",
+    expectedStatus: 404,
+    expectedBodyFragment: "404 page not found",
+  });
+});
+
 test("M4 devx acceptance: fastify-complex fixture emits deterministic method/path scaffold", () => {
   const cwd = setupProjectFromFixture("fastify-complex");
   const rustLauncher = resolveRustEngineLauncherScript();

--- a/packages/emitter-go/test/emit-go.test.ts
+++ b/packages/emitter-go/test/emit-go.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { spawn, spawnSync } from "node:child_process";
 import fs from "node:fs";
+import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { after, test } from "node:test";
@@ -294,6 +295,27 @@ test(
   },
 );
 
+async function allocatePort(): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close(() => reject(new Error("failed to allocate test port")));
+        return;
+      }
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve(address.port);
+      });
+    });
+    server.once("error", reject);
+  });
+}
+
 function shutdownServer(server: ReturnType<typeof spawn>) {
   if (server.exitCode === null && !server.killed) {
     server.kill("SIGTERM");
@@ -329,7 +351,7 @@ test(
   { skip: !runGoSmoke },
   async () => {
     const outDir = createOutDir();
-    const port = String(19000 + Math.floor(Math.random() * 1000));
+    const port = String(await allocatePort());
 
     emitGoProject(sampleIr, outDir);
 
@@ -397,7 +419,7 @@ test(
   { skip: !runGoSmoke },
   async () => {
     const outDir = createOutDir();
-    const port = String(20000 + Math.floor(Math.random() * 1000));
+    const port = String(await allocatePort());
 
     emitGoProject(
       {
@@ -458,6 +480,90 @@ test(
       assert.equal(methodNotAllowed.headers.get("allow"), "DELETE, GET");
 
       const notFound = await fetch(`${base}/unknown/123`, {
+        signal: AbortSignal.timeout(1000),
+      });
+      assert.equal(notFound.status, 404);
+    } finally {
+      await shutdownServer(server);
+    }
+  },
+);
+
+test(
+  "emitGoProject smoke: nested prefixes keep method/path + allow semantics stable",
+  { skip: !runGoSmoke },
+  async () => {
+    const outDir = createOutDir();
+    const port = String(await allocatePort());
+
+    emitGoProject(
+      {
+        modules: [],
+        handlers: [
+          { id: "listPosts", params: [], async: false },
+          { id: "updatePost", params: [], async: false },
+        ],
+        diagnostics: [],
+        routes: [
+          {
+            method: "GET",
+            path: "/api/v1/posts/:postId",
+            handlerRef: "listPosts",
+          },
+          {
+            method: "PATCH",
+            path: "/api/v1/posts/:postId",
+            handlerRef: "updatePost",
+          },
+        ],
+      },
+      outDir,
+    );
+
+    const modInit = spawnSync(
+      "go",
+      ["mod", "init", "example.com/tsgodown-runtime-nested-prefix"],
+      {
+        cwd: outDir,
+        encoding: "utf8",
+      },
+    );
+    assert.equal(modInit.status, 0, modInit.stderr || modInit.stdout);
+
+    const server = spawn("go", ["run", "."], {
+      cwd: outDir,
+      env: { ...process.env, PORT: port },
+      stdio: "ignore",
+    });
+
+    const base = `http://127.0.0.1:${port}`;
+    const deadline = Date.now() + 10_000;
+
+    try {
+      while (Date.now() < deadline) {
+        try {
+          const warm = await fetch(`${base}/api/v1/posts/42`, {
+            signal: AbortSignal.timeout(1000),
+          });
+          if (warm.status > 0) break;
+        } catch {
+          await new Promise((resolve) => setTimeout(resolve, 200));
+        }
+      }
+
+      const getRes = await fetch(`${base}/api/v1/posts/42`, {
+        signal: AbortSignal.timeout(1000),
+      });
+      assert.equal(getRes.status, 501);
+
+      const methodNotAllowed = await fetch(`${base}/api/v1/posts/42`, {
+        method: "POST",
+        signal: AbortSignal.timeout(1000),
+      });
+      assert.equal(methodNotAllowed.status, 405);
+      assert.equal(methodNotAllowed.headers.get("allow"), "GET, PATCH");
+
+      const notFound = await fetch(`${base}/api/v2/posts/42`, {
         signal: AbortSignal.timeout(1000),
       });
       assert.equal(notFound.status, 404);


### PR DESCRIPTION
## Summary
Strengthen runtime contract coverage for newly supported Fastify patterns across CLI E2E and emitter-go runtime smoke tests.

## What changed
- **CLI E2E (`packages/cli/test/commands.e2e.test.ts`)**
  - Added `M3 regression: fastify-supported-complex keeps method/path scaffold stable`
    - Asserts generated Go scaffold contains expected method/path registrations:
      - `GET /health`
      - `POST /users`
      - `PATCH /users/{id}`
      - `DELETE /users/{id}`
    - Asserts runtime contract stability:
      - `HEAD /users/:id` => `405` + `Allow: DELETE, PATCH`
      - `GET /missing` => `404` (`404 page not found`)
  - Added `M3 regression: runtime-method-matrix fixture keeps 404/405/Allow stable`
    - Asserts runtime behavior:
      - `PUT /users/:id` => `501` TODO stub
      - `GET /users/:id` => `405` + `Allow: PUT`
      - `GET /missing` => `404`

- **Emitter-go runtime (`packages/emitter-go/test/emit-go.test.ts`)**
  - Replaced random fixed-range ports with deterministic OS-assigned ports (`allocatePort()`), reducing flaky collisions.
  - Added smoke test: `nested prefixes keep method/path + allow semantics stable`
    - Routes under nested prefix-style paths:
      - `GET /api/v1/posts/:postId`
      - `PATCH /api/v1/posts/:postId`
    - Runtime assertions:
      - `GET /api/v1/posts/42` => `501`
      - `POST /api/v1/posts/42` => `405` + `Allow: GET, PATCH`
      - `GET /api/v2/posts/42` => `404`

## Runtime assertion matrix
- **Method/path registration**
  - CLI: verifies emitted `HandleFunc("METHOD /path")` signatures for complex fixture routes.
  - emitter-go: verifies generated runtime path/method matches nested-prefix-style IR routes.
- **Path params**
  - CLI: `runtime-method-matrix` exercises `PUT /users/:id` and 405 fallback on same param path.
  - emitter-go: nested-prefix smoke exercises param matching on `/api/v1/posts/:postId`.
- **404/405/Allow contract stability**
  - CLI: explicit assertions for `405` and deterministic `Allow` headers + `404` path misses.
  - emitter-go: explicit assertions for `405`/`Allow` and `404` in nested prefix scenario.
- **Port determinism / runtime stability**
  - emitter-go: all runtime smoke tests now use OS-assigned ephemeral ports via `allocatePort()`.

## Before / After contract notes
- **Before**
  - emitter-go runtime smoke used pseudo-random fixed-range ports, vulnerable to collisions.
  - Nested-prefix-style runtime contract was not directly asserted in emitter-go smoke tests.
  - CLI had strong M2 coverage but weaker explicit regression checks for 404/405/Allow on additional method matrix scenarios.
- **After**
  - Runtime smoke startup is more stable due to deterministic port allocation strategy.
  - Nested-prefix runtime behavior now has explicit 404/405/Allow assertions in emitter-go tests.
  - CLI regression coverage now explicitly locks additional 404/405/Allow behavior and method/path scaffolding for supported fixtures.

## Validation run (local)
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run docs:diagnostics:sync`
- `pnpm run build`
- `pnpm run test`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --all-targets`

All passed locally.
