### PR TITLE
feat(analyzer-rust): convert high-value Fastify unsupported patterns

### DIFF
--- a/docs/specs/DIAGNOSTICS.md
+++ b/docs/specs/DIAGNOSTICS.md
@@ -180,7 +180,8 @@ fastify.route({ method: "POST", url: "/users", handler: createUser });
 
 **Rationale**
 
-Named handler references allow stable handler IDs and metadata extraction.
+Inline handlers with statically parseable signatures are now synthesized to deterministic handler refs.
+This diagnostic remains for non-parseable/non-deterministic handler expressions (e.g. factory call results).
 
 ---
 

--- a/docs/specs/FASTIFY_SUPPORT_MATRIX.md
+++ b/docs/specs/FASTIFY_SUPPORT_MATRIX.md
@@ -42,13 +42,15 @@ fastify.route({ method: 'GET', url: '/users', handler: listUsers })
 fastify.route({ method: 'PATCH', path: '/users/:id', handler: updateUser })
 ```
 
-### 1.4 Route object method array
+### 1.4 Route object method array + normalized method variants
 
 ```ts
 fastify.route({ method: ['PUT', 'PATCH'], url: '/things/:id', handler: replaceThing })
+fastify.route({ method: 'patch', url: '/users/:id', handler: updateUser })
+fastify.route({ method: ['put', 'del'], url: '/users/:id', handler: replaceUser })
 ```
 
-Supported method set for route object extraction:
+Supported method set for route object extraction (case-insensitive, with `DEL` alias → `DELETE`):
 - `GET`
 - `POST`
 - `PUT`
@@ -59,10 +61,12 @@ Supported method set for route object extraction:
 
 ```ts
 fastify.register(apiPlugin, { prefix: '/api' })
+fastify.register(fp(apiPlugin), { prefix: '/api' })
 // plugin routes become /api/*
 ```
 
 Nested `register(..., { prefix })` composition is supported when plugin callback/definition is statically analyzable in-file.
+Single-argument wrapper calls are unwrapped deterministically (e.g. `fp(pluginRef)`).
 
 ### 1.6 Handler reference forms
 
@@ -71,6 +75,16 @@ Named/member references are supported, including object/class member references 
 ```ts
 fastify.get('/users', userHandlers.list)
 fastify.delete('/users/:id', controller.remove)
+```
+
+### 1.7 Deterministic inline handler synthesis
+
+Inline function/arrow handlers are supported when their signature is statically parseable.
+Analyzer synthesizes stable handler refs and emits `HandlerIR` with inferred params/async flag.
+
+```ts
+fastify.get('/health', async (req, reply) => reply.send({ ok: true }))
+fastify.route({ method: 'POST', url: '/users', handler: function (request) { return {} } })
 ```
 
 ---
@@ -128,11 +142,11 @@ fastify.route({ method: 'GET', url: '/users', handler: listUsers })
 ## 3.2 `ANALYZER_UNSUPPORTED_INLINE_HANDLER`
 
 When it triggers:
-- Shorthand route handler is inline (arrow/function expression) instead of handler reference.
-- Route object `handler` is inline/non-reference.
+- Shorthand route handler expression is non-reference and signature cannot be deterministically parsed.
+- Route object `handler` expression is non-reference and signature cannot be deterministically parsed.
 
 Why unsupported:
-- IR contracts require stable handler identity (`handler_ref`) for downstream mapping.
+- IR contracts require stable handler identity (`handler_ref`) and statically parseable handler signature.
 
 Recommended rewrite:
 

--- a/packages/analyzer-rust/src/ast.rs
+++ b/packages/analyzer-rust/src/ast.rs
@@ -173,15 +173,65 @@ pub(crate) fn extract_object_string_array_prop(obj: &str, key: &str) -> Vec<Stri
         .collect()
 }
 
-pub(crate) fn extract_object_handler_ref(obj: &str, key: &str) -> Option<String> {
+pub(crate) fn extract_object_prop_expr(obj: &str, key: &str) -> Option<String> {
     let pattern = format!(
         r#"(?s)(?:\b{}\b|"{}")\s*:\s*([^,}}]+)"#,
         regex::escape(key),
         regex::escape(key)
     );
     let re = Regex::new(&pattern).unwrap();
-    let expr = re.captures(obj).map(|c| c[1].trim().to_string())?;
+    re.captures(obj).map(|c| c[1].trim().to_string())
+}
+
+pub(crate) fn extract_object_handler_ref(obj: &str, key: &str) -> Option<String> {
+    let expr = extract_object_prop_expr(obj, key)?;
     extract_handler_ref(&expr)
+}
+
+pub(crate) fn unwrap_single_call_arg(expr: &str) -> Option<String> {
+    let t = expr.trim();
+    let open = t.find('(')?;
+    if !t.ends_with(')') {
+        return None;
+    }
+    let args_src = &t[open + 1..t.len() - 1];
+    let args = split_top_level(args_src, ',');
+    if args.len() != 1 {
+        return None;
+    }
+    Some(args[0].trim().to_string())
+}
+
+pub(crate) fn parse_inline_handler_signature(expr: &str) -> Option<(Vec<String>, bool)> {
+    let t = expr.trim();
+
+    let re_arrow = Regex::new(r"(?s)^(async\s+)?(?:\(([^)]*)\)|([A-Za-z_$][\w$]*))\s*=>").unwrap();
+    if let Some(cap) = re_arrow.captures(t) {
+        let params_src = cap
+            .get(2)
+            .or_else(|| cap.get(3))
+            .map(|m| m.as_str())
+            .unwrap_or("");
+        let params = split_top_level(params_src, ',')
+            .into_iter()
+            .map(|p| p.trim().to_string())
+            .filter(|p| !p.is_empty())
+            .collect::<Vec<_>>();
+        return Some((params, cap.get(1).is_some()));
+    }
+
+    let re_fn =
+        Regex::new(r"(?s)^(async\s+)?function(?:\s+[A-Za-z_$][\w$]*)?\s*\(([^)]*)\)").unwrap();
+    re_fn.captures(t).map(|cap| {
+        (
+            split_top_level(&cap[2], ',')
+                .into_iter()
+                .map(|p| p.trim().to_string())
+                .filter(|p| !p.is_empty())
+                .collect::<Vec<_>>(),
+            cap.get(1).is_some(),
+        )
+    })
 }
 
 pub(crate) fn find_if_block_ranges(src: &str) -> Vec<(usize, usize)> {

--- a/packages/analyzer-rust/src/register.rs
+++ b/packages/analyzer-rust/src/register.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use crate::ast::{
     extract_handler_ref, extract_object_string_prop, parse_inline_plugin, split_top_level,
+    unwrap_single_call_arg,
 };
 use crate::defs::{HandlerDef, PluginDef};
 use crate::diagnostics::diag;
@@ -28,27 +29,19 @@ pub(crate) fn analyze_register_call(
         extract_object_string_prop(options_expr, "prefix").unwrap_or_default();
     let next_prefix = join_path(prefix, &prefix_from_register);
 
-    if let Some(inline) = parse_inline_plugin(plugin_expr) {
-        analyze_scope(
-            &inline.body,
-            file,
-            &inline.param_name,
-            &next_prefix,
-            plugin_defs,
-            handler_defs,
-            routes,
-            handlers,
-            diagnostics,
-        );
-        return;
+    let mut candidates = vec![plugin_expr.to_string()];
+    let mut cursor = plugin_expr.to_string();
+    while let Some(inner) = unwrap_single_call_arg(&cursor) {
+        candidates.push(inner.clone());
+        cursor = inner;
     }
 
-    if let Some(plugin_ref) = extract_handler_ref(plugin_expr) {
-        if let Some(plugin) = plugin_defs.get(&plugin_ref) {
+    for candidate in &candidates {
+        if let Some(inline) = parse_inline_plugin(candidate) {
             analyze_scope(
-                &plugin.body,
+                &inline.body,
                 file,
-                &plugin.param_name,
+                &inline.param_name,
                 &next_prefix,
                 plugin_defs,
                 handler_defs,
@@ -59,15 +52,32 @@ pub(crate) fn analyze_register_call(
             return;
         }
 
-        diagnostics.push(diag(
-            file,
-            "ANALYZER_UNRESOLVED_PLUGIN",
-            &format!(
-                "register plugin '{}' could not be resolved in current file. Ensure plugin is declared in the same file or use an inline callback.",
-                plugin_ref
-            ),
-        ));
-        return;
+        if let Some(plugin_ref) = extract_handler_ref(candidate) {
+            if let Some(plugin) = plugin_defs.get(&plugin_ref) {
+                analyze_scope(
+                    &plugin.body,
+                    file,
+                    &plugin.param_name,
+                    &next_prefix,
+                    plugin_defs,
+                    handler_defs,
+                    routes,
+                    handlers,
+                    diagnostics,
+                );
+                return;
+            }
+
+            diagnostics.push(diag(
+                file,
+                "ANALYZER_UNRESOLVED_PLUGIN",
+                &format!(
+                    "register plugin '{}' could not be resolved in current file. Ensure plugin is declared in the same file or use an inline callback.",
+                    plugin_ref
+                ),
+            ));
+            return;
+        }
     }
 
     diagnostics.push(diag(

--- a/packages/analyzer-rust/src/routes.rs
+++ b/packages/analyzer-rust/src/routes.rs
@@ -1,8 +1,9 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::ast::{
-    extract_handler_ref, extract_object_handler_ref, extract_object_string_array_prop,
-    extract_object_string_prop, extract_quoted_string, first_object_literal, split_top_level,
+    extract_handler_ref, extract_object_handler_ref, extract_object_prop_expr,
+    extract_object_string_array_prop, extract_object_string_prop, extract_quoted_string,
+    first_object_literal, parse_inline_handler_signature, split_top_level,
 };
 use crate::defs::HandlerDef;
 use crate::diagnostics::diag;
@@ -35,26 +36,39 @@ pub(crate) fn extract_shorthand_route(
     }
     let path = path.unwrap();
 
-    let handler_ref = parts.get(1).and_then(|s| extract_handler_ref(s));
-    if handler_ref.is_none() {
-        diagnostics.push(diag(
-            file,
-            "ANALYZER_UNSUPPORTED_INLINE_HANDLER",
-            &format!(
-                "unsupported non-reference handler in {}.{}('{}', handler). Extract handler to a named function and pass its identifier.",
-                instance_name, method, path
-            ),
-        ));
+    let method_upper = method.to_ascii_uppercase();
+    let joined_path = join_path(prefix, &path);
+
+    let handler_expr = parts.get(1).map(|s| s.trim()).unwrap_or("");
+    if let Some(handler_ref) = extract_handler_ref(handler_expr) {
+        routes.push(RouteIR {
+            method: method_upper,
+            path: joined_path,
+            handler_ref: handler_ref.clone(),
+        });
+        upsert_handler(handlers, handler_defs, &handler_ref);
         return;
     }
 
-    let handler_ref = handler_ref.unwrap();
-    routes.push(RouteIR {
-        method: method.to_ascii_uppercase(),
-        path: join_path(prefix, &path),
-        handler_ref: handler_ref.clone(),
-    });
-    upsert_handler(handlers, handler_defs, &handler_ref);
+    if let Some((params, is_async)) = parse_inline_handler_signature(handler_expr) {
+        let synthesized = synthesize_inline_handler_ref(&method_upper, &joined_path, handler_expr);
+        routes.push(RouteIR {
+            method: method_upper,
+            path: joined_path,
+            handler_ref: synthesized.clone(),
+        });
+        upsert_inline_handler(handlers, &synthesized, params, is_async);
+        return;
+    }
+
+    diagnostics.push(diag(
+        file,
+        "ANALYZER_UNSUPPORTED_INLINE_HANDLER",
+        &format!(
+            "unsupported non-reference handler in {}.{}('{}', handler). Extract handler to a named function and pass its identifier.",
+            instance_name, method, path
+        ),
+    ));
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -85,6 +99,7 @@ pub(crate) fn extract_route_object(
     let path = extract_object_string_prop(&obj, "url")
         .or_else(|| extract_object_string_prop(&obj, "path"));
     let handler_ref = extract_object_handler_ref(&obj, "handler");
+    let handler_expr = extract_object_prop_expr(&obj, "handler");
 
     let supported = HashSet::from(["GET", "POST", "PUT", "DELETE", "PATCH"]);
 
@@ -106,7 +121,15 @@ pub(crate) fn extract_route_object(
 
     let methods = methods
         .iter()
-        .map(|m| (m.clone(), m.to_ascii_uppercase()))
+        .map(|m| {
+            let upper = m.to_ascii_uppercase();
+            let normalized = if upper == "DEL" {
+                "DELETE".to_string()
+            } else {
+                upper
+            };
+            (m.clone(), normalized)
+        })
         .collect::<Vec<_>>();
 
     for (raw, upper) in &methods {
@@ -135,26 +158,87 @@ pub(crate) fn extract_route_object(
         return;
     };
 
-    let Some(handler_ref) = handler_ref else {
-        diagnostics.push(diag(
-            file,
-            "ANALYZER_UNSUPPORTED_INLINE_HANDLER",
-            &format!(
-                "unsupported route object handler in {}.route({{...}}). Provide named handler reference in 'handler' field.",
-                instance_name
-            ),
-        ));
+    if let Some(handler_ref) = handler_ref {
+        for (_, method) in methods {
+            routes.push(RouteIR {
+                method,
+                path: join_path(prefix, &path),
+                handler_ref: handler_ref.clone(),
+            });
+        }
+        upsert_handler(handlers, handler_defs, &handler_ref);
         return;
-    };
-
-    for (_, method) in methods {
-        routes.push(RouteIR {
-            method,
-            path: join_path(prefix, &path),
-            handler_ref: handler_ref.clone(),
-        });
     }
-    upsert_handler(handlers, handler_defs, &handler_ref);
+
+    if let Some(expr) = handler_expr {
+        if let Some((params, is_async)) = parse_inline_handler_signature(&expr) {
+            let synthesized =
+                synthesize_inline_handler_ref("ROUTE", &join_path(prefix, &path), &expr);
+            for (_, method) in methods {
+                routes.push(RouteIR {
+                    method,
+                    path: join_path(prefix, &path),
+                    handler_ref: synthesized.clone(),
+                });
+            }
+            upsert_inline_handler(handlers, &synthesized, params, is_async);
+            return;
+        }
+    }
+
+    diagnostics.push(diag(
+        file,
+        "ANALYZER_UNSUPPORTED_INLINE_HANDLER",
+        &format!(
+            "unsupported route object handler in {}.route({{...}}). Provide named handler reference in 'handler' field.",
+            instance_name
+        ),
+    ));
+}
+
+fn upsert_inline_handler(
+    handlers: &mut Vec<HandlerIR>,
+    handler_ref: &str,
+    params: Vec<String>,
+    is_async: bool,
+) {
+    if handlers.iter().any(|h| h.id == handler_ref) {
+        return;
+    }
+    handlers.push(HandlerIR {
+        id: handler_ref.to_string(),
+        params: params
+            .iter()
+            .map(|name| normalize_inline_param(name))
+            .map(|name| HandlerParamIR {
+                role: infer_param_role(&name),
+                name,
+            })
+            .collect(),
+        r#async: is_async,
+        semantics: Some(HandlerSemanticsIR {
+            response_mode: "unknown".to_string(),
+        }),
+    });
+}
+
+fn normalize_inline_param(param: &str) -> String {
+    let without_default = param.split('=').next().unwrap_or(param).trim();
+    let without_type = without_default
+        .split(':')
+        .next()
+        .unwrap_or(without_default)
+        .trim();
+    without_type.trim_start_matches("...").trim().to_string()
+}
+
+fn synthesize_inline_handler_ref(method: &str, path: &str, expr: &str) -> String {
+    let mut hash: u64 = 1469598103934665603;
+    for b in format!("{}|{}|{}", method, path, expr.trim()).as_bytes() {
+        hash ^= *b as u64;
+        hash = hash.wrapping_mul(1099511628211);
+    }
+    format!("__inline__{}__{:016x}", method.to_ascii_lowercase(), hash)
 }
 
 pub(crate) fn upsert_handler(

--- a/packages/analyzer-rust/tests/contract_parity_regression.rs
+++ b/packages/analyzer-rust/tests/contract_parity_regression.rs
@@ -202,21 +202,19 @@ fn contract_fixtures() -> Vec<ContractFixture> {
         },
         ContractFixture {
             name: "unsupported-fastify.fixture.txt",
-            expected_routes: vec![],
-            expected_handlers: vec![],
+            expected_routes: vec![("POST", "/inline", "__inline__post__6a62a08849cfd7d1")],
+            expected_handlers: vec![("__inline__post__6a62a08849cfd7d1", vec![], true, "unknown")],
             expected_diag_codes: vec![
                 "ANALYZER_UNRESOLVED_PLUGIN",
                 "ANALYZER_UNSUPPORTED_DYNAMIC_PATH",
-                "ANALYZER_UNSUPPORTED_INLINE_HANDLER",
             ],
         },
         ContractFixture {
             name: "unsupported-route-object-fastify.fixture.txt",
-            expected_routes: vec![],
-            expected_handlers: vec![],
+            expected_routes: vec![("POST", "/inline", "__inline__route__b86c00febff9d0f3")],
+            expected_handlers: vec![("__inline__route__b86c00febff9d0f3", vec![], true, "unknown")],
             expected_diag_codes: vec![
                 "ANALYZER_UNSUPPORTED_DYNAMIC_PATH",
-                "ANALYZER_UNSUPPORTED_INLINE_HANDLER",
                 "ANALYZER_UNSUPPORTED_ROUTE_OBJECT_METHOD",
                 "ANALYZER_UNSUPPORTED_ROUTE_OBJECT_METHOD",
                 "ANALYZER_UNSUPPORTED_ROUTE_OBJECT_SHAPE",
@@ -333,12 +331,7 @@ fn rust_contract_parity_routes_and_diagnostics_are_stable() {
                     "warn",
                     file.as_str(),
                 ),
-                (
-                    "ANALYZER_UNSUPPORTED_INLINE_HANDLER",
-                    "unsupported non-reference handler in fastify.post('/inline', handler). Extract handler to a named function and pass its identifier.",
-                    "warn",
-                    file.as_str(),
-                ),
+                // inline handlers with parseable signatures are now synthesized deterministically.
             ];
             expected_diag_details.sort();
 

--- a/packages/analyzer-rust/tests/fastify_ast_analyzer.rs
+++ b/packages/analyzer-rust/tests/fastify_ast_analyzer.rs
@@ -78,7 +78,6 @@ fn emits_explicit_diagnostics_for_unsupported_patterns() {
         vec![
             "ANALYZER_UNRESOLVED_PLUGIN".to_string(),
             "ANALYZER_UNSUPPORTED_DYNAMIC_PATH".to_string(),
-            "ANALYZER_UNSUPPORTED_INLINE_HANDLER".to_string(),
         ]
     );
 
@@ -90,8 +89,7 @@ fn emits_explicit_diagnostics_for_unsupported_patterns() {
     assert!(messages
         .iter()
         .any(|m| m.contains("dynamic path") && m.contains("Use string literal path")));
-    assert!(messages.iter().any(|m| m.contains("non-reference handler")
-        && m.contains("Extract handler to a named function")));
+    assert!(!messages.iter().any(|m| m.contains("non-reference handler")));
     assert!(messages
         .iter()
         .any(|m| m.contains("register plugin 'externalPlugin'")
@@ -450,7 +448,13 @@ fn emits_deterministic_boundary_diagnostics_for_unsupported_route_object_pattern
     let (file, src) = fixture("unsupported-route-object-fastify.fixture.txt");
     let ir = analyze_fastify_entry(&file, &src);
 
-    assert!(ir.routes.is_empty());
+    assert_eq!(
+        ir.routes
+            .iter()
+            .map(|r| (r.method.as_str(), r.path.as_str()))
+            .collect::<Vec<_>>(),
+        vec![("POST", "/inline")]
+    );
 
     let actual = ir
         .diagnostics
@@ -495,12 +499,6 @@ fn emits_deterministic_boundary_diagnostics_for_unsupported_route_object_pattern
                 "warn",
                 file.as_str(),
             ),
-            (
-                "ANALYZER_UNSUPPORTED_INLINE_HANDLER",
-                "unsupported route object handler in fastify.route({...}). Provide named handler reference in 'handler' field.",
-                "warn",
-                file.as_str(),
-            ),
         ]
     );
 }
@@ -518,6 +516,84 @@ fn supports_route_object_method_array_extraction() {
         vec![
             ("PUT", "/things/:id", "replaceThing"),
             ("PATCH", "/things/:id", "replaceThing"),
+        ]
+    );
+    assert!(ir.diagnostics.is_empty());
+}
+
+#[test]
+fn supports_route_object_method_variants_and_register_wrapper_plugin() {
+    let (file_route, src_route) = fixture("route-object-method-variants-fastify.fixture.txt");
+    let route_ir = analyze_fastify_entry(&file_route, &src_route);
+
+    assert_eq!(
+        route_ir
+            .routes
+            .iter()
+            .map(|r| (r.method.as_str(), r.path.as_str(), r.handler_ref.as_str()))
+            .collect::<Vec<_>>(),
+        vec![
+            ("PATCH", "/users/:id", "updateUser"),
+            ("PUT", "/users/:id", "removeUser"),
+            ("DELETE", "/users/:id", "removeUser"),
+        ]
+    );
+    assert!(route_ir.diagnostics.is_empty());
+
+    let (file_register, src_register) = fixture("register-wrapper-fastify.fixture.txt");
+    let register_ir = analyze_fastify_entry(&file_register, &src_register);
+    assert_eq!(
+        register_ir
+            .routes
+            .iter()
+            .map(|r| (r.method.as_str(), r.path.as_str(), r.handler_ref.as_str()))
+            .collect::<Vec<_>>(),
+        vec![("GET", "/v1/users", "listUsers")]
+    );
+    assert!(register_ir.diagnostics.is_empty());
+}
+
+#[test]
+fn supports_deterministic_inline_handler_synthesis() {
+    let (file, src) = fixture("inline-handler-synth-fastify.fixture.txt");
+    let ir = analyze_fastify_entry(&file, &src);
+
+    assert_eq!(
+        ir.routes
+            .iter()
+            .map(|r| (r.method.as_str(), r.path.as_str(), r.handler_ref.as_str()))
+            .collect::<Vec<_>>(),
+        vec![
+            ("GET", "/health", "__inline__get__a38f039b84b03a0a"),
+            ("POST", "/users", "__inline__route__73ddf17fee278333"),
+        ]
+    );
+
+    assert_eq!(
+        ir.handlers
+            .iter()
+            .map(|h| {
+                (
+                    h.id.as_str(),
+                    h.params
+                        .iter()
+                        .map(|p| (p.name.as_str(), p.role.as_str()))
+                        .collect::<Vec<_>>(),
+                    h.r#async,
+                )
+            })
+            .collect::<Vec<_>>(),
+        vec![
+            (
+                "__inline__get__a38f039b84b03a0a",
+                vec![("req", "request"), ("reply", "response")],
+                true,
+            ),
+            (
+                "__inline__route__73ddf17fee278333",
+                vec![("request", "request")],
+                false,
+            ),
         ]
     );
     assert!(ir.diagnostics.is_empty());

--- a/packages/analyzer-rust/tests/fixtures/duplicate-diagnostics-fastify.golden.txt
+++ b/packages/analyzer-rust/tests/fixtures/duplicate-diagnostics-fastify.golden.txt
@@ -1,7 +1,6 @@
-routes=[]
-handlers=[]
+routes=[POST /inline -> __inline__post__6a62a08849cfd7d1, POST /inline -> __inline__post__6a62a08849cfd7d1]
+handlers=[__inline__post__6a62a08849cfd7d1(req=[];async=true;mode=unknown)]
 diagnostics=[
   {level=warn,code=ANALYZER_UNSUPPORTED_DYNAMIC_PATH,message=unsupported dynamic path in fastify.get(...). Use string literal path (e.g. '/users/:id') for IR extraction.,source.file=duplicate-diagnostics-fastify.fixture.txt},
-  {level=warn,code=ANALYZER_UNSUPPORTED_INLINE_HANDLER,message=unsupported non-reference handler in fastify.post('/inline', handler). Extract handler to a named function and pass its identifier.,source.file=duplicate-diagnostics-fastify.fixture.txt},
   {level=warn,code=ANALYZER_UNRESOLVED_PLUGIN,message=register plugin 'externalPlugin' could not be resolved in current file. Ensure plugin is declared in the same file or use an inline callback.,source.file=duplicate-diagnostics-fastify.fixture.txt},
 ]

--- a/packages/analyzer-rust/tests/fixtures/fastify-unsupported-inline-handler.bad.fixture.txt
+++ b/packages/analyzer-rust/tests/fixtures/fastify-unsupported-inline-handler.bad.fixture.txt
@@ -2,4 +2,8 @@ import Fastify from "fastify";
 
 const fastify = Fastify();
 
-fastify.post("/users", async () => {});
+function makeHandler() {
+  return async () => {};
+}
+
+fastify.post("/users", makeHandler());

--- a/packages/analyzer-rust/tests/fixtures/fastify-unsupported-route-object-handler.bad.fixture.txt
+++ b/packages/analyzer-rust/tests/fixtures/fastify-unsupported-route-object-handler.bad.fixture.txt
@@ -2,4 +2,8 @@ import Fastify from "fastify";
 
 const fastify = Fastify();
 
-fastify.route({ method: "POST", url: "/users", handler: async () => {} });
+function makeHandler() {
+  return async () => {};
+}
+
+fastify.route({ method: "POST", url: "/users", handler: makeHandler() });

--- a/packages/analyzer-rust/tests/fixtures/inline-handler-synth-fastify.fixture.txt
+++ b/packages/analyzer-rust/tests/fixtures/inline-handler-synth-fastify.fixture.txt
@@ -1,0 +1,11 @@
+import Fastify from "fastify";
+
+const fastify = Fastify();
+
+fastify.get("/health", async (req, reply) => {
+  reply.send({ ok: true });
+});
+
+fastify.route({ method: "post", url: "/users", handler: function (request) {
+  return { ok: true };
+}});

--- a/packages/analyzer-rust/tests/fixtures/register-wrapper-fastify.fixture.txt
+++ b/packages/analyzer-rust/tests/fixtures/register-wrapper-fastify.fixture.txt
@@ -1,0 +1,15 @@
+import Fastify from "fastify";
+
+const fastify = Fastify();
+
+function listUsers() {}
+
+const usersPlugin = (app) => {
+  app.get("/users", listUsers);
+};
+
+function fp(p: any) {
+  return p;
+}
+
+fastify.register(fp(usersPlugin), { prefix: "/v1" });

--- a/packages/analyzer-rust/tests/fixtures/route-object-method-variants-fastify.fixture.txt
+++ b/packages/analyzer-rust/tests/fixtures/route-object-method-variants-fastify.fixture.txt
@@ -1,0 +1,9 @@
+import Fastify from "fastify";
+
+const fastify = Fastify();
+
+function updateUser() {}
+function removeUser() {}
+
+fastify.route({ method: "patch", url: "/users/:id", handler: updateUser });
+fastify.route({ method: ["put", "del"], url: "/users/:id", handler: removeUser });


### PR DESCRIPTION
## What changed
- Expanded Fastify analyzer support for higher-value unsupported patterns while preserving deterministic extraction boundaries (no silent fallback).
- Added deterministic inline handler synthesis for parseable inline function/arrow handlers in shorthand route calls and `fastify.route({...})` handler fields.
- Added register callback unwrapping for single-argument wrapper calls (e.g. `fastify.register(fp(usersPlugin))`) to resolve in-file plugin refs.
- Added route-object method normalization support:
  - case-insensitive method tokens (`patch`, `put`, etc.)
  - `DEL` alias normalization to `DELETE`
- Updated tests/fixtures and docs support matrix for parity.

## Newly supported patterns
1. **Register/plugin callback patterns**
   - Wrapped local plugin refs with single-arg wrappers are resolved deterministically:
     - `fastify.register(fp(usersPlugin), { prefix: '/v1' })`

2. **Route-object shape/method variants**
   - Method values normalized case-insensitively.
   - `del`/`DEL` maps to `DELETE`.
   - Deterministic allowlist enforcement remains (`GET|POST|PUT|DELETE|PATCH`).

3. **Inline handler support (safe deterministic synthesis)**
   - Parseable inline handlers are supported by synthesized stable handler refs:
     - shorthand: `fastify.get('/health', async (req, reply) => {...})`
     - route object: `fastify.route({ method: 'POST', url: '/users', handler: function (request) {...} })`

## Remaining unsupported patterns
- `ANALYZER_UNSUPPORTED_CONDITIONAL_ROUTE`
- `ANALYZER_UNSUPPORTED_DYNAMIC_PATH`
- `ANALYZER_UNSUPPORTED_INLINE_HANDLER` (non-parseable/non-deterministic handler expressions)
- `ANALYZER_UNSUPPORTED_REGISTER_CALLBACK` (outside inline/local-ref + deterministic single-arg unwrap boundary)
- `ANALYZER_UNSUPPORTED_ROUTE_OBJECT_METHOD` (missing/invalid/non-allowlisted)
- `ANALYZER_UNSUPPORTED_ROUTE_OBJECT_SHAPE`
- `ANALYZER_UNRESOLVED_PLUGIN`

## Deterministic guarantees
- Inline handler IDs are synthesized from stable `(method|path|handler-expr-trimmed)` hashing.
- Repeated extraction of same source yields identical route/handler refs.
- Unsupported/non-deterministic patterns remain explicit diagnostics (no best-effort guessing).

## Exact test evidence (rerun in this retry)
- `pnpm install --frozen-lockfile` ✅
- `pnpm run lint` ✅ (Biome: checked 141 files, 0 issues)
- `pnpm run format:check` ✅ (Biome check, 0 changes)
- `pnpm run build` ✅
- `pnpm run test` ✅
  - `packages/cli`: 21 passed, 0 failed
  - `packages/emitter-go`: 10 passed, 0 failed
  - `packages/pipeline`: 3 passed, 0 failed
- `cargo fmt --all --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo test --workspace --all-targets` ✅
  - `fastify_ast_analyzer`: 17 passed, 0 failed
  - `contract_parity_regression`: 2 passed, 0 failed
- `./scripts/smoke-m1.sh` ✅ PASS
