### PR TITLE
feat(analyzer): support Fastify route object local const bindings

### DIFF
--- a/docs/specs/DIAGNOSTICS.md
+++ b/docs/specs/DIAGNOSTICS.md
@@ -27,7 +27,7 @@ These lines are managed by `scripts/check-fastify-diagnostics-sync.mjs` and must
 - `ANALYZER_UNSUPPORTED_REGISTER_CALLBACK`: `unsupported register callback pattern on {}.register(...). Use inline function(plugin) {{ ... }} or named local plugin reference.`
 - `ANALYZER_UNSUPPORTED_ROUTE_OBJECT_METHOD`: `unsupported route object method in {}.route({{...}}): '{}'. Supported methods: GET|POST|PUT|DELETE|PATCH.`
 - `ANALYZER_UNSUPPORTED_ROUTE_OBJECT_METHOD`: `unsupported route object method in {}.route({{...}}): missing string 'method' or non-empty string array. Supported methods: GET|POST|PUT|DELETE|PATCH.`
-- `ANALYZER_UNSUPPORTED_ROUTE_OBJECT_SHAPE`: `unsupported route object pattern in {}.route(...). Provide an inline object literal (e.g. {{ method: 'GET', url: '/users', handler: listUsers }}).`
+- `ANALYZER_UNSUPPORTED_ROUTE_OBJECT_SHAPE`: `unsupported route object pattern in {}.route(...). Provide an inline object literal or local const object reference (e.g. {{ method: 'GET', url: '/users', handler: listUsers }}).`
 - `DYNAMIC_IMPORT_DETECTED`: `dynamic import detected; use static import declarations for deterministic IR extraction.`
 <!-- AUTO-GENERATED:DIAGNOSTIC_MESSAGES:END -->
 

--- a/docs/specs/FASTIFY_SUPPORT_MATRIX.md
+++ b/docs/specs/FASTIFY_SUPPORT_MATRIX.md
@@ -35,11 +35,14 @@ fastify
 
 Also supported inside nested plugins when analyzable.
 
-### 1.3 `fastify.route({...})` object literal
+### 1.3 `fastify.route({...})` object literal (inline or local const ref)
 
 ```ts
 fastify.route({ method: 'GET', url: '/users', handler: listUsers })
 fastify.route({ method: 'PATCH', path: '/users/:id', handler: updateUser })
+
+const routeDef = { method: 'GET', url: '/health', handler: health }
+fastify.route(routeDef)
 ```
 
 ### 1.4 Route object method array + normalized method variants
@@ -190,7 +193,7 @@ fastify.route({ method: 'POST', url: '/users', handler: createUser })
 ## 3.3 `ANALYZER_UNSUPPORTED_ROUTE_OBJECT_SHAPE`
 
 When it triggers:
-- `fastify.route(...)` is not passed an inline object literal shape analyzable by current extractor.
+- `fastify.route(...)` is not passed an analyzable route-object source (inline literal or local const object reference).
 
 Why unsupported:
 - Analyzer relies on direct object-literal inspection for deterministic extraction.

--- a/docs/specs/FASTIFY_UNSUPPORTED_INVENTORY.md
+++ b/docs/specs/FASTIFY_UNSUPPORTED_INVENTORY.md
@@ -15,7 +15,7 @@ This file is auto-managed by `scripts/check-fastify-diagnostics-sync.mjs`.
 | `ANALYZER_UNSUPPORTED_REGISTER_CALLBACK` | `unsupported register callback pattern on {}.register(...). Use inline function(plugin) {{ ... }} or named local plugin reference.` | `packages/analyzer-rust/src/register.rs` |
 | `ANALYZER_UNSUPPORTED_ROUTE_OBJECT_METHOD` | `unsupported route object method in {}.route({{...}}): '{}'. Supported methods: GET\|POST\|PUT\|DELETE\|PATCH.` | `packages/analyzer-rust/src/routes.rs` |
 | `ANALYZER_UNSUPPORTED_ROUTE_OBJECT_METHOD` | `unsupported route object method in {}.route({{...}}): missing string 'method' or non-empty string array. Supported methods: GET\|POST\|PUT\|DELETE\|PATCH.` | `packages/analyzer-rust/src/routes.rs` |
-| `ANALYZER_UNSUPPORTED_ROUTE_OBJECT_SHAPE` | `unsupported route object pattern in {}.route(...). Provide an inline object literal (e.g. {{ method: 'GET', url: '/users', handler: listUsers }}).` | `packages/analyzer-rust/src/routes.rs` |
+| `ANALYZER_UNSUPPORTED_ROUTE_OBJECT_SHAPE` | `unsupported route object pattern in {}.route(...). Provide an inline object literal or local const object reference (e.g. {{ method: 'GET', url: '/users', handler: listUsers }}).` | `packages/analyzer-rust/src/routes.rs` |
 | `DYNAMIC_IMPORT_DETECTED` | `dynamic import detected; use static import declarations for deterministic IR extraction.` | `packages/analyzer-rust/src/lib.rs` |
 
 ## Regeneration

--- a/packages/analyzer-rust/src/ast.rs
+++ b/packages/analyzer-rust/src/ast.rs
@@ -161,6 +161,39 @@ pub(crate) fn extract_handler_ref(v: &str) -> Option<String> {
     }
 }
 
+pub(crate) fn extract_identifier(v: &str) -> Option<String> {
+    let t = v.trim();
+    let re = Regex::new(r"^[A-Za-z_$][\w$]*$").unwrap();
+    if re.is_match(t) {
+        Some(t.to_string())
+    } else {
+        None
+    }
+}
+
+pub(crate) fn resolve_bound_object_literal(src: &str, name: &str) -> Option<String> {
+    let pattern = format!(
+        r"(?s)(?:const|let|var)\s+{}\s*(?::\s*[^=;]+)?\s*=\s*\{{",
+        regex::escape(name)
+    );
+    let re = Regex::new(&pattern).unwrap();
+    let cap = re.captures(src)?;
+    let m0 = cap.get(0)?;
+    let open_idx = m0.end() - 1;
+    let (body, _) = capture_balanced(&src[open_idx + 1..], '{', '}')?;
+    Some(body)
+}
+
+pub(crate) fn resolve_bound_static_string(src: &str, name: &str) -> Option<String> {
+    let pattern = format!(
+        r"(?m)(?:const|let|var)\s+{}\s*(?::\s*[^=;]+)?\s*=\s*([^;]+);",
+        regex::escape(name)
+    );
+    let re = Regex::new(&pattern).unwrap();
+    let cap = re.captures(src)?;
+    extract_static_string_literal(cap.get(1)?.as_str())
+}
+
 pub(crate) fn extract_object_string_prop(obj: &str, key: &str) -> Option<String> {
     let pattern = format!(
         r#"(?s)(?:\b{}\b|"{}")\s*:\s*("[^"]*"|'[^']*'|`[^`]*`)"#,

--- a/packages/analyzer-rust/src/routes.rs
+++ b/packages/analyzer-rust/src/routes.rs
@@ -1,9 +1,10 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::ast::{
-    extract_handler_ref, extract_object_handler_ref, extract_object_prop_expr,
+    extract_handler_ref, extract_identifier, extract_object_handler_ref, extract_object_prop_expr,
     extract_object_string_array_prop, extract_object_string_prop, extract_quoted_string,
-    first_object_literal, parse_inline_handler_signature, split_top_level,
+    first_object_literal, parse_inline_handler_signature, resolve_bound_object_literal,
+    resolve_bound_static_string, split_top_level,
 };
 use crate::defs::HandlerDef;
 use crate::diagnostics::diag;
@@ -74,6 +75,7 @@ pub(crate) fn extract_shorthand_route(
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn extract_route_object(
     args: &str,
+    scope_src: &str,
     file: &str,
     instance_name: &str,
     prefix: &str,
@@ -82,22 +84,40 @@ pub(crate) fn extract_route_object(
     handler_defs: &HashMap<String, HandlerDef>,
     diagnostics: &mut Vec<DiagnosticIR>,
 ) {
-    let Some(obj) = first_object_literal(args) else {
+    let obj = first_object_literal(args).or_else(|| {
+        extract_identifier(args).and_then(|name| resolve_bound_object_literal(scope_src, &name))
+    });
+
+    let Some(obj) = obj else {
         diagnostics.push(diag(
             file,
             "ANALYZER_UNSUPPORTED_ROUTE_OBJECT_SHAPE",
             &format!(
-                "unsupported route object pattern in {}.route(...). Provide an inline object literal (e.g. {{ method: 'GET', url: '/users', handler: listUsers }}).",
+                "unsupported route object pattern in {}.route(...). Provide an inline object literal or local const object reference (e.g. {{ method: 'GET', url: '/users', handler: listUsers }}).",
                 instance_name
             ),
         ));
         return;
     };
 
-    let raw_method = extract_object_string_prop(&obj, "method");
+    let raw_method = extract_object_string_prop(&obj, "method").or_else(|| {
+        extract_object_prop_expr(&obj, "method")
+            .and_then(|expr| extract_identifier(&expr))
+            .and_then(|name| resolve_bound_static_string(scope_src, &name))
+    });
     let raw_method_array = extract_object_string_array_prop(&obj, "method");
     let path = extract_object_string_prop(&obj, "url")
-        .or_else(|| extract_object_string_prop(&obj, "path"));
+        .or_else(|| {
+            extract_object_prop_expr(&obj, "url")
+                .and_then(|expr| extract_identifier(&expr))
+                .and_then(|name| resolve_bound_static_string(scope_src, &name))
+        })
+        .or_else(|| extract_object_string_prop(&obj, "path"))
+        .or_else(|| {
+            extract_object_prop_expr(&obj, "path")
+                .and_then(|expr| extract_identifier(&expr))
+                .and_then(|name| resolve_bound_static_string(scope_src, &name))
+        });
     let handler_ref = extract_object_handler_ref(&obj, "handler");
     let handler_expr = extract_object_prop_expr(&obj, "handler");
 

--- a/packages/analyzer-rust/src/traversal.rs
+++ b/packages/analyzer-rust/src/traversal.rs
@@ -65,6 +65,7 @@ pub(crate) fn analyze_scope(
 
         if let Some(consumed) = analyze_call_chain(
             tail,
+            body,
             file,
             instance_name,
             prefix,
@@ -124,6 +125,7 @@ fn first_supported_method(chain: &str) -> Option<&'static str> {
 #[allow(clippy::too_many_arguments)]
 fn analyze_call_chain(
     mut chain: &str,
+    scope_src: &str,
     file: &str,
     instance_name: &str,
     prefix: &str,
@@ -164,6 +166,7 @@ fn analyze_call_chain(
             if let Some(args) = capture_call_args(chain, "route") {
                 extract_route_object(
                     &args,
+                    scope_src,
                     file,
                     instance_name,
                     prefix,

--- a/packages/analyzer-rust/tests/contract_parity_regression.rs
+++ b/packages/analyzer-rust/tests/contract_parity_regression.rs
@@ -211,13 +211,20 @@ fn contract_fixtures() -> Vec<ContractFixture> {
         },
         ContractFixture {
             name: "unsupported-route-object-fastify.fixture.txt",
-            expected_routes: vec![("POST", "/inline", "__inline__route__b86c00febff9d0f3")],
-            expected_handlers: vec![("__inline__route__b86c00febff9d0f3", vec![], true, "unknown")],
+            expected_routes: vec![
+                ("GET", "/from-config", "listFromConfig"),
+                ("GET", "/from-variable-method", "listUsers"),
+                ("GET", "/dynamic", "listAudits"),
+                ("POST", "/inline", "__inline__route__b86c00febff9d0f3"),
+            ],
+            expected_handlers: vec![
+                ("listUsers", vec![], false, "unknown"),
+                ("listAudits", vec![], false, "unknown"),
+                ("__inline__route__b86c00febff9d0f3", vec![], true, "unknown"),
+            ],
             expected_diag_codes: vec![
-                "ANALYZER_UNSUPPORTED_DYNAMIC_PATH",
                 "ANALYZER_UNSUPPORTED_ROUTE_OBJECT_METHOD",
                 "ANALYZER_UNSUPPORTED_ROUTE_OBJECT_METHOD",
-                "ANALYZER_UNSUPPORTED_ROUTE_OBJECT_SHAPE",
             ],
         },
     ]

--- a/packages/analyzer-rust/tests/fastify_ast_analyzer.rs
+++ b/packages/analyzer-rust/tests/fastify_ast_analyzer.rs
@@ -451,9 +451,14 @@ fn emits_deterministic_boundary_diagnostics_for_unsupported_route_object_pattern
     assert_eq!(
         ir.routes
             .iter()
-            .map(|r| (r.method.as_str(), r.path.as_str()))
+            .map(|r| (r.method.as_str(), r.path.as_str(), r.handler_ref.as_str()))
             .collect::<Vec<_>>(),
-        vec![("POST", "/inline")]
+        vec![
+            ("GET", "/from-config", "listFromConfig"),
+            ("GET", "/from-variable-method", "listUsers"),
+            ("GET", "/dynamic", "listAudits"),
+            ("POST", "/inline", "__inline__route__b86c00febff9d0f3"),
+        ]
     );
 
     let actual = ir
@@ -476,12 +481,6 @@ fn emits_deterministic_boundary_diagnostics_for_unsupported_route_object_pattern
         actual,
         vec![
             (
-                "ANALYZER_UNSUPPORTED_ROUTE_OBJECT_SHAPE",
-                "unsupported route object pattern in fastify.route(...). Provide an inline object literal (e.g. { method: 'GET', url: '/users', handler: listUsers }).",
-                "warn",
-                file.as_str(),
-            ),
-            (
                 "ANALYZER_UNSUPPORTED_ROUTE_OBJECT_METHOD",
                 "unsupported route object method in fastify.route({...}): missing string 'method' or non-empty string array. Supported methods: GET|POST|PUT|DELETE|PATCH.",
                 "warn",
@@ -490,12 +489,6 @@ fn emits_deterministic_boundary_diagnostics_for_unsupported_route_object_pattern
             (
                 "ANALYZER_UNSUPPORTED_ROUTE_OBJECT_METHOD",
                 "unsupported route object method in fastify.route({...}): 'OPTIONS'. Supported methods: GET|POST|PUT|DELETE|PATCH.",
-                "warn",
-                file.as_str(),
-            ),
-            (
-                "ANALYZER_UNSUPPORTED_DYNAMIC_PATH",
-                "unsupported route object path in fastify.route({...}). Provide string literal 'url' or 'path' (e.g. '/users/:id').",
                 "warn",
                 file.as_str(),
             ),

--- a/packages/analyzer-rust/tests/fixtures/fastify-unsupported-route-object-path.bad.fixture.txt
+++ b/packages/analyzer-rust/tests/fixtures/fastify-unsupported-route-object-path.bad.fixture.txt
@@ -1,7 +1,8 @@
 import Fastify from "fastify";
 
 const fastify = Fastify();
-const dynamicPath = "/users/:id";
+const id = "id";
+const dynamicPath = `/users/${id}`;
 
 function getUser() {}
 

--- a/packages/analyzer-rust/tests/fixtures/fastify-unsupported-route-object-shape.bad.fixture.txt
+++ b/packages/analyzer-rust/tests/fixtures/fastify-unsupported-route-object-shape.bad.fixture.txt
@@ -4,5 +4,8 @@ const fastify = Fastify();
 
 function listUsers() {}
 
-const routeDef = { method: "GET", url: "/users", handler: listUsers };
-fastify.route(routeDef);
+function buildRoute() {
+  return { method: "GET", url: "/users", handler: listUsers };
+}
+
+fastify.route(buildRoute());


### PR DESCRIPTION
## intent/scope
- Add Fastify analyzer support for `fastify.route(...)` when route options are provided via a **local const object reference** (not only inline literals).
- Add support for resolving local const string references used in route-object `method`, `url`, and `path` fields.
- Keep unsupported boundaries deterministic by tightening bad fixtures to truly dynamic/non-analyzable cases.
- Update diagnostics/docs sync artifacts to reflect current behavior and message templates.

## unsupported items cleared
- Cleared `ANALYZER_UNSUPPORTED_ROUTE_OBJECT_SHAPE` for: `fastify.route(routeDef)` where `routeDef` is a local const object literal.
- Cleared `ANALYZER_UNSUPPORTED_DYNAMIC_PATH` for route-object path/url values that are local const static strings.
- Cleared one `ANALYZER_UNSUPPORTED_ROUTE_OBJECT_METHOD` false-positive for route-object method values that are local const static strings.

## test evidence
Ran full CI-parity gate locally (all pass):
- `pnpm install --frozen-lockfile` ✅
- `pnpm run lint` ✅
- `pnpm run format:check` ✅
- `pnpm run build` ✅
- `pnpm run test` ✅
- `cargo fmt --all --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo test --workspace --all-targets` ✅
- `./scripts/smoke-m1.sh` ✅ (`[smoke-m1] PASS`)

Additional focused analyzer validation:
- `cargo test -p analyzer-rust --test fastify_ast_analyzer` ✅
- `cargo test -p analyzer-rust` ✅
- `node scripts/check-fastify-diagnostics-sync.mjs --write` ✅
- `node scripts/check-fastify-diagnostics-sync.mjs` ✅

## residual unsupported items
Remaining deterministic unsupported backlog (Fastify-specific diagnostic boundaries):
- `ANALYZER_UNSUPPORTED_CONDITIONAL_ROUTE`
- `ANALYZER_UNSUPPORTED_DYNAMIC_PATH` (truly dynamic/computed)
- `ANALYZER_UNSUPPORTED_INLINE_HANDLER` (non-parseable inline forms)
- `ANALYZER_UNSUPPORTED_REGISTER_CALLBACK`
- `ANALYZER_UNSUPPORTED_ROUTE_OBJECT_METHOD` (missing/unsupported method tokens)
- `ANALYZER_UNSUPPORTED_ROUTE_OBJECT_SHAPE` (non-analyzable/non-local-indirection route config)
- `ANALYZER_UNRESOLVED_PLUGIN`
