### PR TITLE
feat(examples): add real Fastify scaffold baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,11 @@ Output:
 
 - `examples/fastify-min/dist-go/main.go`
 
+Scaffold-oriented sample (real Fastify app structure) is available at:
+
+- `examples/fastify-scaffold-real/src/app.ts`
+- `examples/fastify-scaffold-real/src/routes/*`
+
 ## Runtime contracts (404/405/Allow)
 
 Generated Go runtime keeps HTTP mismatch behavior deterministic:

--- a/examples/fastify-scaffold-real/src/app.ts
+++ b/examples/fastify-scaffold-real/src/app.ts
@@ -1,0 +1,12 @@
+import Fastify from "fastify";
+import healthRoutes from "./routes/health";
+import userRoutes from "./routes/users";
+
+export function buildApp() {
+  const app = Fastify();
+
+  app.register(healthRoutes);
+  app.register(userRoutes, { prefix: "/users" });
+
+  return app;
+}

--- a/examples/fastify-scaffold-real/src/routes/health.ts
+++ b/examples/fastify-scaffold-real/src/routes/health.ts
@@ -1,0 +1,9 @@
+import type { FastifyPluginAsync } from "fastify";
+
+const healthRoutes: FastifyPluginAsync = async (app) => {
+  app.get("/health", async () => {
+    return { ok: true };
+  });
+};
+
+export default healthRoutes;

--- a/examples/fastify-scaffold-real/src/routes/users.ts
+++ b/examples/fastify-scaffold-real/src/routes/users.ts
@@ -1,0 +1,20 @@
+import type { FastifyPluginAsync } from "fastify";
+
+type UserReply = { id: string } | { ok: true };
+
+const userRoutes: FastifyPluginAsync = async (app) => {
+  app.post<{ Reply: UserReply }>("/", async (_request, reply) => {
+    reply.code(201);
+    return { id: "u1" };
+  });
+
+  app.patch<{ Params: { id: string }; Reply: UserReply }>("/:id", async () => {
+    return { ok: true };
+  });
+
+  app.delete<{ Params: { id: string }; Reply: UserReply }>("/:id", async () => {
+    return { ok: true };
+  });
+};
+
+export default userRoutes;

--- a/examples/fastify-scaffold-real/src/server.ts
+++ b/examples/fastify-scaffold-real/src/server.ts
@@ -1,0 +1,9 @@
+import { buildApp } from "./app";
+
+const app = buildApp();
+
+const port = Number(process.env.PORT ?? 3000);
+app.listen({ port, host: "0.0.0.0" }).catch((error) => {
+  app.log.error(error);
+  process.exit(1);
+});

--- a/examples/fastify-scaffold-real/tsgodown.config.ts
+++ b/examples/fastify-scaffold-real/tsgodown.config.ts
@@ -1,0 +1,4 @@
+export default {
+  entry: "src/app.ts",
+  outDir: "dist-go",
+};

--- a/packages/cli/test/commands.e2e.test.ts
+++ b/packages/cli/test/commands.e2e.test.ts
@@ -1181,6 +1181,31 @@ test("M4 acceptance: fastify-unsupported-dynamic fixture fails with deterministi
   );
 });
 
+test("M4 acceptance: real fastify scaffold fixture builds but currently drops plugin-registered routes", () => {
+  const cwd = setupProjectFromFixture("fastify-scaffold-real");
+  const rustLauncher = resolveRustEngineLauncherScript();
+  const engineCoreBin = resolveEngineCoreBin();
+
+  const result = runCli(cwd, "build", {
+    ...process.env,
+    TSGODOWN_RUST_ENGINE_BIN: rustLauncher,
+    TSGODOWN_ENGINE_CORE_BIN: engineCoreBin,
+  });
+
+  assert.equal(result.status, 0, `build failed: ${result.stderr}`);
+  assert.match(result.stdout, /entry: .*src\/app.ts/);
+  assert.match(result.stdout, /"routes"\s*:\s*0/);
+
+  const goPath = path.join(cwd, "dist-go", "main.go");
+  assert.equal(fs.existsSync(goPath), true);
+
+  const goMain = fs.readFileSync(goPath, "utf8");
+  assert.match(goMain, /mux\.HandleFunc\("GET \/health"/);
+  assert.doesNotMatch(goMain, /POST \/users/);
+  assert.doesNotMatch(goMain, /PATCH \/users\/\{id\}/);
+  assert.doesNotMatch(goMain, /DELETE \/users\/\{id\}/);
+});
+
 test("rust-only fixture matrix surfaces deterministic contract error path", () => {
   const cwd = setupProjectFromFixture("error-missing-entry");
   const rustLauncher = createRustEngineLauncher(cwd, [

--- a/packages/cli/test/fixtures/projects/fastify-scaffold-real/dist-go/main.go
+++ b/packages/cli/test/fixtures/projects/fastify-scaffold-real/dist-go/main.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+)
+
+func resolveListenAddr() string {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+	return ":" + port
+}
+
+func main() {
+	fmt.Println("tsgodown-fastify-runtime-ready")
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /health", func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusNotImplemented)
+		fmt.Fprintln(w, "TODO implement handler health for GET /health")
+	})
+	_ = http.ListenAndServe(resolveListenAddr(), mux)
+}
+

--- a/packages/cli/test/fixtures/projects/fastify-scaffold-real/src/app.ts
+++ b/packages/cli/test/fixtures/projects/fastify-scaffold-real/src/app.ts
@@ -1,0 +1,12 @@
+import Fastify from "fastify";
+import healthRoutes from "./routes/health";
+import userRoutes from "./routes/users";
+
+export function buildApp() {
+  const app = Fastify();
+
+  app.register(healthRoutes);
+  app.register(userRoutes, { prefix: "/users" });
+
+  return app;
+}

--- a/packages/cli/test/fixtures/projects/fastify-scaffold-real/src/routes/health.ts
+++ b/packages/cli/test/fixtures/projects/fastify-scaffold-real/src/routes/health.ts
@@ -1,0 +1,9 @@
+import type { FastifyPluginAsync } from "fastify";
+
+const healthRoutes: FastifyPluginAsync = async (app) => {
+  app.get("/health", async () => {
+    return { ok: true };
+  });
+};
+
+export default healthRoutes;

--- a/packages/cli/test/fixtures/projects/fastify-scaffold-real/src/routes/users.ts
+++ b/packages/cli/test/fixtures/projects/fastify-scaffold-real/src/routes/users.ts
@@ -1,0 +1,18 @@
+import type { FastifyPluginAsync } from "fastify";
+
+const userRoutes: FastifyPluginAsync = async (app) => {
+  app.post("/", async (_request, reply) => {
+    reply.code(201);
+    return { id: "u1" };
+  });
+
+  app.patch("/:id", async () => {
+    return { ok: true };
+  });
+
+  app.delete("/:id", async () => {
+    return { ok: true };
+  });
+};
+
+export default userRoutes;

--- a/packages/cli/test/fixtures/projects/fastify-scaffold-real/tsgodown.config.ts
+++ b/packages/cli/test/fixtures/projects/fastify-scaffold-real/tsgodown.config.ts
@@ -1,0 +1,4 @@
+export default {
+  entry: "src/app.ts",
+  outDir: "dist-go",
+};


### PR DESCRIPTION
## Summary
- add a real Fastify scaffold-style example project under `examples/fastify-scaffold-real`
- add matching CLI fixture project under `packages/cli/test/fixtures/projects/fastify-scaffold-real`
- add e2e coverage that locks current behavior for scaffold-style input (build succeeds, plugin-registered routes are not yet extracted)
- update README quickstart section to point to scaffold-oriented example structure

## Why
- move from toy single-file TS samples toward a scaffold-shaped Fastify project baseline
- make upcoming unsupported cleanup work measurable against real project layout (`app.ts` + `routes/*`)

## Validation
- pnpm install --frozen-lockfile
- pnpm run lint
- pnpm run format:check
- pnpm run build
- pnpm run test
- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace --all-targets
- ./scripts/smoke-m1.sh

All passed locally.

## Follow-up
- A2: implement deterministic plugin/register resolution for scaffold route extraction
- A3: update runtime/devx assertions once extracted route count increases from 0
- A4: sync diagnostics/support matrix/inventory docs with new supported scope
