### PR TITLE
test(cli): lock scaffold runtime fallback contract

### DIFF
--- a/packages/cli/test/commands.e2e.test.ts
+++ b/packages/cli/test/commands.e2e.test.ts
@@ -1141,6 +1141,37 @@ test("M4 devx acceptance: fastify-complex fixture emits deterministic method/pat
   assertGoMainScaffold(goMain);
 });
 
+test("M4 runtime contract: scaffold-style fixture keeps deterministic fallback behavior", async () => {
+  const cwd = setupProjectFromFixture("fastify-scaffold-contract");
+  const rustLauncher = resolveRustEngineLauncherScript();
+  const engineCoreBin = resolveEngineCoreBin();
+
+  const result = runCli(cwd, "build", {
+    ...process.env,
+    TSGODOWN_RUST_ENGINE_BIN: rustLauncher,
+    TSGODOWN_ENGINE_CORE_BIN: engineCoreBin,
+  });
+
+  assert.equal(result.status, 0, `build failed: ${result.stderr}`);
+  const goMain = fs.readFileSync(path.join(cwd, "dist-go", "main.go"), "utf8");
+  assert.match(goMain, /mux\.HandleFunc\("GET \/health"/);
+  assert.doesNotMatch(goMain, /POST \/users/);
+
+  const goDir = path.join(cwd, "dist-go");
+  await assertGoRunRequest(goDir, {
+    method: "GET",
+    routePath: "/health",
+    expectedStatus: 501,
+    expectedBodyFragment: "TODO implement handler",
+  });
+  await assertGoRunRequest(goDir, {
+    method: "POST",
+    routePath: "/users",
+    expectedStatus: 404,
+    expectedBodyFragment: "404 page not found",
+  });
+});
+
 test("M4 acceptance: fastify-unsupported-dynamic fixture fails with deterministic diagnostics", () => {
   const cwd = setupProjectFromFixture("fastify-unsupported-dynamic");
   const rustLauncher = resolveRustEngineLauncherScript();

--- a/packages/cli/test/fixtures/projects/fastify-scaffold-contract/src/app.ts
+++ b/packages/cli/test/fixtures/projects/fastify-scaffold-contract/src/app.ts
@@ -1,0 +1,10 @@
+import Fastify from "fastify";
+import healthRoutes from "./routes/health";
+import userRoutes from "./routes/users";
+
+export function buildApp() {
+  const app = Fastify();
+  app.register(healthRoutes);
+  app.register(userRoutes, { prefix: "/users" });
+  return app;
+}

--- a/packages/cli/test/fixtures/projects/fastify-scaffold-contract/src/routes/health.ts
+++ b/packages/cli/test/fixtures/projects/fastify-scaffold-contract/src/routes/health.ts
@@ -1,0 +1,7 @@
+import type { FastifyPluginAsync } from "fastify";
+
+const healthRoutes: FastifyPluginAsync = async (app) => {
+  app.get("/health", async () => ({ ok: true }));
+};
+
+export default healthRoutes;

--- a/packages/cli/test/fixtures/projects/fastify-scaffold-contract/src/routes/users.ts
+++ b/packages/cli/test/fixtures/projects/fastify-scaffold-contract/src/routes/users.ts
@@ -1,0 +1,10 @@
+import type { FastifyPluginAsync } from "fastify";
+
+const userRoutes: FastifyPluginAsync = async (app) => {
+  app.post("/", async (_request, reply) => {
+    reply.code(201);
+    return { id: "u1" };
+  });
+};
+
+export default userRoutes;

--- a/packages/cli/test/fixtures/projects/fastify-scaffold-contract/tsgodown.config.ts
+++ b/packages/cli/test/fixtures/projects/fastify-scaffold-contract/tsgodown.config.ts
@@ -1,0 +1,4 @@
+export default {
+  entry: "src/app.ts",
+  outDir: "dist-go",
+};


### PR DESCRIPTION
## Summary
- add scaffold-style CLI fixture for runtime contract checks (`fastify-scaffold-contract`)
- add e2e assertion that current generated Go runtime keeps deterministic fallback behavior for scaffold/plugin-registered routes
- lock expected behavior now so plugin-resolution improvements can be measured as explicit deltas later

## Why
- prevent hidden runtime behavior drift while scaffold support is being expanded
- establish baseline contracts for `/health` and `/users` on scaffold-shaped input

## Validation
- pnpm install --frozen-lockfile
- pnpm run lint
- pnpm run format:check
- pnpm run build
- pnpm run test
- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace --all-targets
- ./scripts/smoke-m1.sh

All passed locally.
