### PR TITLE
ci: add scaffold example/fixture sync guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
 
       - name: Check diagnostics/docs sync + support-state coherence
         run: pnpm run docs:diagnostics:sync
+      - name: Check fastify scaffold example/fixture sync
+        run: pnpm run docs:scaffold:sync
 
       - name: Build
         run: pnpm run build

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Additional project docs:
 - `pnpm run test:tdd`
 - `pnpm run perf:baseline`
 - `pnpm run devx:fastify-complex`
+- `pnpm run docs:scaffold:sync`
 - `./scripts/smoke-m1.sh`
 
 ## License

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "perf:baseline": "tsx scripts/perf-baseline.ts",
     "devx:fastify-complex": "./scripts/devx-fastify-complex.sh",
     "docs:diagnostics:sync": "node scripts/check-fastify-diagnostics-sync.mjs",
-    "docs:diagnostics:sync:write": "node scripts/check-fastify-diagnostics-sync.mjs --write"
+    "docs:diagnostics:sync:write": "node scripts/check-fastify-diagnostics-sync.mjs --write",
+    "docs:scaffold:sync": "node scripts/check-fastify-scaffold-sync.mjs"
   },
   "devDependencies": {
     "@types/node": "^24.3.0",

--- a/scripts/check-fastify-scaffold-sync.mjs
+++ b/scripts/check-fastify-scaffold-sync.mjs
@@ -1,0 +1,39 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+
+const required = [
+  "examples/fastify-scaffold-real/src/app.ts",
+  "examples/fastify-scaffold-real/src/routes/health.ts",
+  "examples/fastify-scaffold-real/src/routes/users.ts",
+  "examples/fastify-scaffold-real/tsgodown.config.ts",
+  "packages/cli/test/fixtures/projects/fastify-scaffold-real/src/app.ts",
+  "packages/cli/test/fixtures/projects/fastify-scaffold-real/src/routes/health.ts",
+  "packages/cli/test/fixtures/projects/fastify-scaffold-real/src/routes/users.ts",
+  "packages/cli/test/fixtures/projects/fastify-scaffold-real/tsgodown.config.ts",
+];
+
+const presentCount = required.filter((p) =>
+  fs.existsSync(path.join(root, p)),
+).length;
+
+if (presentCount === 0) {
+  console.log(
+    "[scaffold-sync] SKIP (scaffold baseline not introduced on this branch yet)",
+  );
+  process.exit(0);
+}
+
+if (presentCount !== required.length) {
+  const missing = required.filter((p) => !fs.existsSync(path.join(root, p)));
+  console.error(
+    "[scaffold-sync] partial scaffold baseline detected; missing files:",
+  );
+  for (const p of missing) {
+    console.error(`- ${p}`);
+  }
+  process.exit(1);
+}
+
+console.log(`[scaffold-sync] PASS (${required.length} files present)`);


### PR DESCRIPTION
## Summary
- add scaffold example/fixture sync guard script: `scripts/check-fastify-scaffold-sync.mjs`
- wire new CI step: `pnpm run docs:scaffold:sync`
- expose command in package scripts and README dev commands

## Why
- prevent example/fixture drift once scaffold baseline is introduced
- enforce that scaffold files are either fully present in both locations or absent (no partial stale state)

## Validation
- pnpm install --frozen-lockfile
- pnpm run lint
- pnpm run format:check
- pnpm run build
- pnpm run test
- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace --all-targets
- ./scripts/smoke-m1.sh
- pnpm run docs:scaffold:sync

All passed locally.
