### PR TITLE
test(cli): validate scaffold build via installed workspace CLI flow

### DIFF
--- a/packages/cli/test/commands.e2e.test.ts
+++ b/packages/cli/test/commands.e2e.test.ts
@@ -122,6 +122,53 @@ function runCli(
   return result;
 }
 
+const installedWorkspaceCliDirs = new Set<string>();
+
+function runInstalledWorkspaceCli(
+  cwd: string,
+  command: "build" | "check" | "report" | "stages",
+  env?: NodeJS.ProcessEnv,
+) {
+  const packageJsonPath = path.join(cwd, "package.json");
+  if (!fs.existsSync(packageJsonPath)) {
+    fs.writeFileSync(
+      packageJsonPath,
+      JSON.stringify({ name: "tsgodown-e2e-scaffold", private: true }, null, 2),
+    );
+  }
+
+  if (!installedWorkspaceCliDirs.has(cwd)) {
+    const install = spawnSync(
+      "pnpm",
+      ["add", "-D", path.join(repoRoot, "packages", "cli")],
+      {
+        cwd,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          ...env,
+        },
+      },
+    );
+    assert.equal(
+      install.status,
+      0,
+      `pnpm add workspace cli failed: ${install.stderr || install.stdout}`,
+    );
+    installedWorkspaceCliDirs.add(cwd);
+  }
+
+  const result = spawnSync("pnpm", ["exec", "tsgodown", command, "--json"], {
+    cwd,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      ...env,
+    },
+  });
+  return result;
+}
+
 function createRustEngineLauncher(
   cwd: string,
   responseScript: string[],
@@ -1212,12 +1259,12 @@ test("M4 acceptance: fastify-unsupported-dynamic fixture fails with deterministi
   );
 });
 
-test("M4 acceptance: real fastify scaffold fixture builds but currently drops plugin-registered routes", () => {
+test("M4 acceptance: real fastify scaffold fixture builds via installed workspace CLI and currently drops plugin-registered routes", () => {
   const cwd = setupProjectFromFixture("fastify-scaffold-real");
   const rustLauncher = resolveRustEngineLauncherScript();
   const engineCoreBin = resolveEngineCoreBin();
 
-  const result = runCli(cwd, "build", {
+  const result = runInstalledWorkspaceCli(cwd, "build", {
     ...process.env,
     TSGODOWN_RUST_ENGINE_BIN: rustLauncher,
     TSGODOWN_ENGINE_CORE_BIN: engineCoreBin,


### PR DESCRIPTION
## Summary
- shift scaffold-project M4 acceptance coverage from direct `dist/index.js` entry execution to an install-style workspace CLI flow
- add a new helper that installs `tsgodown` into the fixture project via local workspace path and executes `pnpm exec tsgodown build --json`
- keep deterministic runtime-contract assertions unchanged for the real scaffold fixture (entry path, route count, and dropped plugin route expectations)

## What changed
- `packages/cli/test/commands.e2e.test.ts`
  - added `runInstalledWorkspaceCli(...)` helper
    - writes minimal `package.json` in fixture cwd if absent
    - runs `pnpm add -D <repoRoot>/packages/cli`
    - runs `pnpm exec tsgodown <command> --json`
  - updated test:
    - from: `M4 acceptance: real fastify scaffold fixture builds but currently drops plugin-registered routes`
    - to: `M4 acceptance: real fastify scaffold fixture builds via installed workspace CLI and currently drops plugin-registered routes`
    - switched invocation from `runCli(...)` to `runInstalledWorkspaceCli(...)`

## Validation (full local gate)
- `pnpm run format:check`
- `pnpm run docs:diagnostics:sync`
- `pnpm run build`
- `pnpm run test`

## Install/build command path exercised
- install in scaffold fixture cwd:
  - `pnpm add -D /Users/kimhyeongjeong/Desktop/code/agents/tsgodown-a3/packages/cli`
- execute build via installed CLI bin in scaffold fixture cwd:
  - `pnpm exec tsgodown build --json`
