### PR TITLE
ci: add scaffold regeneration/sync gate for fixtures/examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,9 @@ jobs:
         if: ${{ hashFiles('Cargo.toml') != '' }}
         run: cargo test --workspace --all-targets
 
+      - name: Check scaffold regeneration/sync
+        run: pnpm run scaffold:sync:check
+
   smoke-executable:
     name: Smoke executable path (TS -> Go -> run -> health)
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "devx:fastify-complex": "./scripts/devx-fastify-complex.sh",
     "docs:diagnostics:sync": "node scripts/check-fastify-diagnostics-sync.mjs",
     "docs:diagnostics:sync:write": "node scripts/check-fastify-diagnostics-sync.mjs --write",
-    "docs:scaffold:sync": "node scripts/check-fastify-scaffold-sync.mjs"
+    "docs:scaffold:sync": "node scripts/check-fastify-scaffold-sync.mjs",
+    "scaffold:sync:check": "node scripts/check-scaffold-sync.mjs",
+    "scaffold:sync:write": "node scripts/check-scaffold-sync.mjs --write"
   },
   "devDependencies": {
     "@types/node": "^24.3.0",

--- a/scripts/check-scaffold-sync.mjs
+++ b/scripts/check-scaffold-sync.mjs
@@ -1,0 +1,212 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const args = new Set(process.argv.slice(2));
+const writeMode = args.has("--write");
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const rustLauncher = path.join(repoRoot, "scripts", "rust-engine-launcher.sh");
+const engineCoreBin = path.join(repoRoot, "target", "debug", "engine-core");
+const cliBuiltEntry = path.join(
+  repoRoot,
+  "packages",
+  "cli",
+  "dist",
+  "index.js",
+);
+
+function run(cmd, cmdArgs, opts = {}) {
+  const res = spawnSync(cmd, cmdArgs, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    ...opts,
+  });
+  if (res.status !== 0) {
+    const context = [
+      `${cmd} ${cmdArgs.join(" ")} failed (exit=${res.status ?? "null"})`,
+      res.stdout ? `stdout:\n${res.stdout}` : "",
+      res.stderr ? `stderr:\n${res.stderr}` : "",
+    ]
+      .filter(Boolean)
+      .join("\n\n");
+    throw new Error(context);
+  }
+  return res.stdout;
+}
+
+function listTrackedDistGoFiles() {
+  const out = run("git", ["ls-files", "**/dist-go/**"]);
+  return out
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function isScaffoldScope(file) {
+  return (
+    file.startsWith("examples/") ||
+    file.includes("/fixtures/") ||
+    file.startsWith("packages/cli/test/fixtures/")
+  );
+}
+
+function copyDir(src, dest) {
+  fs.mkdirSync(dest, { recursive: true });
+  for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
+    const srcPath = path.join(src, entry.name);
+    const destPath = path.join(dest, entry.name);
+    if (entry.isDirectory()) {
+      copyDir(srcPath, destPath);
+    } else if (entry.isSymbolicLink()) {
+      const target = fs.readlinkSync(srcPath);
+      fs.symlinkSync(target, destPath);
+    } else {
+      fs.copyFileSync(srcPath, destPath);
+    }
+  }
+}
+
+function ensureEngineReady() {
+  if (!fs.existsSync(cliBuiltEntry)) {
+    throw new Error(
+      `missing built CLI entry: ${path.relative(repoRoot, cliBuiltEntry)}\nHint: run \`pnpm run build\` before scaffold sync check.`,
+    );
+  }
+  if (!fs.existsSync(rustLauncher)) {
+    throw new Error(
+      `missing launcher: ${path.relative(repoRoot, rustLauncher)}`,
+    );
+  }
+  fs.chmodSync(rustLauncher, 0o755);
+  if (!fs.existsSync(engineCoreBin)) {
+    console.log(
+      "[scaffold-sync] engine-core not found; building cargo target...",
+    );
+    run("cargo", ["build", "-p", "engine-core"]);
+  }
+}
+
+function normalizeEol(text) {
+  return text.replace(/\r\n/g, "\n");
+}
+
+function regenerateMainGo(projectRootRel) {
+  const absSourceProject = path.join(repoRoot, projectRootRel);
+  const tmpRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), "tsgodown-scaffold-sync-"),
+  );
+  const absTmpProject = path.join(tmpRoot, path.basename(projectRootRel));
+
+  try {
+    copyDir(absSourceProject, absTmpProject);
+
+    const env = {
+      ...process.env,
+      TSGODOWN_RUST_ENGINE_BIN: rustLauncher,
+      TSGODOWN_ENGINE_CORE_BIN: engineCoreBin,
+    };
+
+    const build = spawnSync("node", [cliBuiltEntry, "build", "--json"], {
+      cwd: absTmpProject,
+      encoding: "utf8",
+      env,
+    });
+
+    if (build.status !== 0) {
+      throw new Error(
+        [
+          `failed to regenerate scaffold for ${projectRootRel} (exit=${build.status ?? "null"})`,
+          build.stdout ? `stdout:\n${build.stdout}` : "",
+          build.stderr ? `stderr:\n${build.stderr}` : "",
+        ]
+          .filter(Boolean)
+          .join("\n\n"),
+      );
+    }
+
+    const outPath = path.join(absTmpProject, "dist-go", "main.go");
+    if (!fs.existsSync(outPath)) {
+      throw new Error(
+        `build did not emit dist-go/main.go for ${projectRootRel}`,
+      );
+    }
+    return fs.readFileSync(outPath, "utf8");
+  } finally {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  }
+}
+
+function main() {
+  ensureEngineReady();
+
+  const trackedDistGoFiles = listTrackedDistGoFiles().filter(isScaffoldScope);
+  const disallowedTracked = trackedDistGoFiles.filter(
+    (file) => path.basename(file) !== "main.go",
+  );
+
+  const failures = [];
+
+  if (disallowedTracked.length > 0) {
+    failures.push(
+      [
+        "Tracked dist-go artifacts must only include dist-go/main.go in scaffold-managed examples/fixtures.",
+        ...disallowedTracked.map((file) => `  - ${file}`),
+      ].join("\n"),
+    );
+  }
+
+  const trackedMainGoFiles = trackedDistGoFiles.filter(
+    (file) => path.basename(file) === "main.go",
+  );
+
+  for (const mainGoRel of trackedMainGoFiles) {
+    const projectRootRel = path.dirname(path.dirname(mainGoRel));
+    const configPath = path.join(
+      repoRoot,
+      projectRootRel,
+      "tsgodown.config.ts",
+    );
+    if (!fs.existsSync(configPath)) {
+      failures.push(
+        `${mainGoRel}: expected project config missing (${path.relative(repoRoot, configPath)})`,
+      );
+      continue;
+    }
+
+    const expected = fs.readFileSync(path.join(repoRoot, mainGoRel), "utf8");
+    const regenerated = regenerateMainGo(projectRootRel);
+    if (normalizeEol(expected) === normalizeEol(regenerated)) {
+      continue;
+    }
+
+    if (writeMode) {
+      fs.writeFileSync(path.join(repoRoot, mainGoRel), regenerated, "utf8");
+      console.log(`[scaffold-sync] updated ${mainGoRel}`);
+      continue;
+    }
+
+    failures.push(
+      [
+        `${mainGoRel} is out of sync with regenerated scaffold output.`,
+        "Hint: run `node scripts/check-scaffold-sync.mjs --write` and commit the updated scaffold.",
+      ].join("\n"),
+    );
+  }
+
+  if (failures.length > 0) {
+    console.error("✖ Scaffold regeneration/sync check failed.\n");
+    for (const failure of failures) {
+      console.error(`- ${failure}\n`);
+    }
+    process.exit(1);
+  }
+
+  console.log(
+    `✔ Scaffold sync is valid (${trackedMainGoFiles.length} tracked dist-go/main.go target${trackedMainGoFiles.length === 1 ? "" : "s"}).`,
+  );
+}
+
+main();


### PR DESCRIPTION
## Summary

Adds a CI guard that enforces scaffold regeneration/sync policy for scaffold-managed examples/fixtures.

### What changed

- Added `scripts/check-scaffold-sync.mjs`:
  - Discovers tracked `**/dist-go/**` artifacts in scaffold scope (`examples/` + fixture paths).
  - Enforces policy that only `dist-go/main.go` may be tracked in scaffold-managed targets.
  - Regenerates scaffold output in an isolated temp copy per target using the real CLI + Rust launcher contract.
  - Compares regenerated `dist-go/main.go` with tracked file content (strict, deterministic comparison with EOL normalization).
  - Supports `--write` mode to refresh out-of-sync scaffold files.
- Added package scripts:
  - `pnpm run scaffold:sync:check`
  - `pnpm run scaffold:sync:write`
- Wired CI step in `.github/workflows/ci.yml`:
  - `Check scaffold regeneration/sync` via `pnpm run scaffold:sync:check`

## Why this is strict but non-flaky

- Uses isolated temp workspace copies (does not depend on mutable in-place state).
- Uses tracked-file discovery (`git ls-files`) for deterministic target set.
- Uses the same real Rust adapter/engine path already validated by existing tests.
- Avoids Go runtime variability for this guard (scaffold parity only).
- Gives actionable failure guidance (`--write` command).

## Local gate run (full)

Executed successfully:

- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run docs:diagnostics:sync`
- `pnpm run build`
- `pnpm run test`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --all-targets`
- `pnpm run scaffold:sync:check`
- `./scripts/smoke-m1.sh`

## Notes

- Existing unrelated untracked local files/directories were intentionally not included in this PR.
