### PR TITLE
test(cli): prefer installed CLI path in e2e command execution

### DIFF
--- a/packages/cli/test/commands.e2e.test.ts
+++ b/packages/cli/test/commands.e2e.test.ts
@@ -9,7 +9,6 @@ import { after, test } from "node:test";
 
 const tempDirs: string[] = [];
 const fixturesDir = path.join(import.meta.dirname, "fixtures");
-const cliEntry = path.resolve(import.meta.dirname, "..", "dist", "index.js");
 const repoRoot = path.resolve(import.meta.dirname, "..", "..", "..");
 
 after(() => {
@@ -106,25 +105,9 @@ function createRustLauncher(cwd: string) {
   return launcherPath;
 }
 
-function runCli(
-  cwd: string,
-  command: "build" | "check" | "report" | "stages",
-  env?: NodeJS.ProcessEnv,
-) {
-  const result = spawnSync(process.execPath, [cliEntry, command, "--json"], {
-    cwd,
-    encoding: "utf8",
-    env: {
-      ...process.env,
-      ...env,
-    },
-  });
-  return result;
-}
-
 const installedWorkspaceCliDirs = new Set<string>();
 
-function runInstalledWorkspaceCli(
+function runCli(
   cwd: string,
   command: "build" | "check" | "report" | "stages",
   env?: NodeJS.ProcessEnv,
@@ -1264,7 +1247,7 @@ test("M4 acceptance: real fastify scaffold fixture builds via installed workspac
   const rustLauncher = resolveRustEngineLauncherScript();
   const engineCoreBin = resolveEngineCoreBin();
 
-  const result = runInstalledWorkspaceCli(cwd, "build", {
+  const result = runCli(cwd, "build", {
     ...process.env,
     TSGODOWN_RUST_ENGINE_BIN: rustLauncher,
     TSGODOWN_ENGINE_CORE_BIN: engineCoreBin,


### PR DESCRIPTION
## Summary
- switched CLI e2e helper to an install-first execution path for every CLI command test
- made `runCli` install the local CLI package into each temp test project once (`pnpm add -D <repo>/packages/cli`)
- execute commands through the installed binary (`pnpm exec tsgodown <command> --json`) to reduce direct coupling to `packages/cli/dist/index.js`

## Why
The e2e suite should primarily validate the way users actually run the tool after installation, instead of invoking dist entrypoints directly.

## Determinism / contracts
- kept existing deterministic JSON/runtime contract assertions unchanged
- retained rust adapter + runtime diagnostics contract checks

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run build`
- `pnpm run test`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --all-targets`
- `./scripts/smoke-m1.sh`
