### PR TITLE
ci: verify install-first example builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Build
         run: pnpm run build
 
+      - name: Check install-first example builds (pnpm install + build:go)
+        run: pnpm run examples:install-first:check
+
       - name: Test
         run: pnpm run test
 

--- a/examples/fastify-complex/package.json
+++ b/examples/fastify-complex/package.json
@@ -12,7 +12,8 @@
     "build:ts": "tsc",
     "watch:ts": "tsc -w",
     "dev": "npm run build:ts && concurrently -k -p \"[{name}]\" -n \"TypeScript,App\" -c \"yellow.bold,cyan.bold\" \"npm:watch:ts\" \"npm:dev:start\"",
-    "dev:start": "fastify start --ignore-watch=.ts$ -w -l info -P dist/app.js"
+    "dev:start": "fastify start --ignore-watch=.ts$ -w -l info -P dist/app.js",
+    "build:go": "node ../../packages/cli/dist/index.js build"
   },
   "keywords": [],
   "author": "",

--- a/examples/fastify-min/package.json
+++ b/examples/fastify-min/package.json
@@ -12,7 +12,8 @@
     "build:ts": "tsc",
     "watch:ts": "tsc -w",
     "dev": "npm run build:ts && concurrently -k -p \"[{name}]\" -n \"TypeScript,App\" -c \"yellow.bold,cyan.bold\" \"npm:watch:ts\" \"npm:dev:start\"",
-    "dev:start": "fastify start --ignore-watch=.ts$ -w -l info -P dist/app.js"
+    "dev:start": "fastify start --ignore-watch=.ts$ -w -l info -P dist/app.js",
+    "build:go": "node ../../packages/cli/dist/index.js build"
   },
   "keywords": [],
   "author": "",

--- a/examples/fastify-scaffold-real/package.json
+++ b/examples/fastify-scaffold-real/package.json
@@ -12,7 +12,8 @@
     "build:ts": "tsc",
     "watch:ts": "tsc -w",
     "dev": "npm run build:ts && concurrently -k -p \"[{name}]\" -n \"TypeScript,App\" -c \"yellow.bold,cyan.bold\" \"npm:watch:ts\" \"npm:dev:start\"",
-    "dev:start": "fastify start --ignore-watch=.ts$ -w -l info -P dist/app.js"
+    "dev:start": "fastify start --ignore-watch=.ts$ -w -l info -P dist/app.js",
+    "build:go": "node ../../packages/cli/dist/index.js build"
   },
   "keywords": [],
   "author": "",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "docs:diagnostics:sync:write": "node scripts/check-fastify-diagnostics-sync.mjs --write",
     "docs:scaffold:sync": "node scripts/check-fastify-scaffold-sync.mjs",
     "scaffold:sync:check": "node scripts/check-scaffold-sync.mjs",
-    "scaffold:sync:write": "node scripts/check-scaffold-sync.mjs --write"
+    "scaffold:sync:write": "node scripts/check-scaffold-sync.mjs --write",
+    "examples:install-first:check": "node scripts/check-example-install-first.mjs"
   },
   "devDependencies": {
     "@types/node": "^24.3.0",

--- a/scripts/check-example-install-first.mjs
+++ b/scripts/check-example-install-first.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const engineCoreBin = path.join(repoRoot, "target", "debug", "engine-core");
+const rustLauncher = path.join(repoRoot, "scripts", "rust-engine-launcher.sh");
+
+function run(cmd, args, opts = {}) {
+  const res = spawnSync(cmd, args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    stdio: ["inherit", "pipe", "pipe"],
+    ...opts,
+  });
+
+  if (res.status !== 0) {
+    const context = [
+      `${cmd} ${args.join(" ")} failed (exit=${res.status ?? "null"})`,
+      res.stdout ? `stdout:\n${res.stdout}` : "",
+      res.stderr ? `stderr:\n${res.stderr}` : "",
+    ]
+      .filter(Boolean)
+      .join("\n\n");
+    throw new Error(context);
+  }
+
+  return res;
+}
+
+function listTrackedExamples() {
+  const out = run("git", ["ls-files", "examples/*/tsgodown.config.ts"]);
+  return out.stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((configPath) => path.dirname(configPath));
+}
+
+function readScripts(projectDirRel) {
+  const packageJsonPath = path.join(repoRoot, projectDirRel, "package.json");
+  if (!fs.existsSync(packageJsonPath)) {
+    return {};
+  }
+  const raw = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+  return raw.scripts ?? {};
+}
+
+function main() {
+  const examples = listTrackedExamples();
+  if (examples.length === 0) {
+    console.log(
+      "[install-first] SKIP (no tracked examples with tsgodown.config.ts)",
+    );
+    return;
+  }
+
+  if (!fs.existsSync(rustLauncher)) {
+    throw new Error(
+      `[install-first] missing launcher: ${path.relative(repoRoot, rustLauncher)}`,
+    );
+  }
+
+  if (!fs.existsSync(engineCoreBin)) {
+    console.log(
+      "[install-first] engine-core not found; building cargo target...",
+    );
+    run("cargo", ["build", "-p", "engine-core"]);
+  }
+
+  const env = {
+    ...process.env,
+    TSGODOWN_RUST_ENGINE_BIN: rustLauncher,
+    TSGODOWN_ENGINE_CORE_BIN: engineCoreBin,
+  };
+
+  for (const projectDirRel of examples) {
+    const scripts = readScripts(projectDirRel);
+    if (!scripts["build:go"]) {
+      throw new Error(
+        [
+          `[install-first] ${projectDirRel} is missing required script 'build:go'.`,
+          "Hint: add a package.json script so CI can run `pnpm run build:go` after install.",
+        ].join("\n"),
+      );
+    }
+
+    console.log(`\n[install-first] checking ${projectDirRel}`);
+
+    const cwd = path.join(repoRoot, projectDirRel);
+    run("pnpm", ["install", "--lockfile=false", "--reporter=append-only"], {
+      cwd,
+      env,
+    });
+    run("pnpm", ["run", "build:go"], { cwd, env });
+
+    console.log(`[install-first] PASS ${projectDirRel}`);
+  }
+
+  console.log(
+    `\n[install-first] PASS (${examples.length} example${examples.length === 1 ? "" : "s"})`,
+  );
+}
+
+main();


### PR DESCRIPTION
## Summary
- add a dedicated install-first CI gate that runs per tracked example (`examples/*/tsgodown.config.ts`)
- enforce per-example workflow:
  - `pnpm install`
  - `pnpm run build:go`
- keep output actionable with explicit per-example PASS/fail context and remediation hints

## What changed
- **CI workflow** (`.github/workflows/ci.yml`)
  - added step: `Check install-first example builds (pnpm install + build:go)`
  - command: `pnpm run examples:install-first:check`
- **new check script** (`scripts/check-example-install-first.mjs`)
  - discovers tracked examples via `git ls-files examples/*/tsgodown.config.ts`
  - validates each example defines `build:go`
  - runs in each example directory:
    - `pnpm install --lockfile=false --reporter=append-only`
    - `pnpm run build:go`
  - ensures rust engine launcher/bin are present, with clear diagnostics when missing
- **root package script** (`package.json`)
  - added `examples:install-first:check`
- **example scripts**
  - added `build:go` to:
    - `examples/fastify-min/package.json`
    - `examples/fastify-complex/package.json`
    - `examples/fastify-scaffold-real/package.json`
  - `build:go` runs: `node ../../packages/cli/dist/index.js build`

## Why this is safe with scaffold sync checks
- this gate only validates install/build behavior and script presence per example
- existing scaffold sync checks remain authoritative for scaffold parity/regeneration
- no overlapping mutation checks or flaky interdependency added

## Validation run locally
- `pnpm install --frozen-lockfile`
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run build`
- `pnpm run test`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --all-targets`
- `./scripts/smoke-m1.sh`
- `pnpm run examples:install-first:check`
