### PR TITLE
docs: lock compiler-mode goal and subset/proof contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,21 @@
 # tsgodown
 
-## What is tsgodown
+## Primary goal (direction lock)
 
-`tsgodown` compiles a constrained Fastify codebase into a Go HTTP server.
+`tsgodown` is a **compiler-mode pipeline** for TypeScript services.
 
-- **Input**: TypeScript/JavaScript app code (Fastify-first profile)
-- **Compiler core**: Rust analyzer + IR pipeline
-- **Output**: Go project (`dist-go/main.go`) with deterministic routing behavior
-- **Goal**: keep a familiar `tsdown`-style build UX while producing production-oriented Go artifacts
+The primary goal is fixed as:
 
-This repository is intentionally strict: when a Fastify pattern cannot be extracted deterministically, the compiler skips it and emits explicit diagnostics.
+1. **tsdown bundling as compiler input**
+   - input artifact is the tsdown bundle plus `d.ts` and sourcemap metadata
+2. **AST + sourcemap + `d.ts`-driven IR/Go generation**
+   - analysis and lowering are driven by syntax + symbol/type surface + source mapping provenance
+3. **`go build` output**
+   - generated output must compile as a normal Go project/binary using the Go toolchain
+4. **100% behavioral coverage (scoped contract)**
+   - defined as: full behavioral match **within the declared supported subset**, proven by differential testing (TS runtime vs Go runtime), not by claiming universal JS/TS coverage
+
+This repository remains intentionally strict: when code is outside the supported subset or cannot be extracted deterministically, the compiler must emit explicit diagnostics/fallback behavior instead of silently guessing.
 
 ## Supported Fastify patterns
 
@@ -131,6 +137,7 @@ When build output is incomplete, start here:
 - Failure triage playbook: [`docs/operations/FAILURE_TRIAGE_PLAYBOOK.md`](docs/operations/FAILURE_TRIAGE_PLAYBOOK.md)
 - M1 release gate and acceptance criteria: [`docs/specs/M1_RELEASE_GATE.md`](docs/specs/M1_RELEASE_GATE.md)
 - Testing strategy and boundaries: [`docs/specs/TESTING_STRATEGY.md`](docs/specs/TESTING_STRATEGY.md)
+- Compiler-mode supported subset + proof contracts: [`docs/specs/COMPILER_MODE_CONTRACTS.md`](docs/specs/COMPILER_MODE_CONTRACTS.md)
 
 Additional project docs:
 

--- a/docs/specs/COMPILER_MODE_CONTRACTS.md
+++ b/docs/specs/COMPILER_MODE_CONTRACTS.md
@@ -1,0 +1,29 @@
+# Compiler Mode Contracts
+
+## Supported Subset Contract
+
+`tsgodown` only claims correctness for a declared, versioned supported subset.
+
+- The subset is the union of patterns explicitly documented in capability/spec docs.
+- Any source shape outside this subset is **out of contract**.
+- Out-of-contract cases must produce deterministic diagnostics and/or explicit fallback behavior.
+- Shipping milestones must not silently expand claims beyond the documented subset.
+
+In short: coverage claims are scoped to what we explicitly support, not the full TypeScript/Fastify ecosystem.
+
+## Proof Contract
+
+For each supported-subset feature, correctness is established by differential proof obligations.
+
+Minimum proof obligations:
+
+1. **Semantic differential tests**
+   - compare TS runtime behavior and generated Go runtime behavior for equivalent inputs.
+2. **Runtime compatibility layer verification**
+   - document and test any semantic shims required to match TS/Fastify behavior.
+3. **Fallback policy verification**
+   - verify out-of-contract inputs fail/diagnose/fallback as specified (never silently miscompile).
+4. **Performance SLO gates**
+   - enforce agreed build/runtime budgets so correctness is delivered at acceptable cost.
+
+`100% behavioral coverage` means every behavior inside the supported subset is covered by these proof obligations and passes the differential gate.


### PR DESCRIPTION
## Direction lock: compiler-mode primary goal

This PR locks top-level project messaging to the compiler-mode goal and makes the coverage/proof boundary explicit.

### What changed

1. **README direction lock**
   - Declares the primary goal as:
     - `tsdown` bundling (`bundle + d.ts + sourcemap`) as compiler input
     - `AST + sourcemap + d.ts`-driven IR/Go generation
     - `go build` output path
     - `100% behavioral coverage` defined only inside the declared supported subset, proven by differential tests
2. **New spec doc for ambiguity removal**
   - Added `docs/specs/COMPILER_MODE_CONTRACTS.md`
   - Defines:
     - **Supported Subset Contract**
     - **Proof Contract** (semantic differential tests, runtime-compat layer verification, fallback policy verification, performance SLO gates)
3. **README docs pointers updated**
   - Links to the new contracts doc from the diagnostics/specs section.

### Why this is needed now

Without an explicit subset/proof contract, "100% coverage" can be interpreted as universal TS/JS coverage and cause roadmap drift. This PR intentionally narrows and formalizes the claim so implementation and CI quality gates can align to one contract.

### Validation run (all green)

- `pnpm install --frozen-lockfile`
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run build`
- `pnpm run test`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --all-targets`
- `./scripts/smoke-m1.sh`

### Related

- Issue #117 updated with stronger checklist gates for:
  - semantic differential tests (TS runtime vs Go runtime)
  - runtime compatibility layer scope
  - fallback policy
  - performance SLO gates