### PR TITLE
hard-reset A3: switch CLI default path to compiler kickoff

### DIFF
--- a/packages/cli/src/argv.ts
+++ b/packages/cli/src/argv.ts
@@ -4,7 +4,7 @@ export function parseArgv(argv: string[]): {
   command: Command | string;
   json: boolean;
 } {
-  const command = (argv[0] || "build") as Command | string;
+  const command = (argv[0] || "compiler") as Command | string;
   const flags = new Set(argv.slice(1));
   const json = flags.has("--json") || flags.has("-j");
   return { command, json };
@@ -15,6 +15,7 @@ export function isCommand(value: string): value is Command {
     value === "build" ||
     value === "check" ||
     value === "report" ||
-    value === "stages"
+    value === "stages" ||
+    value === "compiler"
   );
 }

--- a/packages/cli/src/command-executor.ts
+++ b/packages/cli/src/command-executor.ts
@@ -1,4 +1,10 @@
-import { runBuild, runCheck, runReport, runStages } from "./commands/index.js";
+import {
+  runBuild,
+  runCheck,
+  runCompiler,
+  runReport,
+  runStages,
+} from "./commands/index.js";
 import type { Command } from "./types.js";
 
 export async function executeCommand(
@@ -15,6 +21,9 @@ export async function executeCommand(
       return;
     case "report":
       await runReport(cwd, json);
+      return;
+    case "compiler":
+      await runCompiler(cwd, json);
       return;
     case "stages":
       await runStages(cwd, json);

--- a/packages/cli/src/commands/compiler.ts
+++ b/packages/cli/src/commands/compiler.ts
@@ -1,0 +1,11 @@
+export async function runCompiler(_cwd: string, _json: boolean) {
+  throw new Error(
+    [
+      "[compiler-mode] default compiler kickoff is not implemented yet",
+      "source: cli-default-command",
+      "stage: COMPILER_KICKOFF",
+      "cause: compiler mode pipeline entrypoint missing",
+      "guidance: run `tsgodown build` for current Rust-backed build flow until compiler-mode is fully implemented.",
+    ].join("; "),
+  );
+}

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -1,4 +1,5 @@
 export { runBuild } from "./build.js";
 export { runCheck } from "./check.js";
+export { runCompiler } from "./compiler.js";
 export { runReport } from "./report.js";
 export { runStages } from "./stages.js";

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -1,4 +1,4 @@
-export type Command = "build" | "check" | "report" | "stages";
+export type Command = "build" | "check" | "report" | "stages" | "compiler";
 
 export type TargetDiagnostics = {
   routes: number;

--- a/packages/cli/test/commands.e2e.test.ts
+++ b/packages/cli/test/commands.e2e.test.ts
@@ -152,6 +152,46 @@ function runCli(
   return result;
 }
 
+function runCliDefault(cwd: string, env?: NodeJS.ProcessEnv) {
+  const packageJsonPath = path.join(cwd, "package.json");
+  if (!fs.existsSync(packageJsonPath)) {
+    fs.writeFileSync(
+      packageJsonPath,
+      JSON.stringify({ name: "tsgodown-e2e-scaffold", private: true }, null, 2),
+    );
+  }
+
+  if (!installedWorkspaceCliDirs.has(cwd)) {
+    const install = spawnSync(
+      "pnpm",
+      ["add", "-D", path.join(repoRoot, "packages", "cli")],
+      {
+        cwd,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          ...env,
+        },
+      },
+    );
+    assert.equal(
+      install.status,
+      0,
+      `pnpm add workspace cli failed: ${install.stderr || install.stdout}`,
+    );
+    installedWorkspaceCliDirs.add(cwd);
+  }
+
+  return spawnSync("pnpm", ["exec", "tsgodown"], {
+    cwd,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      ...env,
+    },
+  });
+}
+
 function createRustEngineLauncher(
   cwd: string,
   responseScript: string[],
@@ -567,6 +607,27 @@ test("CLI JSON contract fixtures: warn path", () => {
     const normalized = normalizeResult(cwd, parsed);
     assertSubset(normalized, fixture[command], command);
   }
+});
+
+test("CLI default command kicks off compiler mode and fails deterministically", () => {
+  const cwd = setupProject([
+    "const fastify = {} as any;",
+    "const health = () => {};",
+    "fastify.get('/health', health);",
+  ]);
+
+  const result = runCliDefault(cwd);
+  assert.notEqual(result.status, 0, "default compiler kickoff should fail");
+  assert.match(
+    result.stderr,
+    /\[tsgodown\] command failed: \[compiler-mode\] default compiler kickoff is not implemented yet/,
+  );
+  assert.match(result.stderr, /source: cli-default-command/);
+  assert.match(result.stderr, /stage: COMPILER_KICKOFF/);
+  assert.match(
+    result.stderr,
+    /cause: compiler mode pipeline entrypoint missing/,
+  );
 });
 
 test("CLI fail diagnostics include source/cause/guidance contract", () => {


### PR DESCRIPTION
## Summary
- switch CLI default command path from implicit `build` to explicit compiler-mode kickoff
- add `compiler` command wiring in CLI executor/command typing
- implement compiler kickoff stub with deterministic error contract fields (source/stage/cause/guidance)
- add e2e coverage for default invocation to assert stable deterministic failure UX

## Validation
- pnpm install --frozen-lockfile
- pnpm run lint
- pnpm run format:check
- pnpm run build
- pnpm run test
- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace --all-targets
- ./scripts/smoke-m1.sh