### PR TITLE
refactor: purge fastify-specific rust analyzer residues

### DIFF
--- a/crates/engine-core/src/lib.rs
+++ b/crates/engine-core/src/lib.rs
@@ -17,7 +17,7 @@ mod tests {
         let request = AnalyzeRequest {
             manifest: InputManifest {
                 entry: "src/server.ts".to_string(),
-                framework: Some("fastify".to_string()),
+                framework: Some("compiler".to_string()),
             },
             config: AnalyzeConfig {
                 profile: Some("default".to_string()),
@@ -59,7 +59,7 @@ mod tests {
         let request = AnalyzeRequest {
             manifest: InputManifest {
                 entry: "src/server.ts".to_string(),
-                framework: Some("fastify".to_string()),
+                framework: Some("compiler".to_string()),
             },
             config: AnalyzeConfig::default(),
         };

--- a/packages/analyzer-rust/src/lib.rs
+++ b/packages/analyzer-rust/src/lib.rs
@@ -5,9 +5,7 @@ pub use ir::{
     ModuleIR, ProgramIR, RouteIR,
 };
 
-pub fn analyze_fastify_entry(_file: &str, _src: &str) -> ProgramIR {
-    // TODO(compiler-mode): replace this legacy Fastify pattern-matching analyzer entrypoint
-    // with compiler-mode IR builder flow.
+pub fn analyze_compiler_entry(_file: &str, _src: &str) -> ProgramIR {
     ProgramIR {
         modules: vec![],
         routes: vec![],

--- a/packages/analyzer-rust/tests/compiler_mode_stub.rs
+++ b/packages/analyzer-rust/tests/compiler_mode_stub.rs
@@ -1,8 +1,11 @@
-use analyzer_rust::analyze_fastify_entry;
+use analyzer_rust::analyze_compiler_entry;
 
 #[test]
-fn returns_empty_program_ir_in_compiler_mode_stub() {
-    let ir = analyze_fastify_entry("src/index.ts", "fastify.get('/health', health)");
+fn returns_empty_program_ir_for_compiler_mode_stub() {
+    let ir = analyze_compiler_entry(
+        "src/index.ts",
+        "export const health = () => ({ ok: true });",
+    );
 
     assert!(ir.modules.is_empty());
     assert!(ir.routes.is_empty());


### PR DESCRIPTION
## Summary
- remove the legacy fastify-named analyzer-rust entrypoint and replace it with a compiler-mode neutral stub API
- update rust analyzer stub test input/expectations to compiler-mode wording (no fastify-specific pattern assumptions)
- keep deterministic diagnostics/build contracts unchanged in adapter flow while purging fastify-specific test request metadata in engine-core rust tests

## Validation
- pnpm install --frozen-lockfile
- pnpm run lint
- pnpm run format:check
- pnpm run build
- pnpm run test
- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace --all-targets
- ./scripts/smoke-m1.sh