### PR TITLE
docs(specs): define TS vs Go semantic parity contract

### DIFF
--- a/docs/specs/COMPILER_MODE_CONTRACTS.md
+++ b/docs/specs/COMPILER_MODE_CONTRACTS.md
@@ -19,6 +19,7 @@ Minimum proof obligations:
 
 1. **Semantic differential tests**
    - compare TS runtime behavior and generated Go runtime behavior for equivalent inputs.
+   - parity is measured by the normative dimensions in [`SEMANTIC_PARITY_CONTRACT.md`](./SEMANTIC_PARITY_CONTRACT.md) (status/body/headers/method behavior).
 2. **Runtime compatibility layer verification**
    - document and test any semantic shims required to match TS/Fastify behavior.
 3. **Fail-closed policy verification**

--- a/docs/specs/SEMANTIC_PARITY_CONTRACT.md
+++ b/docs/specs/SEMANTIC_PARITY_CONTRACT.md
@@ -1,0 +1,42 @@
+# Semantic Parity Contract (TS Runtime ↔ Go Runtime)
+
+## Purpose
+Define the **observable equivalence contract** between:
+
+- TypeScript/Fastify runtime behavior (reference)
+- Generated Go runtime behavior (target)
+
+for in-contract routes and requests.
+
+This document is the normative definition used by M1+ differential parity tests.
+
+## Observable equivalence (normative)
+For any request accepted by the supported subset contract, TS runtime and Go runtime are considered semantically equivalent when all parity dimensions below hold.
+
+### Parity dimensions
+
+| Dimension | Contract definition | Notes |
+| --- | --- | --- |
+| Status code | Exact numeric equality (`2xx/4xx/5xx` + exact code) | e.g. `200 != 201`; `404` and `405` must not be collapsed |
+| Body | Byte-equivalent response body for scaffolded deterministic fixtures | For non-deterministic content, tests must assert a canonicalized comparator (explicitly documented per fixture) |
+| Headers | Equality on the parity header set: `Content-Type`, `Allow` (when method mismatch), and any fixture-declared deterministic headers | Header name comparison is case-insensitive; values are compared after trimming OWS around comma-separated entries |
+| Method behavior | Identical method dispatch outcome for equivalent path: allowed methods return route response; disallowed methods return `405 Method Not Allowed` with deterministic `Allow`; unknown path returns `404` | `Allow` ordering must be deterministic and stable in fixtures |
+
+## Non-goals (explicitly out of parity scope)
+
+- Byte-for-byte framework-default header parity beyond the parity header set (e.g., `Date`, `Server`, transport/runtime injected headers).
+- Streaming/chunking and connection-level behavior (keep-alive semantics, flush timing, HTTP/2 specific framing).
+- Performance equivalence (covered by performance baseline/SLO docs, not semantic parity).
+- Behavior for out-of-contract source patterns (those are governed by diagnostics/fallback contracts).
+
+## Acceptance criteria by test layer
+
+| Layer | Required acceptance criteria | Representative tests / artifacts |
+| --- | --- | --- |
+| Unit | Deterministic method matrix and header construction rules are stable (`Allow` generation, route method normalization). | `packages/emitter-go/test/emit-go.test.ts` |
+| Integration | Rust analyzer/emitter contract preserves route/method semantics and diagnostics boundaries for supported subset. | `packages/analyzer-rust/tests/contract_parity_regression.rs` |
+| E2E differential parity | Same fixture requests against TS runtime and generated Go runtime satisfy parity dimensions (status/body/headers/method behavior). | `packages/cli/test/commands.e2e.test.ts` (M2/M3 acceptance tests) |
+| Release gate | Canonical M1 gate proves build path and generated runtime scaffold viability (generation + compile path). | `scripts/m1-release-gate.sh`, `docs/specs/M1_RELEASE_GATE.md` |
+
+## Pass/fail rule
+A parity suite run is **PASS** only when every in-scope assertion in each required layer passes. Any mismatch in a normative parity dimension is a release-blocking failure for the corresponding milestone gate.

--- a/docs/specs/TESTING_STRATEGY.md
+++ b/docs/specs/TESTING_STRATEGY.md
@@ -40,6 +40,7 @@ Note: the gate is limited to execution-path verification and does not cover inte
 
 ## M3 runtime correctness/stability extension
 - Runtime executable-fixture coverage is extended beyond the M1/M2 happy-path checks.
+- Normative parity definition: [`SEMANTIC_PARITY_CONTRACT.md`](./SEMANTIC_PARITY_CONTRACT.md)
 - Primary test location: `packages/cli/test/commands.e2e.test.ts`
 - Key acceptance tests:
   - `M2 acceptance: TS fixture routes are reachable in generated Go runtime`


### PR DESCRIPTION
## Summary
- add a normative semantic parity contract for TS runtime vs generated Go runtime
- define exact parity dimensions (status/body/headers/method behavior)
- define explicit non-goals
- add acceptance-criteria table mapped to unit/integration/e2e/release-gate test layers
- link the parity contract from compiler-mode proof obligations and testing strategy

## Why
Clarifies what "semantic parity" means for release decisions and prevents ambiguity in differential testing claims.

## Validation
- full repo gate executed locally (lint/format/build/test/cargo/smoke)
