### PR TITLE
docs: finalize M1 compiler-mode spec lock contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ When build output is incomplete, start here:
 - Failure triage playbook: [`docs/operations/FAILURE_TRIAGE_PLAYBOOK.md`](docs/operations/FAILURE_TRIAGE_PLAYBOOK.md)
 - M1 release gate and acceptance criteria: [`docs/specs/M1_RELEASE_GATE.md`](docs/specs/M1_RELEASE_GATE.md)
 - Testing strategy and boundaries: [`docs/specs/TESTING_STRATEGY.md`](docs/specs/TESTING_STRATEGY.md)
-- Compiler-mode supported subset + proof contracts: [`docs/specs/COMPILER_MODE_CONTRACTS.md`](docs/specs/COMPILER_MODE_CONTRACTS.md)
+- Canonical compiler-mode spec lock (supported subset / out-of-scope / fail-closed): [`docs/specs/COMPILER_MODE_CONTRACTS.md`](docs/specs/COMPILER_MODE_CONTRACTS.md)
 
 Additional project docs:
 

--- a/docs/specs/COMPILER_MODE_CONTRACTS.md
+++ b/docs/specs/COMPILER_MODE_CONTRACTS.md
@@ -1,30 +1,49 @@
-# Compiler Mode Contracts
+# Compiler Mode Contracts (Canonical)
 
-## Supported Subset Contract
+This document is the canonical policy source for compiler-mode support claims.
 
-`tsgodown` only claims correctness for a declared, versioned supported subset.
+## 1) Supported Subset (Spec Lock)
 
-- The subset is the union of patterns explicitly documented in capability/spec docs.
-- Any source shape outside this subset is **out of contract**.
-- Out-of-contract cases must produce deterministic diagnostics and fail closed.
-- Shipping milestones must not silently expand claims beyond the documented subset.
+`tsgodown` is a compiler. It only guarantees correctness for a declared, versioned subset of input programs.
 
-In short: coverage claims are scoped to what we explicitly support, not the full TypeScript/Fastify ecosystem.
+- The supported subset is the union of compiler-recognized source patterns explicitly listed in spec/capability documents.
+- Any input program outside that subset is **out of scope** for correctness claims.
+- The compiler must not infer support from best-effort behavior or incidental pass cases.
+- Milestone/release messaging must not expand claims beyond this locked subset.
 
-## Proof Contract
+In short: correctness claims are locked to explicit compiler contracts, not to the general TypeScript/Fastify ecosystem.
+
+## 2) Out-of-Scope Handling (Fail Closed)
+
+For out-of-scope input programs, compiler behavior is fixed:
+
+1. Emit deterministic diagnostics (stable code + reproducible location).
+2. Stop compilation for that input (no silent partial success).
+3. Never fall back to permissive/heuristic translation that could mask semantic mismatch.
+
+This is a fail-closed compiler policy: no silent miscompile, no silent acceptance.
+
+## 3) Proof Obligations for In-Scope Features
 
 For each supported-subset feature, correctness is established by differential proof obligations.
 
-Minimum proof obligations:
+Minimum obligations:
 
 1. **Semantic differential tests**
-   - compare TS runtime behavior and generated Go runtime behavior for equivalent inputs.
-   - parity is measured by the normative dimensions in [`SEMANTIC_PARITY_CONTRACT.md`](./SEMANTIC_PARITY_CONTRACT.md) (status/body/headers/method behavior).
-2. **Runtime compatibility layer verification**
-   - document and test any semantic shims required to match TS/Fastify behavior.
-3. **Fail-closed policy verification**
-   - verify out-of-contract inputs fail with deterministic diagnostics as specified (never silently miscompile).
+   - Compare TypeScript runtime behavior vs generated Go runtime behavior for equivalent inputs.
+   - Parity is measured by the normative dimensions in [`SEMANTIC_PARITY_CONTRACT.md`](./SEMANTIC_PARITY_CONTRACT.md) (status/body/headers/method behavior).
+2. **Runtime-compatibility verification**
+   - Specify and test semantic shims required to preserve source-program behavior.
+3. **Fail-closed verification**
+   - Verify out-of-scope inputs fail with deterministic diagnostics as specified (never silently miscompile).
 4. **Performance SLO gates**
-   - enforce agreed build/runtime budgets so correctness is delivered at acceptable cost.
+   - Enforce agreed compile/runtime budgets so correctness is delivered within accepted cost.
 
-`100% behavioral coverage` means every behavior inside the supported subset is covered by these proof obligations and passes the differential gate.
+`100% behavioral coverage` means every behavior inside the supported subset is covered by these obligations and passes the differential gate.
+
+## 4) Canonical References
+
+- Capability boundary table: [`CAPABILITY_MATRIX.md`](./CAPABILITY_MATRIX.md)
+- Diagnostic contract: [`DIAGNOSTICS.md`](./DIAGNOSTICS.md)
+- M1 executable release gate: [`M1_RELEASE_GATE.md`](./M1_RELEASE_GATE.md)
+- Test policy and required gate commands: [`TESTING_STRATEGY.md`](./TESTING_STRATEGY.md)

--- a/docs/specs/FASTIFY_COMPILER_MODE_STATUS.md
+++ b/docs/specs/FASTIFY_COMPILER_MODE_STATUS.md
@@ -2,12 +2,15 @@
 
 This project tracks Fastify status through compiler-mode contracts and executable proof gates.
 
-For current source-of-truth contracts and delivery direction, see:
+Canonical compiler contract source:
 
-- Contracts: `docs/specs/COMPILER_MODE_CONTRACTS.md`
-- Diagnostics behavior: `docs/specs/DIAGNOSTICS.md`
-- Capability gate (compile viability): `docs/specs/CAPABILITY_MATRIX.md`
-- Near-term execution gate: `docs/specs/M1_RELEASE_GATE.md`
+- Compiler-mode spec lock + fail-closed policy: `docs/specs/COMPILER_MODE_CONTRACTS.md`
+
+Related compiler references:
+
+- Diagnostics contract: `docs/specs/DIAGNOSTICS.md`
+- Capability boundary gate (compile viability): `docs/specs/CAPABILITY_MATRIX.md`
+- Executable M1 release gate: `docs/specs/M1_RELEASE_GATE.md`
 - Backlog/roadmap queue: `docs/backlog/NODE_COMPAT_MATRIX.md`
 
-Policy: support claims are made through compiler-mode contracts + differential proof obligations.
+Policy: compiler support claims are made only through documented compiler contracts plus differential proof obligations.


### PR DESCRIPTION
## Summary
- finalize canonical compiler-mode spec lock contract in `docs/specs/COMPILER_MODE_CONTRACTS.md`
- define supported subset boundary, explicit out-of-scope handling, and fail-closed compile policy
- normalize wording to compiler terminology (input programs, compilation, diagnostics, semantic mismatch)
- update related docs pointers so `COMPILER_MODE_CONTRACTS.md` is the canonical source

## Changes
- `docs/specs/COMPILER_MODE_CONTRACTS.md`
  - rewritten as canonical policy doc
  - added explicit sections:
    - Supported Subset (Spec Lock)
    - Out-of-Scope Handling (Fail Closed)
    - Proof Obligations for In-Scope Features
    - Canonical References
- `docs/specs/FASTIFY_COMPILER_MODE_STATUS.md`
  - updated links/wording to point to canonical compiler contract source
- `README.md`
  - updated docs link text to canonical spec lock framing

## DoD checklist
- [x] Supported subset contract finalized
- [x] Out-of-scope boundary finalized
- [x] Fail-closed policy finalized
- [x] Compiler terminology normalized across touched docs
- [x] Related docs links updated to canonical source
- [x] Rebasing on latest `origin/main` completed before push
- [x] Full required gate executed and passing

## TDD evidence (RED → GREEN → REFACTOR)
RED
- docs contract ambiguity identified (supported subset / out-of-scope / fail-closed wording and canonical-source linkage were not explicit enough for compiler-mode lock intent)

GREEN
- minimal doc implementation applied to make the contract explicit in canonical doc + linked references:
  - `docs/specs/COMPILER_MODE_CONTRACTS.md`
  - `docs/specs/FASTIFY_COMPILER_MODE_STATUS.md`
  - `README.md`

REFACTOR
- terminology normalized to compiler-centric wording and section structure tightened
- full gate re-run and passing (see evidence comment):
  - https://github.com/jingjing2222/tsgodown/pull/128#issuecomment-3914223683
