### PR TITLE
test: strengthen differential harness for real-fastify scaffold patterns

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Test
         run: pnpm run test
 
+      - name: Differential harness (deterministic parity gate)
+        run: pnpm run harness:differential
+
       - name: Setup Rust
         if: ${{ hashFiles('Cargo.toml') != '' }}
         uses: dtolnay/rust-toolchain@stable

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "scaffold:sync:write": "node scripts/check-scaffold-sync.mjs --write",
     "examples:install-first:check": "node scripts/check-example-install-first.mjs",
     "guard:compiler-mode-only": "node scripts/guard-compiler-mode-only.mjs",
-    "harness:differential": "node scripts/differential-harness.mjs --scenario fastify-min-get-health"
+    "harness:differential": "node scripts/differential-harness.mjs --scenario fastify-scaffold-real-routes"
   },
   "devDependencies": {
     "@types/node": "^24.3.0",

--- a/packages/cli/test/differential-harness.test.ts
+++ b/packages/cli/test/differential-harness.test.ts
@@ -6,19 +6,18 @@ import { test } from "node:test";
 const repoRoot = path.resolve(import.meta.dirname, "..", "..", "..");
 const harnessPath = path.join(repoRoot, "scripts", "differential-harness.mjs");
 
-function runHarness(env: NodeJS.ProcessEnv = {}) {
-  return spawnSync(
-    process.execPath,
-    [harnessPath, "--scenario", "fastify-min-get-health"],
-    {
-      cwd: repoRoot,
-      encoding: "utf8",
-      env: {
-        ...process.env,
-        ...env,
-      },
+function runHarness(
+  scenario = "fastify-min-get-health",
+  env: NodeJS.ProcessEnv = {},
+) {
+  return spawnSync(process.execPath, [harnessPath, "--scenario", scenario], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      ...env,
     },
-  );
+  });
 }
 
 test("differential harness emits deterministic report format for supported-subset scenario", () => {
@@ -65,8 +64,44 @@ test("differential harness emits deterministic report format for supported-subse
   assert.deepEqual(report.cases[0]?.diffs, []);
 });
 
+test("differential harness covers deterministic scaffold-real style endpoint matrix", () => {
+  const result = runHarness("fastify-scaffold-real-routes");
+  assert.equal(result.status, 0, result.stderr);
+
+  const report = JSON.parse(result.stdout) as {
+    scenario: string;
+    summary: {
+      total: number;
+      matched: number;
+      mismatched: number;
+      pass: boolean;
+    };
+    cases: Array<{ id: string; request: { method: string; path: string } }>;
+  };
+
+  assert.equal(report.scenario, "fastify-scaffold-real-routes");
+  assert.deepEqual(report.summary, {
+    total: 5,
+    matched: 5,
+    mismatched: 0,
+    pass: true,
+  });
+  assert.deepEqual(
+    report.cases.map((entry) => entry.id),
+    [
+      "health-get-200",
+      "missing-get-404",
+      "users-get-405",
+      "users-post-200",
+      "users-put-200",
+    ],
+  );
+});
+
 test("differential harness fails closed on runtime mismatch", () => {
-  const result = runHarness({ TSGODOWN_DIFF_FORCE_MISMATCH: "1" });
+  const result = runHarness("fastify-min-get-health", {
+    TSGODOWN_DIFF_FORCE_MISMATCH: "1",
+  });
   assert.equal(result.status, 1, "expected mismatch to fail harness");
 
   const report = JSON.parse(result.stdout) as {
@@ -85,4 +120,36 @@ test("differential harness fails closed on runtime mismatch", () => {
   assert.equal(report.summary.pass, false);
   assert.equal(report.cases[0]?.match, false);
   assert.deepEqual(report.cases[0]?.diffs, ["status:200!=501"]);
+});
+
+test("differential harness gate catches each deterministic drift type", () => {
+  const driftCases: Array<{ mode: string; diff: string }> = [
+    { mode: "status", diff: "status:200!=501" },
+    { mode: "headers", diff: "headers-mismatch" },
+    { mode: "body", diff: "body-mismatch" },
+    { mode: "missing-go", diff: "missing-go-case" },
+    { mode: "missing-ts", diff: "missing-ts-case" },
+  ];
+
+  for (const driftCase of driftCases) {
+    const result = runHarness("fastify-scaffold-real-routes", {
+      TSGODOWN_DIFF_FORCE_DRIFT: driftCase.mode,
+    });
+    assert.equal(result.status, 1, `expected ${driftCase.mode} drift to fail`);
+
+    const report = JSON.parse(result.stdout) as {
+      summary: {
+        mismatched: number;
+        pass: boolean;
+      };
+      cases: Array<{ diffs: string[] }>;
+    };
+
+    assert.equal(report.summary.pass, false);
+    assert.equal(report.summary.mismatched, 1);
+    assert.ok(
+      report.cases.some((entry) => entry.diffs.includes(driftCase.diff)),
+      `missing expected diff marker ${driftCase.diff}`,
+    );
+  }
 });

--- a/scripts/differential-harness.mjs
+++ b/scripts/differential-harness.mjs
@@ -24,6 +24,61 @@ const SCENARIOS = {
       },
     ],
   },
+  "fastify-scaffold-real-routes": {
+    subset: "real-fastify scaffold route behavior parity",
+    description:
+      "Deterministic parity checks for scaffold-real style endpoints including method matrix and negative-path behavior.",
+    cases: [
+      {
+        id: "health-get-200",
+        request: { method: "GET", path: "/health" },
+        expected: {
+          status: 200,
+          body: { ok: true },
+          headers: { "content-type": "application/json" },
+        },
+      },
+      {
+        id: "missing-get-404",
+        request: { method: "GET", path: "/missing" },
+        expected: {
+          status: 404,
+          body: "404 page not found",
+          headers: { "content-type": "text/plain; charset=utf-8" },
+        },
+      },
+      {
+        id: "users-get-405",
+        request: { method: "GET", path: "/users" },
+        expected: {
+          status: 405,
+          body: "Method Not Allowed",
+          headers: {
+            allow: "POST",
+            "content-type": "text/plain; charset=utf-8",
+          },
+        },
+      },
+      {
+        id: "users-post-200",
+        request: { method: "POST", path: "/users" },
+        expected: {
+          status: 200,
+          body: { id: "u1" },
+          headers: { "content-type": "application/json" },
+        },
+      },
+      {
+        id: "users-put-200",
+        request: { method: "PUT", path: "/users/42" },
+        expected: {
+          status: 200,
+          body: { ok: true },
+          headers: { "content-type": "application/json" },
+        },
+      },
+    ],
+  },
 };
 
 function normalizeHeaders(headers = {}) {
@@ -117,7 +172,7 @@ function compareScenario({ scenarioName, tsProbe, goProbe }) {
     });
   }
 
-  const report = {
+  return {
     version: REPORT_VERSION,
     scenario: scenarioName,
     subset: scenario.subset,
@@ -138,8 +193,6 @@ function compareScenario({ scenarioName, tsProbe, goProbe }) {
     },
     cases,
   };
-
-  return report;
 }
 
 function runTsRuntimeProbe(scenarioName) {
@@ -155,25 +208,59 @@ function runTsRuntimeProbe(scenarioName) {
   }));
 }
 
+function applyDrift(goProbe) {
+  const mode =
+    process.env.TSGODOWN_DIFF_FORCE_DRIFT ??
+    (process.env.TSGODOWN_DIFF_FORCE_MISMATCH === "1" ? "status" : null);
+  if (!mode) return goProbe;
+
+  const mutated = [...goProbe];
+  if (mode === "missing-go") {
+    return mutated.slice(1);
+  }
+
+  if (mode === "missing-ts") {
+    return mutated;
+  }
+
+  if (mutated.length === 0) return mutated;
+  const first = {
+    ...mutated[0],
+    response: {
+      ...mutated[0].response,
+      headers: {
+        ...mutated[0].response.headers,
+      },
+    },
+  };
+
+  if (mode === "status") {
+    first.response.status = 501;
+  }
+  if (mode === "headers") {
+    first.response.headers["x-drift"] = "1";
+  }
+  if (mode === "body") {
+    first.response.body = { drift: true };
+  }
+
+  mutated[0] = first;
+  return mutated;
+}
+
 function runGoRuntimeProbe(scenarioName) {
   const scenario = SCENARIOS[scenarioName];
   if (!scenario) throw new Error(`unknown scenario: ${scenarioName}`);
 
-  return scenario.cases.map((testCase) => {
-    const forceMismatch = process.env.TSGODOWN_DIFF_FORCE_MISMATCH === "1";
-    return {
+  return applyDrift(
+    scenario.cases.map((testCase) => ({
       id: testCase.id,
       request: testCase.request,
-      response: forceMismatch
-        ? {
-            ...testCase.expected,
-            status: 501,
-          }
-        : {
-            ...testCase.expected,
-          },
-    };
-  });
+      response: {
+        ...testCase.expected,
+      },
+    })),
+  );
 }
 
 function getArg(flag) {
@@ -192,6 +279,13 @@ function main() {
 
   const tsProbe = runTsRuntimeProbe(scenarioName);
   const goProbe = runGoRuntimeProbe(scenarioName);
+  if (process.env.TSGODOWN_DIFF_FORCE_DRIFT === "missing-ts") {
+    const [, ...rest] = tsProbe;
+    const report = compareScenario({ scenarioName, tsProbe: rest, goProbe });
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    process.exit(report.summary.pass ? 0 : 1);
+  }
+
   const report = compareScenario({ scenarioName, tsProbe, goProbe });
 
   process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);


### PR DESCRIPTION
## Summary
- split p2 into a dedicated code PR from fresh main sync
- expand differential harness scenarios with real fastify-scaffold-real style behaviors
- gate deterministic drift detection across status/headers/body/missing-case failures
- wire CI to run differential harness explicitly and switch default harness scenario to scaffold-real

## Scope
- scripts/differential-harness.mjs
- packages/cli/test/differential-harness.test.ts
- package.json
- .github/workflows/ci.yml

## TDD evidence
### RED
- forced deterministic drift to prove fail-closed gate
- command: TSGODOWN_DIFF_FORCE_DRIFT=missing-go node scripts/differential-harness.mjs --scenario fastify-scaffold-real-routes
- result: exit code 1
- report summary: mismatched=1, pass=false, diff marker=missing-go-case

### GREEN
- command: node --import tsx --test packages/cli/test/differential-harness.test.ts
  - result: 4/4 passing
- command: pnpm run harness:differential
  - result: pass, total=5 matched=5 mismatched=0

### REFACTOR
- consolidated drift injection under TSGODOWN_DIFF_FORCE_DRIFT for explicit deterministic mismatch classes
- set canonical harness command to scaffold-real scenario (harness:differential)
- added CI step: Differential harness (deterministic parity gate)

## Notes
- this PR intentionally excludes unrelated branch #137 changes and contains only differential harness real-fastify strengthening work
