### PR TITLE
docs(p3): split Fastify v2 supported-subset status matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,20 @@ Documentation and gate execution follow this fixed sequence:
 
 The sequence is locked for planning/reporting consistency and should be used in issue/PR text, roadmap updates, and release evidence.
 
+## Fastify v2 support status (real-user view)
+
+`tsgodown` currently supports a **compiler-mode subset** of Fastify v2 patterns. Use this matrix for production decisions.
+
+| Area | Usable now | Not yet / fail-closed |
+|---|---|---|
+| Route declaration | `fastify.<method>("/literal", handlerRef)` for `get/post/put/delete/patch`; `fastify.route({ method, url\|path, handler })` with analyzable literals | Dynamic/non-literal paths, unsupported `route({...})` object shapes/method encodings |
+| Handler extraction | Named/local handler references that resolve deterministically | Inline/anonymous handlers where named references are required; unresolved handler/plugin references |
+| Plugin composition | `fastify.register(...)` inline callback or named local plugin reference; deterministic `prefix` composition | Unsupported register callback patterns; conditional or non-deterministic route registration |
+| Runtime behavior in generated Go | Deterministic 404/405/`Allow` scaffold behavior covered by emitter/CLI/smoke checks | Full Fastify runtime parity outside the declared subset |
+| Compiler behavior on out-of-subset input | Deterministic diagnostics + fail-closed stop | Silent fallback/heuristic translation (explicitly forbidden) |
+
+**Rollout note (v2):** treat support as **phased subset rollout**, not full Fastify v2 compatibility. Claims expand only when contracts/specs and required gates are updated together.
+
 ## Supported Fastify patterns
 
 The current extractor supports patterns that are stable for backend builds:

--- a/docs/specs/COMPILER_MODE_CONTRACTS.md
+++ b/docs/specs/COMPILER_MODE_CONTRACTS.md
@@ -23,6 +23,15 @@ All milestone evidence, roadmap references, and issue/PR wording must preserve t
 
 In short: correctness claims are locked to explicit compiler contracts, not to the general TypeScript/Fastify ecosystem.
 
+### Support-claim wording rule
+
+User-facing docs must classify surfaces as either:
+
+- **Usable now**: in declared subset + covered by required proof obligations/gates.
+- **Not yet**: outside subset or missing proof obligations; must remain fail-closed.
+
+Avoid ambiguous wording such as broad "Fastify v2 supported" without subset boundaries.
+
 ## 2) Out-of-Scope Handling (Fail Closed)
 
 For out-of-scope input programs, compiler behavior is fixed:

--- a/docs/specs/FASTIFY_COMPILER_MODE_STATUS.md
+++ b/docs/specs/FASTIFY_COMPILER_MODE_STATUS.md
@@ -1,20 +1,61 @@
-# Fastify Compiler-Mode Status (Minimal)
+# Fastify Compiler-Mode Status (v2 rollout)
 
-This project tracks Fastify status through compiler-mode contracts and executable proof gates.
+This document is the user-facing status page for Fastify v2 support in `tsgodown`.
 
 Milestone sequence is locked and must be referenced consistently in roadmap/issues/PRs:
 
 `M5 -> M1 -> M2 -> M3 -> M4`
 
-Canonical compiler contract source:
+## Status policy
 
-- Compiler-mode spec lock + fail-closed policy: `docs/specs/COMPILER_MODE_CONTRACTS.md`
+Support claims are valid only when all three are true:
 
-Related compiler references:
+1. Behavior is inside the declared compiler-mode subset.
+2. Contracts/specs include that behavior explicitly.
+3. Required local/CI gates pass for the current branch.
 
-- Diagnostics behavior: `docs/specs/DIAGNOSTICS.md`
-- Capability gate (compile viability): `docs/specs/CAPABILITY_MATRIX.md`
-- Near-term execution gate: `docs/specs/M1_RELEASE_GATE.md`
+Canonical policy source: `docs/specs/COMPILER_MODE_CONTRACTS.md`.
+
+## Fastify v2 support matrix
+
+| Surface | Usable now | Not yet (must fail closed) | Contract / proof source |
+|---|---|---|---|
+| Route extraction | `fastify.<method>("/literal", handlerRef)` for `get/post/put/delete/patch`; analyzable `fastify.route({...})` with literal `url/path`, supported `method`, resolvable handler ref | Dynamic paths, unsupported route object shapes/method encodings, non-resolvable route handlers | `README.md`, `docs/specs/DIAGNOSTICS.md`, analyzer/emitter contract tests |
+| Plugin graph | `fastify.register(...)` inline callback or named local plugin reference with deterministic `prefix` composition | Unresolved plugin refs, unsupported register callback patterns, conditional route registration | `README.md`, analyzer contract tests |
+| Generated runtime contracts | Deterministic 404/405/`Allow` behavior for scaffolded router paths | Full Fastify runtime equivalence beyond subset | `docs/specs/SEMANTIC_PARITY_CONTRACT.md`, emitter + CLI tests, `scripts/smoke-m1.sh` |
+| Out-of-subset handling | Deterministic diagnostics and compilation stop | Permissive fallback / partial silent success | `docs/specs/COMPILER_MODE_CONTRACTS.md`, `docs/specs/DIAGNOSTICS.md` |
+
+## v2 rollout note
+
+Fastify v2 support is a **phased subset rollout**. "v2 supported" means "supported subset usable now," not blanket framework-level compatibility.
+
+Expansion rule: a capability moves from "not yet" to "usable now" only after:
+
+- spec/contracts are updated,
+- deterministic diagnostics boundaries are defined,
+- differential/parity obligations are added where relevant,
+- and required gates remain green.
+
+## Current required gates (local and CI-aligned)
+
+From repo root, run all of the following:
+
+1. `pnpm install --frozen-lockfile`
+2. `pnpm run lint`
+3. `pnpm run format:check`
+4. `pnpm run build`
+5. `pnpm run test`
+6. `cargo fmt --all --check`
+7. `cargo clippy --workspace --all-targets -- -D warnings`
+8. `cargo test --workspace --all-targets`
+9. `./scripts/smoke-m1.sh`
+
+Related references:
+
+- Diagnostics contract: `docs/specs/DIAGNOSTICS.md`
+- Capability boundary gate: `docs/specs/CAPABILITY_MATRIX.md`
+- Executable M1 release gate: `docs/specs/M1_RELEASE_GATE.md`
+- Test policy and required gates: `docs/specs/TESTING_STRATEGY.md`
 - Backlog/roadmap queue (post-M4 expansion planning only): `docs/backlog/NODE_COMPAT_MATRIX.md`
 
 Policy: support claims are made through compiler-mode contracts + differential proof obligations; roadmap items do not imply support until the corresponding milestone gate evidence is green.


### PR DESCRIPTION
## Summary
Split-out P3 docs-only PR for Fastify v2 supported-subset clarity.

### Included scope (only)
- `README.md`
  - add explicit real-user matrix: `Usable now` vs `Not yet / fail-closed`
  - add phased rollout note (subset rollout, not blanket v2 compatibility)
- `docs/specs/FASTIFY_COMPILER_MODE_STATUS.md`
  - promote from pointer doc to concrete v2 status + contract/proof-linked matrix
  - include current required gate command list
- `docs/specs/COMPILER_MODE_CONTRACTS.md`
  - add support-claim wording rule to remove ambiguity (`Usable now` / `Not yet` only)

### Out of scope
- No code/runtime behavior changes
- No other docs touched

This PR intentionally reissues docs changes as a separate branch/PR (without reusing #137 branch).
