### PR TITLE
docs: split release/ops release-hardening updates

### DIFF
--- a/docs/operations/FAILURE_TRIAGE_PLAYBOOK.md
+++ b/docs/operations/FAILURE_TRIAGE_PLAYBOOK.md
@@ -76,6 +76,9 @@ cargo test --workspace --all-targets
 
 ### B. `smoke-executable` job
 - Re-run `./scripts/smoke-m1.sh` locally.
+- Treat smoke as a compiler-mode deterministic route gate (not process-liveness only):
+  - `GET /health` => `501` + `TODO implement handler health for GET /health`
+  - `GET /missing` => `404` + `404 page not found`
 - Use built-in diagnostics:
   - `.tmp-smoke-m1-server.log` tail (runtime failures)
   - `examples/fastify-min/dist-go/main.go` head (emission sanity)
@@ -106,17 +109,18 @@ Checklist:
    - `cd examples/fastify-min/dist-go`
    - `go build -o tsgodown-local .`
    - `PORT=18080 ./tsgodown-local`
-4. Validate endpoint: `curl -i http://127.0.0.1:18080/health`
+4. Validate smoke route checks manually:
+   - `curl -i http://127.0.0.1:18080/health`
+   - `curl -i http://127.0.0.1:18080/missing`
 
 ## 6) Escalation Rules
 - If classified as `CI-INFRA` and reproducibility is absent locally, retry once.
 - If still failing, note as infra-suspect in PR and attach logs.
 - Do not merge with unresolved `SMOKE-*` or `RUST-*` failures.
 
-## 7) Definition of Done for Failure Closure (compiler-mode)
+## 7) Definition of Done for Failure Closure
 - Primary category assigned
 - Root cause identified
-- Fix merged with no compiler-mode contract regression (including no TS-analyzer fallback path)
+- Fix merged with no fallback-policy regression
 - Full command matrix passes locally
 - CI green on updated branch
-- Evidence comment/PR note includes milestone stage in locked sequence (`M5->M1->M2->M3->M4`) and verification commands

--- a/docs/specs/RELEASE_WORKFLOW.md
+++ b/docs/specs/RELEASE_WORKFLOW.md
@@ -1,6 +1,6 @@
 # Release Workflow & Versioning Policy
 
-Status: Canonical for compiler-mode release operations (M4 in locked sequence M5 -> M1 -> M2 -> M3 -> M4)
+Status: Canonical for M3 (#77)
 
 This document defines how `tsgodown` versions, cuts releases, and handles rollback/hotfix scenarios.
 
@@ -52,22 +52,57 @@ git status --short
 pnpm install --frozen-lockfile
 ```
 
-### B. Quality gates (required)
+### B. Quality gates (required: same 9-command local gate)
+
+Use the canonical gate order from `docs/specs/TESTING_STRATEGY.md`.
 
 ```bash
+pnpm install --frozen-lockfile
 pnpm run lint
 pnpm run format:check
 pnpm run build
 pnpm run test
-pnpm run gate:differential
-pnpm run gate:compliance
 cargo fmt --all --check
 cargo clippy --workspace --all-targets -- -D warnings
 cargo test --workspace --all-targets
 ./scripts/smoke-m1.sh
 ```
 
-### C. Bump versions
+### C. Smoke acceptance criteria (must be true)
+
+`./scripts/smoke-m1.sh` is a deterministic runtime-path gate, not a liveness-only ping.
+Release/hotfix sign-off requires all of the following:
+
+1. Build path succeeds (`tsgodown build` emits `dist-go/main.go`).
+2. Generated Go app compiles (`go build`).
+3. Runtime route checks pass:
+   - `GET /health` returns `501` with deterministic TODO body (`TODO implement handler health for GET /health`).
+   - `GET /missing` returns `404` with `404 page not found`.
+4. Script exits with `[smoke-m1] PASS`.
+
+If any criterion fails, treat release readiness as **blocked**.
+
+### D. Rollback readiness check (before tagging)
+
+Before `git tag`, confirm rollback inputs are prepared:
+
+1. Identify prior stable tag for fallback:
+
+```bash
+git tag --sort=-v:refname | head
+```
+
+2. Record the exact commit to revert if this release must be rolled back:
+
+```bash
+git rev-parse --short HEAD
+```
+
+3. Add rollback note to PR body/release notes:
+   - "If regression is found, revert `<release_commit_sha>` on `main` and cut patch fix-forward."
+   - "If immediate consumer fallback is required, pin to `<previous_stable_tag>`."
+
+### E. Bump versions
 
 Example: patch release (`0.0.1` -> `0.0.2`) for all active packages.
 
@@ -90,7 +125,7 @@ pnpm run build
 pnpm run test
 ```
 
-### D. Changelog + tag + release commit
+### F. Changelog + tag + release commit
 
 ```bash
 git add -A
@@ -174,4 +209,4 @@ git push origin main
   - risk/impact
   - rollback plan
   - proof of full gate command results
-- Link issue(s) and milestone stage explicitly (example: `Closes #<id>`, `Milestone: M4 (sequence M5->M1->M2->M3->M4)`).
+- Link issue(s), e.g. `Closes #77`.


### PR DESCRIPTION
## Summary
- Split p4 release-hardening work into a dedicated PR from fresh synced main.
- Updated release checklist to explicitly pin canonical 9-command local gate.
- Added explicit smoke acceptance and pre-tag rollback-readiness checks.
- Updated ops triage playbook smoke expectations to match current compiler-mode smoke behavior.

## Scope
- docs/specs/RELEASE_WORKFLOW.md
- docs/operations/FAILURE_TRIAGE_PLAYBOOK.md

## Notes
- This PR intentionally excludes unrelated changes and does not reuse #137 branch.
