### PR TITLE
docs(testing): purge subset-only framing for parity safety-net contracts

### DIFF
--- a/docs/specs/COMPILER_MODE_CONTRACTS.md
+++ b/docs/specs/COMPILER_MODE_CONTRACTS.md
@@ -10,16 +10,16 @@ This document is the contract anchor for `M5` in the locked sequence:
 
 All milestone evidence, roadmap references, and issue/PR wording must preserve this order.
 
-## Declared semantic envelope
+## Contracted Semantics Surface
 
-## 1) Declared semantic envelope (spec lock)
+## 1) Contracted Semantics Surface (Spec Lock)
 
-`tsgodown` is a compiler. It only guarantees correctness for a declared, versioned semantic envelope of input programs.
+`tsgodown` is a compiler. It guarantees correctness only for the declared, versioned semantics surface encoded by compiler contracts.
 
-- The declared semantic envelope is the union of compiler-recognized source patterns explicitly listed in spec/capability documents.
-- Any input program outside that envelope is **out of scope** for correctness claims.
+- The contracted semantics surface is the union of compiler-recognized source patterns explicitly listed in spec/capability documents.
+- Any input program outside that surface is **out of scope** for correctness claims.
 - The compiler must not infer support from best-effort behavior or incidental pass cases.
-- Milestone/release messaging must not expand claims beyond this locked semantic envelope.
+- Milestone/release messaging must not expand claims beyond this locked contract surface.
 
 In short: correctness claims are locked to explicit compiler contracts, not to any specific framework ecosystem.
 
@@ -35,7 +35,7 @@ This is a fail-closed compiler policy: no silent miscompile, no silent acceptanc
 
 ## 3) Proof Obligations for In-Scope Features
 
-For each declared-contract feature, correctness is established by semantics-parity proof obligations.
+For each in-scope feature in the contracted semantics surface, correctness is established by differential proof obligations.
 
 Minimum obligations:
 
@@ -49,7 +49,7 @@ Minimum obligations:
 4. **Performance SLO gates**
    - Enforce agreed compile/runtime budgets so correctness is delivered within accepted cost.
 
-`100% behavioral coverage` means every behavior inside the declared semantic envelope is covered by these obligations and passes the semantics-parity gate.
+`100% behavioral coverage` means every behavior inside the contracted semantics surface is covered by these obligations and passes the differential gate.
 
 ## 4) Canonical References
 

--- a/docs/specs/SEMANTIC_PARITY_CONTRACT.md
+++ b/docs/specs/SEMANTIC_PARITY_CONTRACT.md
@@ -11,7 +11,7 @@ for in-contract routes and requests.
 This document is the normative definition used by M1+ differential parity tests.
 
 ## Observable equivalence (normative)
-For any request accepted by the declared semantic envelope contract, TS runtime and Go runtime are considered semantically equivalent when all parity dimensions below hold.
+For any request accepted by the contracted semantics surface, TS runtime and Go runtime are considered semantically equivalent when all parity dimensions below hold.
 
 ### Parity dimensions
 
@@ -34,7 +34,7 @@ For any request accepted by the declared semantic envelope contract, TS runtime 
 | Layer | Required acceptance criteria | Representative tests / artifacts |
 | --- | --- | --- |
 | Unit | Deterministic method matrix and header construction rules are stable (`Allow` generation, route method normalization). | `packages/emitter-go/test/emit-go.test.ts` |
-| Integration | Rust analyzer/emitter contract preserves route/method semantics and diagnostics boundaries for the declared semantic envelope. | `packages/analyzer-rust/tests/contract_parity_regression.rs` |
+| Integration | Rust analyzer/emitter contract preserves route/method semantics and diagnostics boundaries for the contracted semantics surface. | `packages/analyzer-rust/tests/contract_parity_regression.rs` |
 | E2E differential parity | Same fixture requests against TS runtime and generated Go runtime satisfy parity dimensions (status/body/headers/method behavior). | `packages/cli/test/commands.e2e.test.ts` (M2/M3 acceptance tests) |
 | Release gate | Canonical M1 gate proves build path and generated runtime scaffold viability (generation + compile path). | `scripts/m1-release-gate.sh`, `docs/specs/M1_RELEASE_GATE.md` |
 

--- a/docs/specs/TESTING_STRATEGY.md
+++ b/docs/specs/TESTING_STRATEGY.md
@@ -47,11 +47,12 @@ Note: the gate is limited to execution-path verification and does not cover inte
 
 ## M3 runtime correctness/stability extension
 - Runtime executable-fixture coverage is extended beyond the M1/M2 happy-path checks.
+- M3+ parity suites act as a semantics-parity ratchet: regressions are blocked and previously proven behavior stays protected as a global safety net.
 - Normative parity definition: [`SEMANTIC_PARITY_CONTRACT.md`](./SEMANTIC_PARITY_CONTRACT.md)
 
 ## M4 semantics parity harness skeleton (global safety net)
 - Entrypoint: `scripts/differential-harness.mjs`
-- Representative scenario: `fastify-min-get-health` (initial semantic envelope case: `GET route + JSON response`)
+- Representative scenario: `fastify-min-get-health` (semantics parity ratchet scope: `fastify.get + json response`)
 - Deterministic report contract:
   - `version: "m4-differential-harness.v1"`
   - stable `summary` (`total`, `matched`, `mismatched`, `pass`)

--- a/packages/cli/test/differential-harness.test.ts
+++ b/packages/cli/test/differential-harness.test.ts
@@ -21,14 +21,14 @@ function runHarness(env: NodeJS.ProcessEnv = {}) {
   );
 }
 
-test("differential harness emits deterministic report format for supported-subset scenario", () => {
+test("differential harness emits deterministic report format for semantics-parity safety-net scenario", () => {
   const result = runHarness();
   assert.equal(result.status, 0, result.stderr);
 
   const report = JSON.parse(result.stdout) as {
     version: string;
     scenario: string;
-    subset: string;
+    semanticsSurface: string;
     description: string;
     deterministic: boolean;
     summary: {
@@ -47,8 +47,11 @@ test("differential harness emits deterministic report format for supported-subse
 
   assert.equal(report.version, "m4-differential-harness.v1");
   assert.equal(report.scenario, "fastify-min-get-health");
-  assert.equal(report.subset, "fastify.get + json response");
-  assert.match(report.description, /Representative supported-subset scenario/);
+  assert.equal(report.semanticsSurface, "fastify.get + json response");
+  assert.match(
+    report.description,
+    /Representative semantics-parity safety-net scenario/,
+  );
   assert.equal(report.deterministic, true);
   assert.deepEqual(report.summary, {
     total: 1,

--- a/scripts/differential-harness.mjs
+++ b/scripts/differential-harness.mjs
@@ -4,9 +4,9 @@ const REPORT_VERSION = "m4-differential-harness.v1";
 
 const SCENARIOS = {
   "fastify-min-get-health": {
-    subset: "fastify.get + json response",
+    semanticsSurface: "fastify.get + json response",
     description:
-      "Representative supported-subset scenario for deterministic GET /health behavior parity.",
+      "Representative semantics-parity safety-net scenario for deterministic GET /health behavior parity.",
     cases: [
       {
         id: "health-get-200",
@@ -120,7 +120,7 @@ function compareScenario({ scenarioName, tsProbe, goProbe }) {
   const report = {
     version: REPORT_VERSION,
     scenario: scenarioName,
-    subset: scenario.subset,
+    semanticsSurface: scenario.semanticsSurface,
     description: scenario.description,
     deterministic: true,
     failConditions: [


### PR DESCRIPTION
## Summary
- purged subset-only framing in testing/contracts docs and reframed around a contracted semantics surface
- positioned parity suites as a semantics-parity ratchet + global safety net
- updated differential harness naming from `subset` to `semanticsSurface` to match revised contract language

## Scope control
- focused changes on testing strategy/contracts and minimal related harness naming
- no runtime/refactor changes

## Validation (full required gate)
- pnpm install --frozen-lockfile
- pnpm run lint
- pnpm run format:check
- pnpm run build
- pnpm run test
- pnpm run gate:differential
- pnpm run gate:compliance
- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace --all-targets
- ./scripts/smoke-m1.sh

All commands passed on this branch.
