### PR TITLE
docs/ci: neutralize framework-specific bias in core messaging and checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Build
         run: pnpm run build
 
-      - name: Check install-first example builds (pnpm install + build:go)
+      - name: Check install-first builds for tracked example workspaces (pnpm install + build:go)
         run: pnpm run examples:install-first:check
 
       - name: Test
@@ -62,7 +62,7 @@ jobs:
       - name: Guard compiler-mode-only paths/docs
         run: node scripts/guard-compiler-mode-only.mjs
 
-      - name: Guard core path against framework branching/adapters
+      - name: Guard core path against framework-specific branching/adapters
         run: node scripts/guard-core-path-no-framework-branching.mjs
 
       - name: Test core path guardrail matcher

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ This repository remains intentionally strict: when code is outside the declared 
 
 Core execution path guardrail: framework-name branching/adapters are disallowed in `packages/core/src`, `packages/pipeline/src`, and `packages/cli/src/commands` (check with `pnpm run guard:core-path`).
 
+Canonical compiler input contract (framework-agnostic): `tsdown` bundled JS + sourcemap + `d.ts` are the source of truth for analysis and Go emission. Framework fixtures are validation samples, not compiler-mode scope boundaries.
+
 ## Milestone lock (execution sequence)
 
 Documentation and gate execution follow this fixed sequence:
@@ -121,7 +123,7 @@ cargo build -p engine-core
 export TSGODOWN_RUST_ENGINE_BIN="$(pwd)/scripts/rust-engine-launcher.sh"
 export TSGODOWN_ENGINE_CORE_BIN="$(pwd)/target/debug/engine-core"
 
-cd examples/fastify-min
+cd examples/fastify-min  # current reference fixture
 pnpm install
 pnpm run build:go
 ```
@@ -130,7 +132,7 @@ Output:
 
 - `examples/fastify-min/dist-go/main.go`
 
-Scaffold-oriented sample (real Fastify app structure) is available at:
+Scaffold-oriented sample (current Fastify reference app structure) is available at:
 
 - `examples/fastify-scaffold-real/src/app.ts`
 - `examples/fastify-scaffold-real/src/routes/*`

--- a/docs/specs/M1_RELEASE_GATE.md
+++ b/docs/specs/M1_RELEASE_GATE.md
@@ -2,7 +2,7 @@
 
 Milestone 1 is release-gated by a **single canonical verification path**:
 
-- Test name: `M1 release gate: CLI build fastify-min fixture -> dist-go/main.go -> go build (if available)`
+- Test name: `M1 release gate: CLI build fastify-min fixture -> dist-go/main.go -> go build (if available)` (current reference fixture name)
 - Location: `packages/cli/test/commands.e2e.test.ts`
 - Runner: `pnpm run gate:m1`
 - Script: `scripts/m1-release-gate.sh`
@@ -26,7 +26,7 @@ node --import tsx --test-name-pattern "^M1 release gate:" --test test/commands.e
 
 ## What this gate verifies
 
-1. Fastify-min fixture can be built through the CLI + Rust adapter path.
+1. A tracked reference fixture can be built through the CLI + Rust adapter path (currently `examples/fastify-min`).
 2. `dist-go/main.go` is emitted.
 3. Emitted Go scaffold shape is valid (`package main`, `func main`, health route scaffold).
 4. If the Go toolchain exists on the machine, `go build ./...` succeeds.

--- a/docs/specs/TESTING_STRATEGY.md
+++ b/docs/specs/TESTING_STRATEGY.md
@@ -26,17 +26,17 @@ All feature implementation must follow the **Test First** principle.
 - Integration: rust adapter contract + pipeline orchestration
 - E2E: convert real example projects and verify the CLI/build contract
 
-## M1 release gate (TS service fixture -> Go compile success path)
+## M1 release gate (TS service artifact fixture -> Go compile success path)
 M1 release gate is fixed to the **single canonical path** below.
 
 - Canonical reference: [`M1_RELEASE_GATE.md`](M1_RELEASE_GATE.md)
 - Script entrypoint: [`scripts/m1-release-gate.sh`](../../scripts/m1-release-gate.sh)
 - Test location: `packages/cli/test/commands.e2e.test.ts`
-- Test name: `M1 release gate: CLI build fastify-min fixture -> dist-go/main.go -> go build (if available)`
+- Test name: `M1 release gate: CLI build fastify-min fixture -> dist-go/main.go -> go build (if available)` (current reference fixture name)
 - Command: `pnpm run gate:m1`
 
 Verification items:
-1. Input: Fastify-min fixture TypeScript entry (`src/index.ts`)
+1. Input: reference fixture TypeScript entry (`src/index.ts`) from tracked examples (currently `examples/fastify-min`)
 2. Execution: run CLI `build` through the Rust adapter path
 3. Output: confirm `dist-go/main.go` generation
 4. Assertions:
@@ -52,7 +52,7 @@ Note: the gate is limited to execution-path verification and does not cover inte
 
 ## M4 semantics parity harness skeleton (global safety net)
 - Entrypoint: `scripts/differential-harness.mjs`
-- Representative scenario: `fastify-min-get-health` (semantics parity ratchet scope: `fastify.get + json response`)
+- Representative scenario: `fastify-min-get-health` (current baseline scenario; parity harness design remains framework-agnostic)
 - Deterministic report contract:
   - `version: "m4-differential-harness.v1"`
   - stable `summary` (`total`, `matched`, `mismatched`, `pass`)
@@ -93,3 +93,9 @@ Note: the gate is limited to execution-path verification and does not cover inte
 - Do not report features as complete when tests fail.
 - Report the 3-item set: failure cause / reproduction command / mitigation plan.
 - Classify and triage using [`docs/operations/FAILURE_TRIAGE_PLAYBOOK.md`](../operations/FAILURE_TRIAGE_PLAYBOOK.md).
+
+
+## Install-first workspace coverage
+- CI install-first checks must run against **tracked example workspaces** discovered from `examples/*/tsgodown.config.ts` (not a framework-specific allowlist).
+- This guarantees newly added workspaces (for example `examples/generic-simple-cli`, `examples/hono`) are included automatically once added to git.
+- If a planned workspace is not yet present, keep TODO hooks in check scripts/docs instead of baking framework-specific assumptions into the gate language.

--- a/scripts/check-example-install-first.mjs
+++ b/scripts/check-example-install-first.mjs
@@ -7,6 +7,12 @@ const repoRoot = path.resolve(import.meta.dirname, "..");
 const engineCoreBin = path.join(repoRoot, "target", "debug", "engine-core");
 const rustLauncher = path.join(repoRoot, "scripts", "rust-engine-launcher.sh");
 
+const expectedFutureWorkspaces = [
+  // TODO(r2): enable as mandatory once corresponding PRs land.
+  // Expected path: examples/generic-simple-cli
+  // Expected path: examples/hono
+];
+
 function run(cmd, args, opts = {}) {
   const res = spawnSync(cmd, args, {
     cwd: repoRoot,
@@ -49,6 +55,14 @@ function readScripts(projectDirRel) {
 
 function main() {
   const examples = listTrackedExamples();
+
+  for (const expectedPath of expectedFutureWorkspaces) {
+    if (!fs.existsSync(path.join(repoRoot, expectedPath))) {
+      console.log(
+        `[install-first] TODO workspace hook: waiting for ${expectedPath}`,
+      );
+    }
+  }
   if (examples.length === 0) {
     console.log(
       "[install-first] SKIP (no tracked examples with tsgodown.config.ts)",


### PR DESCRIPTION
## Summary
- neutralize framework-specific framing in core docs/CI messaging while keeping current Fastify fixture references explicit as current baseline
- reinforce canonical compiler input contract as `tsdown` bundled JS + sourcemap + `d.ts` (framework-agnostic)
- ensure install-first check language and script behavior are workspace-discovery based (`examples/*/tsgodown.config.ts`) with scaffolding TODO hooks for upcoming workspaces

## Changes
- README: add explicit framework-agnostic artifact contract and de-emphasize fixture-as-scope wording
- docs/specs/TESTING_STRATEGY.md:
  - clarify M1 section as artifact-fixture based
  - add install-first workspace coverage section
  - state baseline scenario as current, not architectural limitation
- docs/specs/M1_RELEASE_GATE.md:
  - keep exact current test name, annotate as current reference fixture name
  - clarify tracked reference fixture wording
- CI workflow:
  - rename steps to “tracked example workspaces” / “framework-specific branching”
- scripts/check-example-install-first.mjs:
  - add TODO scaffolding hooks for expected future paths:
    - `examples/generic-simple-cli`
    - `examples/hono`
  - no hardcoded framework allowlist introduced

## Validation (full required gate)
- `pnpm install --frozen-lockfile`
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run build`
- `pnpm run test`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --all-targets`
- `pnpm run gate:semantics-parity`
- `pnpm run gate:compliance`
- `./scripts/smoke-m1.sh`

All passed locally.

## Dependency notes
- No blocking code dependency on other PRs.
- TODO hooks are intentionally non-blocking until corresponding workspace paths land.
