### PR TITLE
feat(emitter-go): IR-aware semantic handlers (go-codegen split from PR150)

### DIFF
--- a/packages/emitter-go/src/index.ts
+++ b/packages/emitter-go/src/index.ts
@@ -17,7 +17,7 @@ export function emitGoProject(ir: ProgramIR, outDir: string) {
   const lines: string[] = [];
 
   lines.push("package main", "");
-  lines.push(...renderGoImports());
+  lines.push(...renderGoImports(ir.handlers));
   lines.push(...renderDiagnosticsComments(ir.diagnostics));
   lines.push(...renderRuntimeRouter());
   lines.push(...renderRouteRegistry(ir.routes));

--- a/packages/emitter-go/src/render/server-bootstrap-rendering.ts
+++ b/packages/emitter-go/src/render/server-bootstrap-rendering.ts
@@ -1,19 +1,27 @@
-import type { RouteIR } from "@tsgodown/ir-core";
+import type { HandlerIR, RouteIR } from "@tsgodown/ir-core";
 
 import { renderRouteRegistration } from "./template-rendering.js";
 
-export function renderGoImports(): string[] {
-  return [
-    "import (",
+export function renderGoImports(handlers: HandlerIR[]): string[] {
+  const requiresJson = handlers.some((handler) => {
+    const mode = handler.semantics?.responseMode;
+    return mode === "response-object" || mode === "return";
+  });
+
+  const imports = [
     '\t"fmt"',
     '\t"net/http"',
     '\t"os"',
     '\t"sort"',
     '\t"strings"',
     '\t"time"',
-    ")",
-    "",
   ];
+
+  if (requiresJson) {
+    imports.unshift('\t"encoding/json"');
+  }
+
+  return ["import (", ...imports, ")", ""];
 }
 
 export function renderRuntimeRouter(): string[] {

--- a/packages/emitter-go/src/render/template-rendering.ts
+++ b/packages/emitter-go/src/render/template-rendering.ts
@@ -102,6 +102,67 @@ function toTodoHandlerDisplayName(handlerRef: string): string {
   return handlerRef.replace(/^handler[_-]+/, "");
 }
 
+function renderSemanticHandlerBehavior(
+  route: RouteIR,
+  handler: HandlerIR | undefined,
+): string[] {
+  const mode = handler?.semantics?.responseMode ?? "unknown";
+  const normalizedMethod = normalizeHttpMethod(route.method);
+  const normalizedPath = normalizeRoutePath(route.path);
+
+  if (mode === "response-object") {
+    return [
+      '\tw.Header().Set("Content-Type", "application/json; charset=utf-8")',
+      '\tw.Header().Set("X-TSGoDown-Handler", "response-object")',
+      "\tw.WriteHeader(http.StatusOK)",
+      "\tif err := json.NewEncoder(w).Encode(map[string]any{",
+      `\t\t"handler": ${quoteGo(route.handlerRef)},`,
+      `\t\t"method": ${quoteGo(normalizedMethod)},`,
+      `\t\t"path": ${quoteGo(normalizedPath)},`,
+      '\t\t"mode": "response-object",',
+      "\t}); err != nil {",
+      '\t\thttp.Error(w, "json encode failed", http.StatusInternalServerError)',
+      "\t}",
+    ];
+  }
+
+  if (mode === "return") {
+    return [
+      '\tw.Header().Set("Content-Type", "application/json; charset=utf-8")',
+      '\tw.Header().Set("X-TSGoDown-Handler", "return")',
+      "\tw.WriteHeader(http.StatusOK)",
+      "\tif err := json.NewEncoder(w).Encode(map[string]any{",
+      `\t\t"handler": ${quoteGo(route.handlerRef)},`,
+      `\t\t"method": ${quoteGo(normalizedMethod)},`,
+      `\t\t"path": ${quoteGo(normalizedPath)},`,
+      '\t\t"mode": "return",',
+      "\t}); err != nil {",
+      '\t\thttp.Error(w, "json encode failed", http.StatusInternalServerError)',
+      "\t}",
+    ];
+  }
+
+  if (mode === "next-callback") {
+    return [
+      '\tw.Header().Set("X-TSGoDown-Handler", "next-callback")',
+      "\tw.WriteHeader(http.StatusNoContent)",
+    ];
+  }
+
+  const todoHandlerName = toTodoHandlerDisplayName(route.handlerRef);
+  const todoMessage = `TODO implement handler ${todoHandlerName} for ${normalizedMethod} ${normalizedPath}`;
+  return [
+    `\t// TODO(tsgodown): Implement handler ${quoteGo(route.handlerRef)} for ${normalizedMethod} ${normalizedPath}.`,
+    "\t//   - Replace this scaffold with application logic.",
+    "\t//   - Validate request input and map to domain arguments.",
+    "\t//   - Write response status, headers, and body.",
+    "",
+    '\tw.Header().Set("Content-Type", "text/plain; charset=utf-8")',
+    "\tw.WriteHeader(http.StatusNotImplemented)",
+    `\tfmt.Fprintln(w, ${quoteGo(todoMessage)})`,
+  ];
+}
+
 export function renderRoute(
   route: RouteIR,
   index: number,
@@ -109,8 +170,6 @@ export function renderRoute(
 ): string[] {
   const normalizedMethod = normalizeHttpMethod(route.method);
   const normalizedPath = normalizeRoutePath(route.path);
-  const todoHandlerName = toTodoHandlerDisplayName(route.handlerRef);
-  const todoMessage = `TODO implement handler ${todoHandlerName} for ${normalizedMethod} ${normalizedPath}`;
 
   const lines: string[] = [
     `func ${routeHandlerName(index)}(w http.ResponseWriter, req *http.Request) {`,
@@ -133,15 +192,8 @@ export function renderRoute(
   }
 
   lines.push(
-    `\t// TODO(tsgodown): Implement handler ${quoteGo(route.handlerRef)} for ${normalizedMethod} ${normalizedPath}.`,
-    "\t//   - Replace this scaffold with application logic.",
-    "\t//   - Validate request input and map to domain arguments.",
-    "\t//   - Write response status, headers, and body.",
-    "",
     ...emitPathParams(route),
-    '\tw.Header().Set("Content-Type", "text/plain; charset=utf-8")',
-    "\tw.WriteHeader(http.StatusNotImplemented)",
-    `\tfmt.Fprintln(w, ${quoteGo(todoMessage)})`,
+    ...renderSemanticHandlerBehavior(route, handler),
     "}",
     "",
   );

--- a/packages/emitter-go/test/emit-go.test.ts
+++ b/packages/emitter-go/test/emit-go.test.ts
@@ -69,7 +69,7 @@ const representativeFixtureNames = [
 
 const sampleIr = readFixture("sample-ir");
 
-test("emitGoProject emits deterministic main.go scaffold with method-aware route registration and actionable TODO stubs", () => {
+test("emitGoProject emits deterministic main.go scaffold with IR-aware semantic handler behavior", () => {
   const outDir = createOutDir();
 
   emitGoProject(sampleIr, outDir);
@@ -107,20 +107,22 @@ test("emitGoProject emits deterministic main.go scaffold with method-aware route
   assert.match(emitted, /id := req\.PathValue\("id"\)/);
   assert.match(
     emitted,
+    /w\.Header\(\)\.Set\("Content-Type", "application\/json; charset=utf-8"\)/,
+  );
+  assert.match(
+    emitted,
+    /w\.Header\(\)\.Set\("X-TSGoDown-Handler", "response-object"\)/,
+  );
+  assert.match(emitted, /w\.Header\(\)\.Set\("X-TSGoDown-Handler", "return"\)/);
+  assert.match(emitted, /w\.WriteHeader\(http\.StatusOK\)/);
+  assert.match(emitted, /json\.NewEncoder\(w\)\.Encode\(map\[string\]any\{/);
+  assert.doesNotMatch(
+    emitted,
     /TODO\(tsgodown\): Implement handler "health" for GET \/health\./,
   );
-  assert.match(
+  assert.doesNotMatch(
     emitted,
     /TODO\(tsgodown\): Implement handler "createUser" for POST \/users\/:id\./,
-  );
-  assert.match(emitted, /w\.WriteHeader\(http\.StatusNotImplemented\)/);
-  assert.match(
-    emitted,
-    /fmt\.Fprintln\(w, "TODO implement handler health for GET \/health"\)/,
-  );
-  assert.match(
-    emitted,
-    /fmt\.Fprintln\(w, "TODO implement handler createUser for POST \/users\/:id"\)/,
   );
 });
 
@@ -148,7 +150,13 @@ test("emitGoProject keeps deterministic output for equivalent IR with reordered 
         id: "createUser",
         params: [{ role: "request", name: "req" }],
         async: true,
-        semantics: { responseMode: "return" },
+        semantics: {
+          responseMode: "return",
+          usesStatus: false,
+          usesBody: false,
+          usesHeaders: false,
+          usesJson: false,
+        },
       },
       {
         id: "health",
@@ -157,7 +165,13 @@ test("emitGoProject keeps deterministic output for equivalent IR with reordered 
           { role: "response", name: "reply" },
         ],
         async: false,
-        semantics: { responseMode: "response-object" },
+        semantics: {
+          responseMode: "response-object",
+          usesStatus: false,
+          usesBody: false,
+          usesHeaders: false,
+          usesJson: false,
+        },
       },
     ],
     diagnostics: [
@@ -361,7 +375,13 @@ test("emitGoProject TODO message uses stable handler display name for handler_* 
           id: "handler_health",
           params: [],
           async: false,
-          semantics: { responseMode: "unknown" },
+          semantics: {
+            responseMode: "unknown",
+            usesStatus: false,
+            usesBody: false,
+            usesHeaders: false,
+            usesJson: false,
+          },
         },
       ],
     },
@@ -509,7 +529,7 @@ function shutdownServer(server: ReturnType<typeof spawn>) {
 }
 
 test(
-  "emitGoProject smoke: generated server can boot and serve not-implemented route",
+  "emitGoProject smoke: generated server can boot and serve semantic JSON route",
   { skip: !runGoSmoke },
   async () => {
     const outDir = createOutDir();
@@ -563,13 +583,11 @@ test(
 
       assert.equal(
         responseStatus,
-        501,
+        200,
         `server did not become ready at ${url}; lastError=${String(lastError)}`,
       );
-      assert.match(
-        responseText,
-        /TODO implement handler health for GET \/health/,
-      );
+      assert.match(responseText, /"handler":"health"/);
+      assert.match(responseText, /"mode":"response-object"/);
     } finally {
       await shutdownServer(server);
     }

--- a/packages/emitter-go/test/fixtures/go-unsafe-path-params.golden.go
+++ b/packages/emitter-go/test/fixtures/go-unsafe-path-params.golden.go
@@ -102,11 +102,6 @@ func route0(w http.ResponseWriter, req *http.Request) {
 	//   Handler params: none
 	//   Handler async: false
 	//   Handler response mode: unknown
-	// TODO(tsgodown): Implement handler "keywordParams" for GET /things/:type/:req/:w/:pathParamType.
-	//   - Replace this scaffold with application logic.
-	//   - Validate request input and map to domain arguments.
-	//   - Write response status, headers, and body.
-
 	// Extracted path params:
 	pathParamType := req.PathValue("type")
 	_ = pathParamType
@@ -116,6 +111,11 @@ func route0(w http.ResponseWriter, req *http.Request) {
 	_ = pathParamW
 	pathParamType2 := req.PathValue("pathParamType")
 	_ = pathParamType2
+
+	// TODO(tsgodown): Implement handler "keywordParams" for GET /things/:type/:req/:w/:pathParamType.
+	//   - Replace this scaffold with application logic.
+	//   - Validate request input and map to domain arguments.
+	//   - Write response status, headers, and body.
 
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	w.WriteHeader(http.StatusNotImplemented)

--- a/packages/emitter-go/test/fixtures/nested-restish-route.golden.go
+++ b/packages/emitter-go/test/fixtures/nested-restish-route.golden.go
@@ -102,16 +102,16 @@ func route0(w http.ResponseWriter, req *http.Request) {
 	//   Handler params: none
 	//   Handler async: false
 	//   Handler response mode: unknown
-	// TODO(tsgodown): Implement handler "nested" for PATCH /api/v2/users/:id/devices/{deviceId}.
-	//   - Replace this scaffold with application logic.
-	//   - Validate request input and map to domain arguments.
-	//   - Write response status, headers, and body.
-
 	// Extracted path params:
 	id := req.PathValue("id")
 	_ = id
 	deviceId := req.PathValue("deviceId")
 	_ = deviceId
+
+	// TODO(tsgodown): Implement handler "nested" for PATCH /api/v2/users/:id/devices/{deviceId}.
+	//   - Replace this scaffold with application logic.
+	//   - Validate request input and map to domain arguments.
+	//   - Write response status, headers, and body.
 
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	w.WriteHeader(http.StatusNotImplemented)

--- a/packages/emitter-go/test/fixtures/sample-ir.golden.go
+++ b/packages/emitter-go/test/fixtures/sample-ir.golden.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
@@ -104,14 +105,17 @@ func route0(w http.ResponseWriter, req *http.Request) {
 	//   Handler async: false
 	//   Handler response mode: response-object
 	//   Middleware: ["auth"]
-	// TODO(tsgodown): Implement handler "health" for GET /health.
-	//   - Replace this scaffold with application logic.
-	//   - Validate request input and map to domain arguments.
-	//   - Write response status, headers, and body.
-
-	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-	w.WriteHeader(http.StatusNotImplemented)
-	fmt.Fprintln(w, "TODO implement handler health for GET /health")
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set("X-TSGoDown-Handler", "response-object")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(map[string]any{
+		"handler": "health",
+		"method": "GET",
+		"path": "/health",
+		"mode": "response-object",
+	}); err != nil {
+		http.Error(w, "json encode failed", http.StatusInternalServerError)
+	}
 }
 
 func route1(w http.ResponseWriter, req *http.Request) {
@@ -123,16 +127,19 @@ func route1(w http.ResponseWriter, req *http.Request) {
 	//   Handler params: request:req
 	//   Handler async: true
 	//   Handler response mode: return
-	// TODO(tsgodown): Implement handler "createUser" for POST /users/:id.
-	//   - Replace this scaffold with application logic.
-	//   - Validate request input and map to domain arguments.
-	//   - Write response status, headers, and body.
-
 	// Extracted path params:
 	id := req.PathValue("id")
 	_ = id
 
-	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-	w.WriteHeader(http.StatusNotImplemented)
-	fmt.Fprintln(w, "TODO implement handler createUser for POST /users/:id")
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set("X-TSGoDown-Handler", "return")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(map[string]any{
+		"handler": "createUser",
+		"method": "POST",
+		"path": "/users/:id",
+		"mode": "return",
+	}); err != nil {
+		http.Error(w, "json encode failed", http.StatusInternalServerError)
+	}
 }


### PR DESCRIPTION
## Summary
Split from PR150: **GO-CODEGEN-SEMANTIC-HANDLERS only**.

## Scope-only statement
This PR intentionally includes **only emitter-go codegen + tests/goldens**:
- packages/emitter-go/src/index.ts
- packages/emitter-go/src/render/server-bootstrap-rendering.ts
- packages/emitter-go/src/render/template-rendering.ts
- packages/emitter-go/test/emit-go.test.ts
- packages/emitter-go/test/fixtures/*.golden.go

Excluded by design:
- analyzer-rust
- ir-core
- pipeline
- differential harness / CI workflow changes

## Evidence (local CI-parity run)
Ran full 12-step CI-parity command set locally and all passed:
1. pnpm run lint
2. pnpm run format:check
3. pnpm run build
4. pnpm run examples:install-first:check
5. pnpm run test
6. cargo fmt --all --check
7. cargo clippy --workspace --all-targets -- -D warnings
8. cargo test --workspace --all-targets
9. node scripts/guard-compiler-mode-only.mjs
10. node scripts/guard-core-path-no-framework-branching.mjs
11. node --test scripts/guard-core-path-no-framework-branching.test.mjs
12. pnpm run gate:compliance

All checks completed successfully before push.
