### PR TITLE
fix(analyzer-rust): improve handler semantics lowering for typed params + reply.code

### DIFF
--- a/packages/analyzer-rust/src/builder.rs
+++ b/packages/analyzer-rust/src/builder.rs
@@ -181,14 +181,14 @@ fn collect_handler_defs(src: &str) -> BTreeMap<String, HandlerDef> {
                         continue;
                     }
                     let after_eq = after_name.trim_start_matches('=').trim_start();
-                    if let Some((is_async, params, _body)) = parse_arrow_fn(after_eq) {
+                    if let Some((is_async, params, body)) = parse_arrow_fn(after_eq) {
                         let lowered_params = lower_params(&params);
                         handlers.insert(
                             name.to_string(),
                             HandlerDef {
                                 is_async,
                                 params: lowered_params.clone(),
-                                semantics: lower_semantics(&lowered_params, src),
+                                semantics: lower_semantics(&lowered_params, &body),
                             },
                         );
                     }
@@ -197,28 +197,28 @@ fn collect_handler_defs(src: &str) -> BTreeMap<String, HandlerDef> {
         }
 
         if let Some(rest) = trimmed.strip_prefix("async function ") {
-            if let Some((name, params, _body)) = parse_function_decl(rest) {
+            if let Some((name, params, body)) = parse_function_decl(rest) {
                 let lowered_params = lower_params(&params);
                 handlers.insert(
                     name.to_string(),
                     HandlerDef {
                         is_async: true,
                         params: lowered_params.clone(),
-                        semantics: lower_semantics(&lowered_params, src),
+                        semantics: lower_semantics(&lowered_params, &body),
                     },
                 );
             }
         }
 
         if let Some(rest) = trimmed.strip_prefix("function ") {
-            if let Some((name, params, _body)) = parse_function_decl(rest) {
+            if let Some((name, params, body)) = parse_function_decl(rest) {
                 let lowered_params = lower_params(&params);
                 handlers.insert(
                     name.to_string(),
                     HandlerDef {
                         is_async: false,
                         params: lowered_params.clone(),
-                        semantics: lower_semantics(&lowered_params, src),
+                        semantics: lower_semantics(&lowered_params, &body),
                     },
                 );
             }
@@ -281,10 +281,27 @@ fn parse_params(raw: &str) -> Option<Vec<String>> {
 
     let mut params = Vec::new();
     for token in split_top_level_commas(inner) {
-        let param = take_identifier(token.trim())?;
+        let token = normalize_param_token(token.trim());
+        let param = take_identifier(token.as_str())?;
         params.push(param.to_string());
     }
     Some(params)
+}
+
+fn normalize_param_token(raw: &str) -> String {
+    let trimmed = raw.trim();
+
+    let no_default = trimmed
+        .split_once('=')
+        .map(|(left, _)| left.trim())
+        .unwrap_or(trimmed);
+
+    let no_type = no_default
+        .split_once(':')
+        .map(|(left, _)| left.trim())
+        .unwrap_or(no_default);
+
+    no_type.trim_start_matches("...").trim().to_string()
 }
 
 fn lower_params(params: &[String]) -> Vec<HandlerParamIR> {
@@ -335,11 +352,17 @@ fn lower_semantics(params: &[HandlerParamIR], body: &str) -> HandlerSemanticsIR 
     let has_call = |fn_name: &str| {
         response_param_lower
             .as_ref()
-            .map(|response_name| body_lower.contains(&format!("{response_name}.{fn_name}(")))
+            .map(|response_name| {
+                body_lower.contains(&format!("{response_name}.{fn_name}("))
+                    || body_lower.contains(&format!("{response_name}.status("))
+                        && body_lower.contains(&format!(".{fn_name}("))
+                    || body_lower.contains(&format!("{response_name}.code("))
+                        && body_lower.contains(&format!(".{fn_name}("))
+            })
             .unwrap_or(false)
     };
 
-    let uses_status = has_call("status");
+    let uses_status = has_call("status") || has_call("code");
     let uses_headers = has_call("header") || has_call("headers");
     let uses_json = has_call("json");
     let uses_body = has_call("send") || has_call("body");

--- a/packages/analyzer-rust/tests/handler_semantics_lowering.rs
+++ b/packages/analyzer-rust/tests/handler_semantics_lowering.rs
@@ -39,3 +39,54 @@ app.get("/health", health);
         Some("return")
     );
 }
+
+#[test]
+fn lowers_semantics_per_handler_body_not_whole_module() {
+    let src = r#"
+const createUser = (request, reply) => {
+  reply.status(201);
+  reply.send({ ok: true });
+};
+
+const health = (req, res) => ({ ok: true });
+
+app.post("/users", createUser);
+app.get("/health", health);
+"#;
+
+    let ir = analyze_compiler_entry("fixture.ts", src);
+    let health = ir.handlers.iter().find(|h| h.id == "health").unwrap();
+    let semantics = health.semantics.as_ref().unwrap();
+
+    assert!(!semantics.uses_status);
+    assert!(!semantics.uses_body);
+    assert!(!semantics.uses_json);
+    assert!(!semantics.uses_headers);
+}
+
+#[test]
+fn parses_typed_and_default_handler_params_and_fastify_code_alias() {
+    let src = r#"
+const createUser = (
+  request: FastifyRequest,
+  reply: FastifyReply = defaultReply
+) => {
+  reply.code(201).send({ ok: true });
+};
+
+app.post("/users", createUser);
+"#;
+
+    let ir = analyze_compiler_entry("fixture.ts", src);
+    let create_user = ir.handlers.iter().find(|h| h.id == "createUser").unwrap();
+    let semantics = create_user.semantics.as_ref().unwrap();
+
+    assert_eq!(create_user.params.len(), 2);
+    assert_eq!(create_user.params[0].name, "request");
+    assert_eq!(create_user.params[0].role, "request");
+    assert_eq!(create_user.params[1].name, "reply");
+    assert_eq!(create_user.params[1].role, "response");
+
+    assert!(semantics.uses_status);
+    assert!(semantics.uses_body);
+}


### PR DESCRIPTION
## Summary
- fix handler semantics lowering to inspect each handler body, not the full module source
- broaden handler parameter parsing to accept TypeScript-style type annotations, default values, and rest markers
- detect Fastify `reply.code(...)` as status usage and chained response calls for semantics flags
- add regression coverage for per-handler semantics isolation and typed/default param parsing

## Why
This closes a correctness gap where one handler could inherit semantic flags from unrelated handlers in the same module, and extends accepted JS/TS handler syntax in compiler mode.

## Validation
- pnpm run lint
- pnpm run format:check
- pnpm run build
- pnpm run test
- cargo test --workspace --all-targets
- pnpm run gate:semantics-parity
- pnpm run gate:compliance
