### PR TITLE
feat(analyzer-rust): support static template literal route paths

### DIFF
--- a/packages/analyzer-rust/src/builder.rs
+++ b/packages/analyzer-rust/src/builder.rs
@@ -589,11 +589,15 @@ fn parse_named_handler(raw: &str) -> Option<String> {
 }
 
 fn extract_quoted(raw: &str) -> Option<&str> {
-    for quote in ['\'', '"'] {
+    for quote in ['\'', '"', '`'] {
         if let Some(start) = raw.find(quote) {
             let rest = &raw[start + 1..];
             if let Some(end) = rest.find(quote) {
-                return Some(&rest[..end]);
+                let value = &rest[..end];
+                if quote == '`' && value.contains("${") {
+                    return None;
+                }
+                return Some(value);
             }
         }
     }

--- a/packages/analyzer-rust/tests/ast_to_ir_golden.rs
+++ b/packages/analyzer-rust/tests/ast_to_ir_golden.rs
@@ -119,3 +119,11 @@ fn unsupported_patterns_emit_deterministic_diagnostics() {
 fn semantic_patterns_are_lowered_deterministically() {
     assert_fixture("semantic-patterns.ts", "semantic-patterns.golden.txt");
 }
+
+#[test]
+fn template_literal_paths_keep_static_literals_and_reject_interpolated_paths() {
+    assert_fixture(
+        "template-literal-paths.ts",
+        "template-literal-paths.golden.txt",
+    );
+}

--- a/packages/analyzer-rust/tests/fixtures/template-literal-paths.golden.txt
+++ b/packages/analyzer-rust/tests/fixtures/template-literal-paths.golden.txt
@@ -1,0 +1,10 @@
+modules:
+  - id=template-literal-paths.ts source_path=template-literal-paths.ts
+    exports:
+    imports:
+routes:
+  - method=GET path=/health handler_ref=health
+handlers:
+  - id=health async=false params=0 semantics=mode=return req=<none> res=<none> status=false body=false headers=false json=false
+diagnostics:
+  - level=error code=ANALYZER_UNSUPPORTED_DYNAMIC_PATH message=route path must be a string literal source=template-literal-paths.ts

--- a/packages/analyzer-rust/tests/fixtures/template-literal-paths.ts
+++ b/packages/analyzer-rust/tests/fixtures/template-literal-paths.ts
@@ -1,0 +1,6 @@
+const health = () => ({ ok: true });
+const users = () => [{ id: "u1" }];
+
+// biome-ignore lint/style/noUnusedTemplateLiteral: fixture validates static template-literal route extraction.
+app.get(`/health`, health);
+app.get(`${prefix}/users`, users);


### PR DESCRIPTION
## Summary
- expand analyzer route-path parsing to accept static template literals in addition to single/double-quoted literals
- keep fail-closed behavior for interpolated template literals (for example `${prefix}/users`)
- add deterministic golden coverage for mixed static-template + interpolated-template route cases

## Why
Some JS/TS codebases use backtick literals for static route strings. This change broadens accepted syntax without relaxing compiler-mode safety boundaries.

## What changed
- `extract_quoted` now considers backtick-quoted literals
- if a backtick literal contains interpolation markers (`${`), it is treated as dynamic and rejected
- added fixture + golden + test:
  - `template-literal-paths.ts`
  - `template-literal-paths.golden.txt`
  - `template_literal_paths_keep_static_literals_and_reject_interpolated_paths`

## Validation
- pnpm run lint
- pnpm run format:check
- pnpm run build
- pnpm run test
- cargo test --workspace --all-targets
- pnpm run gate:semantics-parity
- pnpm run gate:compliance
