### PR TITLE
feat(analyzer-rust): support optional typed handler params

### DIFF
--- a/packages/analyzer-rust/src/builder.rs
+++ b/packages/analyzer-rust/src/builder.rs
@@ -301,7 +301,11 @@ fn normalize_param_token(raw: &str) -> String {
         .map(|(left, _)| left.trim())
         .unwrap_or(no_default);
 
-    no_type.trim_start_matches("...").trim().to_string()
+    no_type
+        .trim_start_matches("...")
+        .trim_end_matches('?')
+        .trim()
+        .to_string()
 }
 
 fn lower_params(params: &[String]) -> Vec<HandlerParamIR> {

--- a/packages/analyzer-rust/tests/handler_semantics_lowering.rs
+++ b/packages/analyzer-rust/tests/handler_semantics_lowering.rs
@@ -87,3 +87,24 @@ app.post("/users", createUser);
     assert!(semantics.uses_status);
     assert!(semantics.uses_body);
 }
+
+#[test]
+fn parses_optional_typed_handler_params() {
+    let src = r#"
+const createUser = (request?: FastifyRequest, reply?: FastifyReply) => {
+  reply?.status(201);
+  reply?.send({ ok: true });
+};
+
+app.post("/users", createUser);
+"#;
+
+    let ir = analyze_compiler_entry("fixture.ts", src);
+    let create_user = ir.handlers.iter().find(|h| h.id == "createUser").unwrap();
+
+    assert_eq!(create_user.params.len(), 2);
+    assert_eq!(create_user.params[0].name, "request");
+    assert_eq!(create_user.params[0].role, "request");
+    assert_eq!(create_user.params[1].name, "reply");
+    assert_eq!(create_user.params[1].role, "response");
+}


### PR DESCRIPTION
## Summary
- broaden handler signature parsing to support optional TypeScript parameters in compiler mode
- keep response-role inference stable for optional typed names (`request?`, `reply?`)
- add regression test for optional typed handler parameters

## Why
JS/TS Fastify handlers often use optional typed parameters in shared code paths and strict TS settings. This extends accepted syntax coverage for JS->Go compilation without changing runtime behavior contracts.

## Changes
- normalize handler params by stripping trailing `?` in `normalize_param_token`
- preserve existing behavior for type annotations, default values, and rest params
- add test `parses_optional_typed_handler_params` in `handler_semantics_lowering.rs`

## Validation
- pnpm run lint
- pnpm run format:check
- pnpm run build
- pnpm run test
- cargo test --workspace --all-targets
- pnpm run gate:semantics-parity
- pnpm run gate:compliance
