### PR TITLE
feat(emitter-go): emit supported literal object payloads for parity

### DIFF
--- a/packages/emitter-go/src/render/template-rendering.ts
+++ b/packages/emitter-go/src/render/template-rendering.ts
@@ -102,6 +102,67 @@ function toTodoHandlerDisplayName(handlerRef: string): string {
   return handlerRef.replace(/^handler[_-]+/, "");
 }
 
+type JsonPrimitive = string | number | boolean | null;
+
+type JsonObject = Record<string, JsonPrimitive>;
+
+function toGoLiteral(value: JsonPrimitive): string {
+  if (value === null) return "nil";
+  if (typeof value === "string") return quoteGo(value);
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? String(value) : "nil";
+  }
+  return value ? "true" : "false";
+}
+
+function parseSupportedLiteralObjectPayload(
+  handler: HandlerIR | undefined,
+): JsonObject | null {
+  const bodyRef = handler?.bodyRef?.trim();
+  if (!bodyRef || !bodyRef.startsWith("{") || !bodyRef.endsWith("}")) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(bodyRef);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return null;
+    }
+
+    const entries = Object.entries(parsed as Record<string, unknown>);
+    for (const [, value] of entries) {
+      if (
+        value !== null &&
+        typeof value !== "string" &&
+        typeof value !== "number" &&
+        typeof value !== "boolean"
+      ) {
+        return null;
+      }
+    }
+
+    return Object.fromEntries(
+      [...entries]
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, value]) => [key, value as JsonPrimitive]),
+    );
+  } catch {
+    return null;
+  }
+}
+
+function emitJsonEncodeBlock(payload: JsonObject): string[] {
+  return [
+    "\tif err := json.NewEncoder(w).Encode(map[string]any{",
+    ...Object.entries(payload).map(
+      ([key, value]) => `\t\t${quoteGo(key)}: ${toGoLiteral(value)},`,
+    ),
+    "\t}); err != nil {",
+    '\t\thttp.Error(w, "json encode failed", http.StatusInternalServerError)',
+    "\t}",
+  ];
+}
+
 function renderSemanticHandlerBehavior(
   route: RouteIR,
   handler: HandlerIR | undefined,
@@ -109,20 +170,21 @@ function renderSemanticHandlerBehavior(
   const mode = handler?.semantics?.responseMode ?? "unknown";
   const normalizedMethod = normalizeHttpMethod(route.method);
   const normalizedPath = normalizeRoutePath(route.path);
+  const literalPayload = parseSupportedLiteralObjectPayload(handler);
 
   if (mode === "response-object") {
     return [
       '\tw.Header().Set("Content-Type", "application/json; charset=utf-8")',
       '\tw.Header().Set("X-TSGoDown-Handler", "response-object")',
       "\tw.WriteHeader(http.StatusOK)",
-      "\tif err := json.NewEncoder(w).Encode(map[string]any{",
-      `\t\t"handler": ${quoteGo(route.handlerRef)},`,
-      `\t\t"method": ${quoteGo(normalizedMethod)},`,
-      `\t\t"path": ${quoteGo(normalizedPath)},`,
-      '\t\t"mode": "response-object",',
-      "\t}); err != nil {",
-      '\t\thttp.Error(w, "json encode failed", http.StatusInternalServerError)',
-      "\t}",
+      ...(literalPayload
+        ? emitJsonEncodeBlock(literalPayload)
+        : emitJsonEncodeBlock({
+            handler: route.handlerRef,
+            method: normalizedMethod,
+            path: normalizedPath,
+            mode: "response-object",
+          })),
     ];
   }
 
@@ -131,14 +193,14 @@ function renderSemanticHandlerBehavior(
       '\tw.Header().Set("Content-Type", "application/json; charset=utf-8")',
       '\tw.Header().Set("X-TSGoDown-Handler", "return")',
       "\tw.WriteHeader(http.StatusOK)",
-      "\tif err := json.NewEncoder(w).Encode(map[string]any{",
-      `\t\t"handler": ${quoteGo(route.handlerRef)},`,
-      `\t\t"method": ${quoteGo(normalizedMethod)},`,
-      `\t\t"path": ${quoteGo(normalizedPath)},`,
-      '\t\t"mode": "return",',
-      "\t}); err != nil {",
-      '\t\thttp.Error(w, "json encode failed", http.StatusInternalServerError)',
-      "\t}",
+      ...(literalPayload
+        ? emitJsonEncodeBlock(literalPayload)
+        : emitJsonEncodeBlock({
+            handler: route.handlerRef,
+            method: normalizedMethod,
+            path: normalizedPath,
+            mode: "return",
+          })),
     ];
   }
 

--- a/packages/emitter-go/test/emit-go.test.ts
+++ b/packages/emitter-go/test/emit-go.test.ts
@@ -215,6 +215,41 @@ test("emitGoProject keeps deterministic output for equivalent IR with reordered 
   );
 });
 
+test("emitGoProject emits literal object payload for supported return-mode bodyRef subset", () => {
+  const outDir = createOutDir();
+
+  emitGoProject(
+    {
+      modules: [],
+      handlers: [
+        {
+          id: "health",
+          params: [],
+          async: false,
+          bodyRef: '{"ok":true,"message":"healthy"}',
+          semantics: {
+            responseMode: "return",
+            usesStatus: false,
+            usesBody: false,
+            usesHeaders: false,
+            usesJson: false,
+          },
+        },
+      ],
+      diagnostics: [],
+      routes: [{ method: "GET", path: "/health", handlerRef: "health" }],
+    },
+    outDir,
+  );
+
+  const emitted = fs.readFileSync(path.join(outDir, "main.go"), "utf8");
+
+  assert.match(emitted, /"message": "healthy"/);
+  assert.match(emitted, /"ok": true/);
+  assert.doesNotMatch(emitted, /"handler": "health"/);
+  assert.doesNotMatch(emitted, /"mode": "return"/);
+});
+
 test("emitGoProject representative fixtures stay locked to checked-in golden outputs", () => {
   for (const fixtureName of representativeFixtureNames) {
     const outDir = createOutDir();
@@ -588,6 +623,83 @@ test(
       );
       assert.match(responseText, /"handler":"health"/);
       assert.match(responseText, /"mode":"response-object"/);
+    } finally {
+      await shutdownServer(server);
+    }
+  },
+);
+
+test(
+  "emitGoProject smoke: return-mode literal object payload bodyRef serves payload JSON",
+  { skip: !runGoSmoke },
+  async () => {
+    const outDir = createOutDir();
+    const port = await allocateEphemeralPort();
+
+    emitGoProject(
+      {
+        modules: [],
+        handlers: [
+          {
+            id: "health",
+            params: [],
+            async: false,
+            bodyRef: '{"ok":true,"message":"healthy"}',
+            semantics: {
+              responseMode: "return",
+              usesStatus: false,
+              usesBody: false,
+              usesHeaders: false,
+              usesJson: false,
+            },
+          },
+        ],
+        diagnostics: [],
+        routes: [{ method: "GET", path: "/health", handlerRef: "health" }],
+      },
+      outDir,
+    );
+
+    const modInit = spawnSync(
+      "go",
+      ["mod", "init", "example.com/tsgodown-runtime-literal-payload"],
+      {
+        cwd: outDir,
+        encoding: "utf8",
+      },
+    );
+    assert.equal(modInit.status, 0, modInit.stderr || modInit.stdout);
+
+    const server = spawn("go", ["run", "."], {
+      cwd: outDir,
+      env: { ...process.env, PORT: port },
+      stdio: "ignore",
+    });
+
+    const url = `http://127.0.0.1:${port}/health`;
+    const deadline = Date.now() + 10_000;
+    let responseStatus = 0;
+    let body = "";
+
+    try {
+      while (Date.now() < deadline) {
+        try {
+          const response = await fetch(url, {
+            signal: AbortSignal.timeout(1000),
+          });
+          responseStatus = response.status;
+          body = await response.text();
+          break;
+        } catch {
+          await new Promise((resolve) => setTimeout(resolve, 200));
+        }
+      }
+
+      assert.equal(responseStatus, 200);
+      assert.match(body, /"ok":true/);
+      assert.match(body, /"message":"healthy"/);
+      assert.doesNotMatch(body, /"handler":"health"/);
+      assert.doesNotMatch(body, /"mode":"return"/);
     } finally {
       await shutdownServer(server);
     }


### PR DESCRIPTION
## Summary
- add emitter support for a strict literal object payload subset using `handler.bodyRef`
- keep fallback behavior unchanged when payload is missing or unsupported
- add TDD coverage (unit + smoke) for emitted and runtime JSON parity

## TDD flow
1. Added failing tests first:
   - `emitGoProject emits literal object payload for supported return-mode bodyRef subset`
   - `emitGoProject smoke: return-mode literal object payload bodyRef serves payload JSON`
2. Implemented minimal emitter-only support to pass.
3. Refactored JSON encoding generation through shared helpers.

## Supported subset
The new path is enabled only when `handler.bodyRef` is a JSON object string with primitive values:
- string
- number
- boolean
- null

Unsupported shapes (arrays, nested objects, invalid JSON) fail closed to the existing scaffold metadata payload.

## Implementation
- `packages/emitter-go/src/render/template-rendering.ts`
  - added strict parser for supported literal object payloads
  - added Go-literal serializer for primitive values
  - reused a shared JSON encode block helper
  - applied payload emission for `response-object` and `return` response modes

## Validation
- pnpm run lint
- pnpm run format:check
- pnpm run build
- pnpm run test
- cargo test --workspace --all-targets
- pnpm run gate:semantics-parity
- pnpm run gate:compliance
