### PR TITLE
test(pipeline): ratchet failure normalization edge-case coverage

### DIFF
--- a/packages/pipeline/src/internal/result-normalization.ts
+++ b/packages/pipeline/src/internal/result-normalization.ts
@@ -14,6 +14,10 @@ export function resolveEntry(config: UserConfig): string {
 }
 
 export function normalizePipelineCause(cause: unknown): string {
+  if (cause === null || cause === undefined) {
+    return "";
+  }
+
   return cause instanceof Error ? cause.message : String(cause);
 }
 

--- a/packages/pipeline/test/result-normalization.test.ts
+++ b/packages/pipeline/test/result-normalization.test.ts
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { formatPipelineFailure } from "../src/internal/result-normalization.ts";
+import {
+  formatPipelineFailure,
+  resolveEntry,
+} from "../src/internal/result-normalization.ts";
 
 test("formatPipelineFailure keeps source/stage/cause/guidance contract", () => {
   const error = formatPipelineFailure("src/missing.ts", {
@@ -24,4 +27,34 @@ test("formatPipelineFailure keeps source/stage/cause/guidance contract", () => {
     error.message,
     /guidance: Verify rust engine build\/analyze contract and tsgodown\.config\.ts settings\./,
   );
+});
+
+test("formatPipelineFailure falls back to stable defaults when details contain blank strings", () => {
+  const error = formatPipelineFailure("src/blank.ts", {
+    source: "   ",
+    stage: "",
+    cause: "\t",
+    guidance: "\n",
+  });
+
+  assert.match(error.message, /source: pipeline-entry\(src\/blank\.ts\)/);
+  assert.match(error.message, /stage: UNKNOWN/);
+  assert.match(error.message, /cause: unknown pipeline failure/);
+  assert.match(
+    error.message,
+    /guidance: Verify rust engine build\/analyze contract and tsgodown\.config\.ts settings\./,
+  );
+});
+
+test("formatPipelineFailure treats nullish causes as unknown pipeline failure", () => {
+  const withUndefined = formatPipelineFailure("src/undefined.ts", undefined);
+  const withNull = formatPipelineFailure("src/null.ts", null);
+
+  assert.match(withUndefined.message, /cause: unknown pipeline failure/);
+  assert.match(withNull.message, /cause: unknown pipeline failure/);
+});
+
+test("resolveEntry uses string entry and falls back for non-string values", () => {
+  assert.equal(resolveEntry({ entry: "src/custom.ts" }), "src/custom.ts");
+  assert.equal(resolveEntry({ entry: { app: "src/app.ts" } }), "src/index.ts");
 });


### PR DESCRIPTION
## Summary
- add regression tests for pipeline failure normalization defaults when detail fields are blank
- add regression tests ensuring nullish pipeline causes are rendered as `unknown pipeline failure` instead of raw `undefined`/`null`
- add coverage for `resolveEntry` fallback behavior when entry is not a string
- implement minimal normalization fix so `null`/`undefined` causes map to stable fallback messaging

## Why
This tightens error-surface determinism in pipeline failure reporting and prevents leaking JavaScript sentinel values (`undefined`/`null`) into user-facing diagnostics.

## TDD
1. Added failing tests for nullish cause handling in `result-normalization.test.ts`.
2. Implemented minimal change in `normalizePipelineCause`.
3. Kept all tests green and expanded coverage for adjacent fallback paths.

## Validation
- `pnpm run test:tdd`
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run gate:differential`
- `pnpm run gate:compliance`
