### PR TITLE
fix(analyzer-rust): emit deterministic diagnostic for conditional routes

### DIFF
--- a/packages/analyzer-rust/src/builder.rs
+++ b/packages/analyzer-rust/src/builder.rs
@@ -21,6 +21,7 @@ pub fn build_program_ir(file: &str, src: &str) -> ProgramIR {
     let exports = collect_exports(src);
     let handler_defs = collect_handler_defs(src);
     let plugin_defs = collect_plugin_defs(src);
+    collect_conditional_route_diagnostics(src, &mut diagnostics, file);
 
     let mut routes = Vec::new();
     let mut referenced_handlers = BTreeSet::new();
@@ -168,6 +169,50 @@ fn collect_imports(src: &str, diagnostics: &mut Vec<DiagnosticIR>, file: &str) -
 
     imports.sort_by(|a, b| a.spec.cmp(&b.spec).then_with(|| a.kind.cmp(&b.kind)));
     imports
+}
+
+fn collect_conditional_route_diagnostics(
+    src: &str,
+    diagnostics: &mut Vec<DiagnosticIR>,
+    file: &str,
+) {
+    let mut conditional_depth: i32 = 0;
+
+    for line in src.lines() {
+        let trimmed = line.trim();
+
+        if conditional_depth == 0 && (trimmed.starts_with("if(") || trimmed.starts_with("if (")) {
+            conditional_depth = brace_delta(line).max(1);
+        } else if conditional_depth > 0 {
+            if has_route_invocation(trimmed) {
+                diagnostics.push(diag(
+                    "error",
+                    "ANALYZER_UNSUPPORTED_CONDITIONAL_ROUTE",
+                    "conditional route registration is unsupported",
+                    file,
+                ));
+                return;
+            }
+            conditional_depth += brace_delta(line);
+            if conditional_depth <= 0 {
+                conditional_depth = 0;
+            }
+        }
+    }
+}
+
+fn has_route_invocation(line: &str) -> bool {
+    ALLOWED_METHODS
+        .iter()
+        .map(|method| method.to_ascii_lowercase())
+        .any(|method| line.contains(format!(".{method}(").as_str()))
+        || line.contains(".route(")
+}
+
+fn brace_delta(raw: &str) -> i32 {
+    let opens = raw.chars().filter(|ch| *ch == '{').count() as i32;
+    let closes = raw.chars().filter(|ch| *ch == '}').count() as i32;
+    opens - closes
 }
 
 fn collect_handler_defs(src: &str) -> BTreeMap<String, HandlerDef> {

--- a/packages/analyzer-rust/tests/ast_to_ir_golden.rs
+++ b/packages/analyzer-rust/tests/ast_to_ir_golden.rs
@@ -135,3 +135,8 @@ fn unsupported_register_boundaries_emit_spec_mapped_diagnostics() {
         "unsupported-register-boundaries.golden.txt",
     );
 }
+
+#[test]
+fn conditional_routes_emit_unsupported_diagnostic() {
+    assert_fixture("conditional-route.ts", "conditional-route.golden.txt");
+}

--- a/packages/analyzer-rust/tests/fixtures/conditional-route.golden.txt
+++ b/packages/analyzer-rust/tests/fixtures/conditional-route.golden.txt
@@ -1,0 +1,9 @@
+modules:
+  - id=conditional-route.ts source_path=conditional-route.ts
+    exports:
+    imports:
+      - spec=fastify kind=esm resolved=<none>
+routes:
+handlers:
+diagnostics:
+  - level=error code=ANALYZER_UNSUPPORTED_CONDITIONAL_ROUTE message=conditional route registration is unsupported source=conditional-route.ts

--- a/packages/analyzer-rust/tests/fixtures/conditional-route.ts
+++ b/packages/analyzer-rust/tests/fixtures/conditional-route.ts
@@ -1,0 +1,11 @@
+import Fastify from "fastify";
+
+const app = Fastify();
+
+function expHandler() {
+  return { ok: true };
+}
+
+if (process.env.EXPERIMENTAL === "1") {
+  app.get("/exp", expHandler);
+}


### PR DESCRIPTION
## Summary
- add a new analyzer-rust fixture and golden asserting `ANALYZER_UNSUPPORTED_CONDITIONAL_ROUTE`
- implement conditional-route detection in the IR builder for `if (...) { ...route... }` patterns
- keep fail-closed behavior deterministic by emitting a single stable diagnostic per file

## TDD
1. Added failing golden test: `conditional_routes_emit_unsupported_diagnostic`
2. Implemented minimal builder change to satisfy the contract
3. Refactored into small helpers (`has_route_invocation`, `brace_delta`) and re-ran tests

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm run test:tdd`
- `cargo test -p analyzer-rust`
- `pnpm run gate:compliance`
