### PR TITLE
Issue #166: map register callback/plugin boundaries to analyzer diagnostics

### DIFF
--- a/packages/analyzer-rust/src/builder.rs
+++ b/packages/analyzer-rust/src/builder.rs
@@ -20,6 +20,7 @@ pub fn build_program_ir(file: &str, src: &str) -> ProgramIR {
     let imports = collect_imports(src, &mut diagnostics, file);
     let exports = collect_exports(src);
     let handler_defs = collect_handler_defs(src);
+    let plugin_defs = collect_plugin_defs(src);
 
     let mut routes = Vec::new();
     let mut referenced_handlers = BTreeSet::new();
@@ -32,7 +33,9 @@ pub fn build_program_ir(file: &str, src: &str) -> ProgramIR {
         if let Some(route) = parse_route_object(stmt, &mut diagnostics, file) {
             referenced_handlers.insert(route.handler_ref.clone());
             routes.push(route);
+            continue;
         }
+        parse_register_boundary(stmt, &plugin_defs, &mut diagnostics, file);
     }
 
     routes.sort_by(|a, b| {
@@ -226,6 +229,48 @@ fn collect_handler_defs(src: &str) -> BTreeMap<String, HandlerDef> {
     }
 
     handlers
+}
+
+fn collect_plugin_defs(src: &str) -> BTreeSet<String> {
+    let mut defs = BTreeSet::new();
+
+    for stmt in collect_statements(src) {
+        let trimmed = stmt.trim();
+
+        if let Some(rest) = trimmed.strip_prefix("async function ") {
+            if let Some(name) = take_identifier(rest) {
+                defs.insert(name.to_string());
+            }
+            continue;
+        }
+
+        if let Some(rest) = trimmed.strip_prefix("function ") {
+            if let Some(name) = take_identifier(rest) {
+                defs.insert(name.to_string());
+            }
+            continue;
+        }
+
+        for prefix in ["const ", "let ", "var "] {
+            if let Some(rest) = trimmed.strip_prefix(prefix) {
+                if let Some((name, after_name)) = split_identifier_and_rest(rest) {
+                    let after_name = after_name.trim_start();
+                    if !after_name.starts_with('=') {
+                        continue;
+                    }
+                    let after_eq = after_name.trim_start_matches('=').trim_start();
+                    if parse_arrow_fn(after_eq).is_some()
+                        || after_eq.starts_with("function")
+                        || after_eq.starts_with("async function")
+                    {
+                        defs.insert(name.to_string());
+                    }
+                }
+            }
+        }
+    }
+
+    defs
 }
 
 fn parse_arrow_fn(raw: &str) -> Option<(bool, Vec<String>, String)> {
@@ -541,6 +586,59 @@ fn parse_route_object(
         path,
         handler_ref: handler,
     })
+}
+
+fn parse_register_boundary(
+    stmt: &str,
+    plugin_defs: &BTreeSet<String>,
+    diagnostics: &mut Vec<DiagnosticIR>,
+    file: &str,
+) {
+    if !stmt.contains(".register(") {
+        return;
+    }
+
+    let trimmed = stmt.trim_end_matches(';').trim();
+    let Some(open) = trimmed.find(".register(") else {
+        return;
+    };
+    let Some(close) = trimmed.rfind(')') else {
+        return;
+    };
+
+    let args_raw = trimmed[open + ".register(".len()..close].trim();
+    let args = split_top_level_commas(args_raw);
+    let Some(callback_arg) = args.first().map(|v| v.trim()) else {
+        return;
+    };
+
+    if callback_arg.starts_with("function")
+        || callback_arg.starts_with("async function")
+        || callback_arg.contains("=>")
+    {
+        return;
+    }
+
+    if let Some(plugin_ref) = parse_named_handler(callback_arg) {
+        if plugin_defs.contains(&plugin_ref) {
+            return;
+        }
+
+        diagnostics.push(diag(
+            "error",
+            "ANALYZER_UNRESOLVED_PLUGIN",
+            "register plugin reference could not be resolved in current module",
+            file,
+        ));
+        return;
+    }
+
+    diagnostics.push(diag(
+        "error",
+        "ANALYZER_UNSUPPORTED_REGISTER_CALLBACK",
+        "register callback must be an inline function or same-file named reference",
+        file,
+    ));
 }
 
 fn split_top_level_commas(raw: &str) -> Vec<&str> {

--- a/packages/analyzer-rust/tests/ast_to_ir_golden.rs
+++ b/packages/analyzer-rust/tests/ast_to_ir_golden.rs
@@ -127,3 +127,11 @@ fn template_literal_paths_keep_static_literals_and_reject_interpolated_paths() {
         "template-literal-paths.golden.txt",
     );
 }
+
+#[test]
+fn unsupported_register_boundaries_emit_spec_mapped_diagnostics() {
+    assert_fixture(
+        "unsupported-register-boundaries.ts",
+        "unsupported-register-boundaries.golden.txt",
+    );
+}

--- a/packages/analyzer-rust/tests/fixtures/unsupported-register-boundaries.golden.txt
+++ b/packages/analyzer-rust/tests/fixtures/unsupported-register-boundaries.golden.txt
@@ -1,0 +1,9 @@
+modules:
+  - id=unsupported-register-boundaries.ts source_path=unsupported-register-boundaries.ts
+    exports:
+    imports:
+routes:
+handlers:
+diagnostics:
+  - level=error code=ANALYZER_UNRESOLVED_PLUGIN message=register plugin reference could not be resolved in current module source=unsupported-register-boundaries.ts
+  - level=error code=ANALYZER_UNSUPPORTED_REGISTER_CALLBACK message=register callback must be an inline function or same-file named reference source=unsupported-register-boundaries.ts

--- a/packages/analyzer-rust/tests/fixtures/unsupported-register-boundaries.ts
+++ b/packages/analyzer-rust/tests/fixtures/unsupported-register-boundaries.ts
@@ -1,0 +1,6 @@
+const app = {
+  register: (_plugin: unknown, _opts?: unknown) => undefined,
+};
+
+app.register(factoryPlugin(), { prefix: "/v1" });
+app.register(missingPlugin, { prefix: "/v2" });


### PR DESCRIPTION
## Summary
- add a red/green fixture-based TDD cycle for register boundary diagnostics in analyzer-rust
- cover two compiler mapping gaps from docs/specs/IR_SPEC.md:
  - ANALYZER_UNSUPPORTED_REGISTER_CALLBACK
  - ANALYZER_UNRESOLVED_PLUGIN
- implement minimal register-boundary parsing in builder.rs to emit those codes deterministically

## Why
Issue #166 requires strict unsupported-boundary → diagnostic-code mapping parity.
Worker B is already handling inline handler routing boundaries, so this PR targets a non-overlapping, high-impact gap in plugin/register analysis.

## Testing
- cargo test -p analyzer-rust unsupported_register_boundaries_emit_spec_mapped_diagnostics -- --nocapture (red first, then green)
- full local workflow-equivalent checks:
  - pnpm lint
  - pnpm format:check
  - pnpm build
  - pnpm test
  - cargo test -p analyzer-rust

All checks pass locally.
