### PR TITLE
fix(analyzer-rust): detect single-line conditional route registration

### DIFF
--- a/packages/analyzer-rust/src/builder.rs
+++ b/packages/analyzer-rust/src/builder.rs
@@ -182,6 +182,16 @@ fn collect_conditional_route_diagnostics(
         let trimmed = line.trim();
 
         if conditional_depth == 0 && (trimmed.starts_with("if(") || trimmed.starts_with("if (")) {
+            if has_route_invocation(trimmed) {
+                diagnostics.push(diag(
+                    "error",
+                    "ANALYZER_UNSUPPORTED_CONDITIONAL_ROUTE",
+                    "conditional route registration is unsupported",
+                    file,
+                ));
+                return;
+            }
+
             conditional_depth = brace_delta(line).max(1);
         } else if conditional_depth > 0 {
             if has_route_invocation(trimmed) {

--- a/packages/analyzer-rust/tests/ast_to_ir_golden.rs
+++ b/packages/analyzer-rust/tests/ast_to_ir_golden.rs
@@ -140,3 +140,11 @@ fn unsupported_register_boundaries_emit_spec_mapped_diagnostics() {
 fn conditional_routes_emit_unsupported_diagnostic() {
     assert_fixture("conditional-route.ts", "conditional-route.golden.txt");
 }
+
+#[test]
+fn single_line_conditional_routes_emit_unsupported_diagnostic() {
+    assert_fixture(
+        "conditional-route-single-line.ts",
+        "conditional-route-single-line.golden.txt",
+    );
+}

--- a/packages/analyzer-rust/tests/fixtures/conditional-route-single-line.golden.txt
+++ b/packages/analyzer-rust/tests/fixtures/conditional-route-single-line.golden.txt
@@ -1,0 +1,9 @@
+modules:
+  - id=conditional-route-single-line.ts source_path=conditional-route-single-line.ts
+    exports:
+    imports:
+      - spec=fastify kind=esm resolved=<none>
+routes:
+handlers:
+diagnostics:
+  - level=error code=ANALYZER_UNSUPPORTED_CONDITIONAL_ROUTE message=conditional route registration is unsupported source=conditional-route-single-line.ts

--- a/packages/analyzer-rust/tests/fixtures/conditional-route-single-line.ts
+++ b/packages/analyzer-rust/tests/fixtures/conditional-route-single-line.ts
@@ -1,0 +1,9 @@
+import Fastify from "fastify";
+
+const app = Fastify();
+
+function expHandler() {
+  return { ok: true };
+}
+
+if (process.env.EXPERIMENTAL === "1") app.get("/exp", expHandler);


### PR DESCRIPTION
## Summary
- add a regression fixture for single-line conditional route registration (`if (cond) app.get(...)`)
- make conditional-route diagnostics fail-closed for single-line `if` forms in analyzer-rust
- keep deterministic golden output coverage for this unsupported Fastify pattern

## TDD
1. Added failing golden test:
   - `single_line_conditional_routes_emit_unsupported_diagnostic`
   - fixture: `conditional-route-single-line.ts`
2. Implemented minimal fix in `collect_conditional_route_diagnostics`:
   - when an `if` line is detected, check that same line for route invocation before entering depth tracking
3. Re-ran tests to green.

## Verification
- `cargo test -p analyzer-rust single_line_conditional_routes_emit_unsupported_diagnostic`
- `cargo test -p analyzer-rust`
- `pnpm install --frozen-lockfile`
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run build`
- `pnpm run test`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --all-targets`
- `./scripts/smoke-m1.sh`
