### PR TITLE
feat(analyzer-rust): lower fastify.route named object references

### DIFF
--- a/packages/analyzer-rust/src/builder.rs
+++ b/packages/analyzer-rust/src/builder.rs
@@ -21,6 +21,7 @@ pub fn build_program_ir(file: &str, src: &str) -> ProgramIR {
     let exports = collect_exports(src);
     let handler_defs = collect_handler_defs(src);
     let plugin_defs = collect_plugin_defs(src);
+    let route_object_defs = collect_route_object_defs(src);
     collect_conditional_route_diagnostics(src, &mut diagnostics, file);
 
     let mut routes = Vec::new();
@@ -31,7 +32,7 @@ pub fn build_program_ir(file: &str, src: &str) -> ProgramIR {
             routes.push(route);
             continue;
         }
-        if let Some(route) = parse_route_object(stmt, &mut diagnostics, file) {
+        if let Some(route) = parse_route_object(stmt, &route_object_defs, &mut diagnostics, file) {
             referenced_handlers.insert(route.handler_ref.clone());
             routes.push(route);
             continue;
@@ -328,6 +329,37 @@ fn collect_plugin_defs(src: &str) -> BTreeSet<String> {
     defs
 }
 
+fn collect_route_object_defs(src: &str) -> BTreeMap<String, String> {
+    let mut defs = BTreeMap::new();
+
+    for stmt in collect_statements(src) {
+        let trimmed = stmt.trim_end_matches(';').trim();
+
+        for prefix in ["const ", "let ", "var "] {
+            let Some(rest) = trimmed.strip_prefix(prefix) else {
+                continue;
+            };
+
+            let Some((name_raw, rhs_raw)) = rest.split_once('=') else {
+                continue;
+            };
+
+            let name = name_raw.trim();
+            if take_identifier(name) != Some(name) {
+                continue;
+            }
+
+            let rhs = rhs_raw.trim();
+            let rhs = rhs.strip_suffix(" as const").unwrap_or(rhs).trim();
+            if rhs.starts_with('{') && rhs.ends_with('}') {
+                defs.insert(name.to_string(), rhs.to_string());
+            }
+        }
+    }
+
+    defs
+}
+
 fn parse_arrow_fn(raw: &str) -> Option<(bool, Vec<String>, String)> {
     let mut trimmed = raw.trim();
     let is_async = if let Some(rest) = trimmed.strip_prefix("async") {
@@ -567,6 +599,7 @@ fn parse_shorthand_route(
 
 fn parse_route_object(
     stmt: &str,
+    route_object_defs: &BTreeMap<String, String>,
     diagnostics: &mut Vec<DiagnosticIR>,
     file: &str,
 ) -> Option<RouteIR> {
@@ -579,7 +612,21 @@ fn parse_route_object(
     let close = trimmed.rfind(')')?;
     let arg = trimmed[open..close].trim();
 
-    if !arg.starts_with('{') || !arg.ends_with('}') {
+    let object_literal = if arg.starts_with('{') && arg.ends_with('}') {
+        arg.to_string()
+    } else if let Some(route_ref) = parse_named_handler(arg) {
+        if let Some(object_literal) = route_object_defs.get(&route_ref) {
+            object_literal.clone()
+        } else {
+            diagnostics.push(diag(
+                "error",
+                "ANALYZER_UNSUPPORTED_ROUTE_OBJECT_SHAPE",
+                "fastify.route(...) requires an inline object literal",
+                file,
+            ));
+            return None;
+        }
+    } else {
         diagnostics.push(diag(
             "error",
             "ANALYZER_UNSUPPORTED_ROUTE_OBJECT_SHAPE",
@@ -587,9 +634,9 @@ fn parse_route_object(
             file,
         ));
         return None;
-    }
+    };
 
-    let method = if let Some(v) = extract_prop_quoted(arg, "method") {
+    let method = if let Some(v) = extract_prop_quoted(&object_literal, "method") {
         let upper = v.to_ascii_uppercase();
         if !ALLOWED_METHODS.contains(&upper.as_str()) {
             diagnostics.push(diag(
@@ -611,7 +658,8 @@ fn parse_route_object(
         return None;
     };
 
-    let path = extract_prop_quoted(arg, "url").or_else(|| extract_prop_quoted(arg, "path"));
+    let path = extract_prop_quoted(&object_literal, "url")
+        .or_else(|| extract_prop_quoted(&object_literal, "path"));
     let path = if let Some(v) = path {
         v
     } else {
@@ -624,7 +672,7 @@ fn parse_route_object(
         return None;
     };
 
-    let handler = if let Some(v) = extract_prop_identifier(arg, "handler") {
+    let handler = if let Some(v) = extract_prop_identifier(&object_literal, "handler") {
         v
     } else {
         diagnostics.push(diag(

--- a/packages/analyzer-rust/tests/ast_to_ir_golden.rs
+++ b/packages/analyzer-rust/tests/ast_to_ir_golden.rs
@@ -111,6 +111,14 @@ fn route_object_literal_is_lowered_deterministically() {
 }
 
 #[test]
+fn route_object_reference_is_lowered_deterministically() {
+    assert_fixture(
+        "route-object-reference.ts",
+        "route-object-reference.golden.txt",
+    );
+}
+
+#[test]
 fn unsupported_patterns_emit_deterministic_diagnostics() {
     assert_fixture("unsupported-dynamic.ts", "unsupported-dynamic.golden.txt");
 }

--- a/packages/analyzer-rust/tests/fixtures/route-object-reference.golden.txt
+++ b/packages/analyzer-rust/tests/fixtures/route-object-reference.golden.txt
@@ -1,0 +1,9 @@
+modules:
+  - id=route-object-reference.ts source_path=route-object-reference.ts
+    exports:
+    imports:
+routes:
+  - method=GET path=/health handler_ref=health
+handlers:
+  - id=health async=false params=0 semantics=mode=return req=<none> res=<none> status=false body=false headers=false json=false
+diagnostics:

--- a/packages/analyzer-rust/tests/fixtures/route-object-reference.ts
+++ b/packages/analyzer-rust/tests/fixtures/route-object-reference.ts
@@ -1,0 +1,9 @@
+const health = () => ({ ok: true });
+
+const routeDef = {
+  method: "GET",
+  url: "/health",
+  handler: health,
+};
+
+app.route(routeDef);


### PR DESCRIPTION
## Summary
- add support for `fastify.route(<namedObjectRef>)` when the referenced object literal is defined in the same file
- keep existing fail-closed diagnostics for unresolved/non-literal route object references
- add deterministic golden coverage for this route-object reference syntax

## Why
Issue #166 tracks removal of high-impact JS->Go mapping gaps. `fastify.route(routeDef)` (with `const routeDef = { ... }`) is a common JS pattern that previously emitted `ANALYZER_UNSUPPORTED_ROUTE_OBJECT_SHAPE` and dropped route lowering.

This PR closes that specific shape gap for same-file object literal references.

## Added syntax forms
- `const routeDef = { method: "GET", url: "/health", handler: health }; app.route(routeDef);`
- `const routeDef = { ... } as const; app.route(routeDef);` (same-file literal reference normalization)

## Remaining unsupported forms (unchanged)
- `fastify.route(routeFactory())` or other non-literal dynamic expressions
- `fastify.route(importedRouteDef)` (cross-file object resolution not implemented)
- route object references that are not backed by same-file object literals

## TDD proof
1. **Red**
   - added fixture + golden expectation for `route-object-reference.ts`
   - ran:
     - `cargo test -p analyzer-rust route_object_reference_is_lowered_deterministically -- --nocapture`
   - observed failure: analyzer emitted `ANALYZER_UNSUPPORTED_ROUTE_OBJECT_SHAPE` and produced no lowered route

2. **Green (minimal fix)**
   - implemented `collect_route_object_defs` for same-file `const|let|var <id> = { ... }` literals
   - updated `parse_route_object` to resolve named refs via that map before applying existing property extraction
   - reran test and it passed

3. **Regression safety**
   - ran full local workflow-equivalent checks (CI parity command chain), including:
     - `pnpm run lint`
     - `pnpm run format:check`
     - `pnpm run build`
     - `pnpm run examples:install-first:check`
     - `pnpm run test`
     - `cargo fmt --all --check`
     - `cargo clippy --workspace --all-targets -- -D warnings`
     - `cargo test --workspace --all-targets`
     - `node scripts/guard-compiler-mode-only.mjs`
     - `node scripts/guard-core-path-no-framework-branching.mjs`
     - `node --test scripts/guard-core-path-no-framework-branching.test.mjs`
     - `pnpm run gate:differential`
     - `pnpm run gate:compliance`

## Links
- Issue: #166
- Commit: `4e3db8b`
