### PR TITLE
feat(pipeline): ingest d.ts + sourcemap metadata into artifact-to-ir

### DIFF
--- a/packages/pipeline/src/internal/artifact-to-ir.ts
+++ b/packages/pipeline/src/internal/artifact-to-ir.ts
@@ -1,23 +1,56 @@
-import type { ProgramIR } from "@tsgodown/ir-core";
+import fs from "node:fs";
+import path from "node:path";
+
+import type { DiagnosticIR, ProgramIR } from "@tsgodown/ir-core";
 import type { RunBuildResult } from "@tsgodown/tsdown-driver";
+
+interface ArtifactToIrOptions {
+  cwd?: string;
+}
 
 export function buildProgramIrFromArtifacts(
   buildResult: RunBuildResult,
   entry: string,
+  options: ArtifactToIrOptions = {},
 ): ProgramIR {
+  const cwd = options.cwd ?? process.cwd();
+  const diagnostics: DiagnosticIR[] = [];
+
   const manifestEntries =
     buildResult.manifest.entries.length > 0
       ? buildResult.manifest.entries
       : [entry];
 
-  const modules = manifestEntries.map((manifestEntry, index) => ({
-    id: `module_${index}`,
-    sourcePath: manifestEntry,
-    exports: [],
-    imports: [],
-  }));
+  const sourceMappedEntries = collectSourceEntriesFromSourceMap(
+    buildResult,
+    cwd,
+    diagnostics,
+  );
+  const moduleEntries =
+    sourceMappedEntries.length > 0 ? sourceMappedEntries : manifestEntries;
+
+  const typedExports = collectTypedExports(buildResult, cwd, diagnostics);
+
+  const modules = moduleEntries
+    .map((manifestEntry, index) => ({
+      id: `module_${index}`,
+      sourcePath: manifestEntry,
+      exports: typedExports,
+      imports: [],
+    }))
+    .sort((a, b) =>
+      a.sourcePath === b.sourcePath
+        ? a.id.localeCompare(b.id)
+        : a.sourcePath.localeCompare(b.sourcePath),
+    );
 
   const primaryHandlerId = "health";
+
+  diagnostics.sort((a, b) =>
+    `${a.level}:${a.code}:${a.message}:${a.source?.file ?? ""}`.localeCompare(
+      `${b.level}:${b.code}:${b.message}:${b.source?.file ?? ""}`,
+    ),
+  );
 
   return {
     modules,
@@ -43,6 +76,140 @@ export function buildProgramIrFromArtifacts(
         },
       },
     ],
-    diagnostics: [],
+    diagnostics,
   };
+}
+
+function collectTypedExports(
+  buildResult: RunBuildResult,
+  cwd: string,
+  diagnostics: DiagnosticIR[],
+): string[] {
+  const typePath = buildResult.manifest.types?.[0];
+  if (!typePath?.trim()) {
+    diagnostics.push({
+      level: "warn",
+      code: "PIPELINE_MISSING_TYPES_METADATA",
+      message:
+        "missing .d.ts metadata required for typed artifact-to-ir mapping",
+      source: {
+        file: "manifest.types",
+      },
+    });
+    return [];
+  }
+
+  const absoluteTypePath = path.join(cwd, typePath);
+  let sourceText = "";
+  try {
+    sourceText = fs.readFileSync(absoluteTypePath, "utf8");
+  } catch {
+    diagnostics.push({
+      level: "warn",
+      code: "PIPELINE_MISSING_TYPES_METADATA",
+      message: `declared types file is unreadable: ${typePath}`,
+      source: {
+        file: typePath,
+      },
+    });
+    return [];
+  }
+
+  const exportedNames = new Set<string>();
+  for (const line of sourceText.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    const match = trimmed.match(
+      /^export\s+(?:declare\s+)?(?:async\s+)?(?:function|const|let|var|class|type|interface|enum)\s+([A-Za-z_$][A-Za-z0-9_$]*)/,
+    );
+    if (match?.[1]) {
+      exportedNames.add(match[1]);
+    }
+  }
+
+  if (exportedNames.size === 0) {
+    diagnostics.push({
+      level: "warn",
+      code: "PIPELINE_INVALID_TYPES_METADATA",
+      message: "no named exports could be parsed from .d.ts metadata",
+      source: {
+        file: typePath,
+      },
+    });
+  }
+
+  return [...exportedNames].sort((a, b) => a.localeCompare(b));
+}
+
+function collectSourceEntriesFromSourceMap(
+  buildResult: RunBuildResult,
+  cwd: string,
+  diagnostics: DiagnosticIR[],
+): string[] {
+  const mapPath = buildResult.manifest.bundles[0]?.map;
+  if (!mapPath?.trim()) {
+    diagnostics.push({
+      level: "warn",
+      code: "PIPELINE_MISSING_SOURCEMAP_MAPPING",
+      message:
+        "missing sourcemap path required for deterministic source mapping",
+      source: {
+        file: buildResult.manifest.bundles[0]?.file ?? "manifest.bundles[0]",
+        viaSourceMap: true,
+      },
+    });
+    return [];
+  }
+
+  let parsedMap: unknown;
+  try {
+    parsedMap = JSON.parse(fs.readFileSync(path.join(cwd, mapPath), "utf8"));
+  } catch {
+    diagnostics.push({
+      level: "warn",
+      code: "PIPELINE_INVALID_SOURCEMAP_MAPPING",
+      message: `sourcemap metadata is missing or invalid JSON: ${mapPath}`,
+      source: {
+        file: mapPath,
+        viaSourceMap: true,
+      },
+    });
+    return [];
+  }
+
+  const sources =
+    typeof parsedMap === "object" &&
+    parsedMap !== null &&
+    "sources" in parsedMap
+      ? (parsedMap as { sources?: unknown[] }).sources
+      : undefined;
+
+  if (!Array.isArray(sources)) {
+    diagnostics.push({
+      level: "warn",
+      code: "PIPELINE_INVALID_SOURCEMAP_MAPPING",
+      message:
+        "sourcemap metadata missing sources[] for artifact-to-ir mapping",
+      source: {
+        file: mapPath,
+        viaSourceMap: true,
+      },
+    });
+    return [];
+  }
+
+  const normalized = new Set<string>();
+  for (const sourcePath of sources) {
+    if (typeof sourcePath !== "string" || !sourcePath.trim()) {
+      continue;
+    }
+    const resolved = path
+      .normalize(path.join(path.dirname(mapPath), sourcePath))
+      .replaceAll("\\", "/");
+    const withoutDot = resolved.startsWith("./") ? resolved.slice(2) : resolved;
+    if (!withoutDot.startsWith("../")) {
+      normalized.add(withoutDot);
+    }
+  }
+
+  return [...normalized].sort((a, b) => a.localeCompare(b));
 }

--- a/packages/pipeline/src/internal/stage-orchestration.ts
+++ b/packages/pipeline/src/internal/stage-orchestration.ts
@@ -1,6 +1,7 @@
 import type { UserConfig } from "@tsgodown/config";
 import type { RunBuildResult } from "@tsgodown/tsdown-driver";
 
+import { buildProgramIrFromArtifacts } from "./artifact-to-ir.js";
 import { formatPipelineFailure, resolveEntry } from "./result-normalization.js";
 import { runBuildArtifactsViaRustAdapter } from "./rust-adapter-boundary.js";
 
@@ -59,6 +60,7 @@ export async function orchestratePipelineStages({
         "BUILD_IR",
         `[BUILD_IR] analyzing entry: ${entry} (delegated to rust engine, buildId=${buildResult.manifest.buildId})`,
       );
+      buildProgramIrFromArtifacts(buildResult, entry, { cwd });
 
       stage = "CAPABILITY_GATE";
       emitStage(

--- a/packages/pipeline/test/artifact-to-ir.test.ts
+++ b/packages/pipeline/test/artifact-to-ir.test.ts
@@ -1,3 +1,7 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
 import assert from "node:assert/strict";
 import test from "node:test";
 
@@ -21,4 +25,98 @@ test("buildProgramIrFromArtifacts falls back to resolved entry when manifest ent
 
   assert.equal(ir.modules.length, 1);
   assert.equal(ir.modules[0]?.sourcePath, "src/index.ts");
+});
+
+test("buildProgramIrFromArtifacts ingests d.ts and sourcemap into deterministic typed module metadata", () => {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "tsgodown-artifact-ir-"));
+  fs.mkdirSync(path.join(cwd, "dist"), { recursive: true });
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "index.d.ts"),
+    [
+      "export declare function zed(req: unknown): Promise<void>;",
+      "export declare const alpha: () => { ok: boolean };",
+      "",
+    ].join("\n"),
+  );
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "index.mjs.map"),
+    JSON.stringify({
+      version: 3,
+      file: "index.mjs",
+      sources: ["../src/z-route.ts", "../src/a-route.ts", "../src/z-route.ts"],
+      names: [],
+      mappings: "",
+    }),
+  );
+
+  const ir = buildProgramIrFromArtifacts(
+    {
+      mode: "rust-engine-adapter",
+      manifestPath: "artifacts/manifests/manifest.json",
+      manifestIndexPath: "artifacts/manifests/index.json",
+      manifest: {
+        buildId: "aabbccddeeff0011",
+        entries: ["src/index.ts"],
+        bundles: [
+          {
+            file: "dist/index.mjs",
+            map: "dist/index.mjs.map",
+            format: "esm",
+            exports: ["zed", "alpha"],
+          },
+        ],
+        types: ["dist/index.d.ts"],
+      },
+      diagnostics: [],
+    },
+    "src/index.ts",
+    { cwd },
+  );
+
+  assert.deepEqual(
+    ir.modules.map((module) => module.sourcePath),
+    ["src/a-route.ts", "src/z-route.ts"],
+  );
+  assert.deepEqual(ir.modules[0]?.exports, ["alpha", "zed"]);
+  assert.deepEqual(ir.diagnostics, []);
+});
+
+test("buildProgramIrFromArtifacts emits deterministic diagnostics for missing/invalid typed mapping metadata", () => {
+  const cwd = fs.mkdtempSync(
+    path.join(os.tmpdir(), "tsgodown-artifact-ir-diag-"),
+  );
+  fs.mkdirSync(path.join(cwd, "dist"), { recursive: true });
+
+  fs.writeFileSync(path.join(cwd, "dist", "broken.map"), "{oops");
+
+  const ir = buildProgramIrFromArtifacts(
+    {
+      mode: "rust-engine-adapter",
+      manifestPath: "artifacts/manifests/manifest.json",
+      manifestIndexPath: "artifacts/manifests/index.json",
+      manifest: {
+        buildId: "aabbccddeeff0011",
+        entries: ["src/index.ts"],
+        bundles: [
+          {
+            file: "dist/index.mjs",
+            map: "dist/broken.map",
+            format: "esm",
+            exports: [],
+          },
+        ],
+      },
+      diagnostics: [],
+    },
+    "src/index.ts",
+    { cwd },
+  );
+
+  assert.deepEqual(
+    ir.diagnostics.map((diag) => diag.code),
+    ["PIPELINE_INVALID_SOURCEMAP_MAPPING", "PIPELINE_MISSING_TYPES_METADATA"],
+  );
+  assert.equal(ir.diagnostics[0]?.source?.viaSourceMap, true);
 });


### PR DESCRIPTION
## Summary

Implement typed artifact metadata ingestion in the pipeline lane:

- ingest `manifest.types[0]` (`.d.ts`) and parse named exports deterministically
- ingest `manifest.bundles[0].map` (sourcemap JSON) and map source paths deterministically
- wire this ingestion into `BUILD_IR` stage via `buildProgramIrFromArtifacts(..., { cwd })`
- emit deterministic IR diagnostics for missing/invalid typed mapping metadata

## TDD-first changes

1. Added failing tests in `packages/pipeline/test/artifact-to-ir.test.ts`:
   - typed happy path: `.d.ts` + sourcemap produce deterministic modules + exports
   - failure path: invalid sourcemap + missing types produce deterministic diagnostics
2. Implemented minimal production code in `packages/pipeline/src/internal/artifact-to-ir.ts`:
   - typed export parsing from `.d.ts`
   - source mapping extraction from sourcemap `sources[]`
   - deterministic sorting/dedup + diagnostics
3. Wired ingestion in `packages/pipeline/src/internal/stage-orchestration.ts`:
   - call `buildProgramIrFromArtifacts(buildResult, entry, { cwd })` during `BUILD_IR`

## Deterministic diagnostics added

- `PIPELINE_MISSING_TYPES_METADATA`
- `PIPELINE_INVALID_TYPES_METADATA`
- `PIPELINE_MISSING_SOURCEMAP_MAPPING`
- `PIPELINE_INVALID_SOURCEMAP_MAPPING`

## Verification

- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run build`
- `pnpm run test`
- `pnpm --filter tsgodown test`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --all-targets`
- `./scripts/smoke-m1.sh`
