### PR TITLE
pipeline: deterministic d.ts+sourcemap enrichment for typed IR mapping

### DIFF
--- a/packages/pipeline/src/internal/artifact-to-ir.ts
+++ b/packages/pipeline/src/internal/artifact-to-ir.ts
@@ -4,6 +4,11 @@ import path from "node:path";
 import type { DiagnosticIR, ProgramIR } from "@tsgodown/ir-core";
 import type { RunBuildResult } from "@tsgodown/tsdown-driver";
 
+const DETERMINISTIC_SOURCE_LOCATION = {
+  line: 1,
+  column: 1,
+} as const;
+
 interface ArtifactToIrOptions {
   cwd?: string;
 }
@@ -169,6 +174,7 @@ function collectSourceEntriesFromSourceMap(
       source: {
         file: buildResult.manifest.bundles[0]?.file ?? "manifest.bundles[0]",
         viaSourceMap: true,
+        ...DETERMINISTIC_SOURCE_LOCATION,
       },
     });
     return [];
@@ -185,6 +191,7 @@ function collectSourceEntriesFromSourceMap(
       source: {
         file: mapPath,
         viaSourceMap: true,
+        ...DETERMINISTIC_SOURCE_LOCATION,
       },
     });
     return [];
@@ -196,6 +203,13 @@ function collectSourceEntriesFromSourceMap(
     "sources" in parsedMap
       ? (parsedMap as { sources?: unknown[] }).sources
       : undefined;
+  const sourceRoot =
+    typeof parsedMap === "object" &&
+    parsedMap !== null &&
+    "sourceRoot" in parsedMap &&
+    typeof (parsedMap as { sourceRoot?: unknown }).sourceRoot === "string"
+      ? (parsedMap as { sourceRoot: string }).sourceRoot
+      : "";
 
   if (!Array.isArray(sources)) {
     diagnostics.push({
@@ -206,6 +220,7 @@ function collectSourceEntriesFromSourceMap(
       source: {
         file: mapPath,
         viaSourceMap: true,
+        ...DETERMINISTIC_SOURCE_LOCATION,
       },
     });
     return [];
@@ -213,17 +228,37 @@ function collectSourceEntriesFromSourceMap(
 
   const normalized = new Set<string>();
   for (const sourcePath of sources) {
-    if (typeof sourcePath !== "string" || !sourcePath.trim()) {
-      continue;
-    }
-    const resolved = path
-      .normalize(path.join(path.dirname(mapPath), sourcePath))
-      .replaceAll("\\", "/");
-    const withoutDot = resolved.startsWith("./") ? resolved.slice(2) : resolved;
-    if (!withoutDot.startsWith("../")) {
-      normalized.add(withoutDot);
+    const normalizedSource = normalizeSourceMapSourcePath({
+      mapPath,
+      sourceRoot,
+      sourcePath,
+    });
+    if (normalizedSource) {
+      normalized.add(normalizedSource);
     }
   }
 
   return [...normalized].sort((a, b) => a.localeCompare(b));
+}
+
+function normalizeSourceMapSourcePath(params: {
+  mapPath: string;
+  sourceRoot: string;
+  sourcePath: unknown;
+}): string | undefined {
+  if (typeof params.sourcePath !== "string" || !params.sourcePath.trim()) {
+    return undefined;
+  }
+
+  const rootedPath = params.sourceRoot.trim()
+    ? path.join(params.sourceRoot, params.sourcePath)
+    : params.sourcePath;
+  const resolved = path
+    .normalize(path.join(path.dirname(params.mapPath), rootedPath))
+    .replaceAll("\\", "/");
+  const withoutDot = resolved.startsWith("./") ? resolved.slice(2) : resolved;
+  if (withoutDot.startsWith("../")) {
+    return undefined;
+  }
+  return withoutDot;
 }

--- a/packages/pipeline/test/artifact-to-ir.test.ts
+++ b/packages/pipeline/test/artifact-to-ir.test.ts
@@ -82,6 +82,58 @@ test("buildProgramIrFromArtifacts ingests d.ts and sourcemap into deterministic 
   assert.deepEqual(ir.diagnostics, []);
 });
 
+test("buildProgramIrFromArtifacts resolves sourcemap sourceRoot deterministically for module locations", () => {
+  const cwd = fs.mkdtempSync(
+    path.join(os.tmpdir(), "tsgodown-artifact-ir-root-"),
+  );
+  fs.mkdirSync(path.join(cwd, "dist", "maps"), { recursive: true });
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "index.d.ts"),
+    "export declare const ok: true;\n",
+  );
+  fs.writeFileSync(
+    path.join(cwd, "dist", "maps", "index.mjs.map"),
+    JSON.stringify({
+      version: 3,
+      file: "../index.mjs",
+      sourceRoot: "../../src",
+      sources: ["routes/a.ts", "routes/b.ts", "routes/a.ts"],
+      names: [],
+      mappings: "",
+    }),
+  );
+
+  const ir = buildProgramIrFromArtifacts(
+    {
+      mode: "rust-engine-adapter",
+      manifestPath: "artifacts/manifests/manifest.json",
+      manifestIndexPath: "artifacts/manifests/index.json",
+      manifest: {
+        buildId: "aabbccddeeff0011",
+        entries: ["src/index.ts"],
+        bundles: [
+          {
+            file: "dist/index.mjs",
+            map: "dist/maps/index.mjs.map",
+            format: "esm",
+            exports: ["ok"],
+          },
+        ],
+        types: ["dist/index.d.ts"],
+      },
+      diagnostics: [],
+    },
+    "src/index.ts",
+    { cwd },
+  );
+
+  assert.deepEqual(
+    ir.modules.map((module) => module.sourcePath),
+    ["src/routes/a.ts", "src/routes/b.ts"],
+  );
+});
+
 test("buildProgramIrFromArtifacts emits deterministic diagnostics for missing/invalid typed mapping metadata", () => {
   const cwd = fs.mkdtempSync(
     path.join(os.tmpdir(), "tsgodown-artifact-ir-diag-"),
@@ -118,4 +170,40 @@ test("buildProgramIrFromArtifacts emits deterministic diagnostics for missing/in
     ["PIPELINE_INVALID_SOURCEMAP_MAPPING", "PIPELINE_MISSING_TYPES_METADATA"],
   );
   assert.equal(ir.diagnostics[0]?.source?.viaSourceMap, true);
+  assert.equal(ir.diagnostics[0]?.source?.line, 1);
+  assert.equal(ir.diagnostics[0]?.source?.column, 1);
+});
+
+test("buildProgramIrFromArtifacts emits missing-map diagnostics with deterministic bundle source location", () => {
+  const cwd = fs.mkdtempSync(
+    path.join(os.tmpdir(), "tsgodown-artifact-ir-nomap-"),
+  );
+  fs.mkdirSync(path.join(cwd, "dist"), { recursive: true });
+
+  const ir = buildProgramIrFromArtifacts(
+    {
+      mode: "rust-engine-adapter",
+      manifestPath: "artifacts/manifests/manifest.json",
+      manifestIndexPath: "artifacts/manifests/index.json",
+      manifest: {
+        buildId: "aabbccddeeff0011",
+        entries: ["src/index.ts"],
+        bundles: [{ file: "dist/index.mjs", format: "esm", exports: [] }],
+      },
+      diagnostics: [],
+    },
+    "src/index.ts",
+    { cwd },
+  );
+
+  const missingMap = ir.diagnostics.find(
+    (diag) => diag.code === "PIPELINE_MISSING_SOURCEMAP_MAPPING",
+  );
+  assert.ok(missingMap);
+  assert.deepEqual(missingMap.source, {
+    file: "dist/index.mjs",
+    viaSourceMap: true,
+    line: 1,
+    column: 1,
+  });
 });


### PR DESCRIPTION
## Summary
- add TDD coverage for sourcemap `sourceRoot` resolution into deterministic module source paths
- add deterministic missing/invalid sourcemap diagnostic location enrichment (`line: 1`, `column: 1`)
- extract minimal deterministic sourcemap path normalization utility used by artifact-to-ir mapping

## Why
The artifact-to-IR bridge must keep typed and location mapping stable across environments. This PR closes gaps where `sourceRoot` was ignored and missing-map diagnostics lacked source coordinates.

## Test Plan
- pnpm --filter pipeline test -- artifact-to-ir.test.ts
- pnpm lint
- pnpm build
- pnpm test
- pnpm gate:m1
