### PR TITLE
pipeline: deterministic typed IR extraction for indexed sourcemap sections

### DIFF
--- a/packages/pipeline/src/internal/artifact-to-ir.ts
+++ b/packages/pipeline/src/internal/artifact-to-ir.ts
@@ -197,21 +197,8 @@ function collectSourceEntriesFromSourceMap(
     return [];
   }
 
-  const sources =
-    typeof parsedMap === "object" &&
-    parsedMap !== null &&
-    "sources" in parsedMap
-      ? (parsedMap as { sources?: unknown[] }).sources
-      : undefined;
-  const sourceRoot =
-    typeof parsedMap === "object" &&
-    parsedMap !== null &&
-    "sourceRoot" in parsedMap &&
-    typeof (parsedMap as { sourceRoot?: unknown }).sourceRoot === "string"
-      ? (parsedMap as { sourceRoot: string }).sourceRoot
-      : "";
-
-  if (!Array.isArray(sources)) {
+  const sourceEntries = collectSourceMapEntries(parsedMap);
+  if (sourceEntries.length === 0) {
     diagnostics.push({
       level: "warn",
       code: "PIPELINE_INVALID_SOURCEMAP_MAPPING",
@@ -227,11 +214,11 @@ function collectSourceEntriesFromSourceMap(
   }
 
   const normalized = new Set<string>();
-  for (const sourcePath of sources) {
+  for (const entry of sourceEntries) {
     const normalizedSource = normalizeSourceMapSourcePath({
       mapPath,
-      sourceRoot,
-      sourcePath,
+      sourceRoot: entry.sourceRoot,
+      sourcePath: entry.sourcePath,
     });
     if (normalizedSource) {
       normalized.add(normalizedSource);
@@ -239,6 +226,45 @@ function collectSourceEntriesFromSourceMap(
   }
 
   return [...normalized].sort((a, b) => a.localeCompare(b));
+}
+
+function collectSourceMapEntries(parsedMap: unknown): Array<{
+  sourcePath: unknown;
+  sourceRoot: string;
+}> {
+  if (typeof parsedMap !== "object" || parsedMap === null) {
+    return [];
+  }
+
+  const directSources = (parsedMap as { sources?: unknown }).sources;
+  const directSourceRoot =
+    typeof (parsedMap as { sourceRoot?: unknown }).sourceRoot === "string"
+      ? ((parsedMap as { sourceRoot: string }).sourceRoot ?? "")
+      : "";
+  if (Array.isArray(directSources)) {
+    return directSources.map((sourcePath) => ({
+      sourcePath,
+      sourceRoot: directSourceRoot,
+    }));
+  }
+
+  const sections = (parsedMap as { sections?: unknown }).sections;
+  if (!Array.isArray(sections)) {
+    return [];
+  }
+
+  const entries: Array<{ sourcePath: unknown; sourceRoot: string }> = [];
+  for (const section of sections) {
+    if (typeof section !== "object" || section === null) {
+      continue;
+    }
+    const sectionMap = (section as { map?: unknown }).map;
+    for (const nestedEntry of collectSourceMapEntries(sectionMap)) {
+      entries.push(nestedEntry);
+    }
+  }
+
+  return entries;
 }
 
 function normalizeSourceMapSourcePath(params: {

--- a/packages/pipeline/test/artifact-to-ir.test.ts
+++ b/packages/pipeline/test/artifact-to-ir.test.ts
@@ -134,6 +134,75 @@ test("buildProgramIrFromArtifacts resolves sourcemap sourceRoot deterministicall
   );
 });
 
+test("buildProgramIrFromArtifacts resolves indexed sourcemap sections deterministically for module locations", () => {
+  const cwd = fs.mkdtempSync(
+    path.join(os.tmpdir(), "tsgodown-artifact-ir-indexed-"),
+  );
+  fs.mkdirSync(path.join(cwd, "dist", "maps"), { recursive: true });
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "index.d.ts"),
+    "export declare const ok: true;\n",
+  );
+  fs.writeFileSync(
+    path.join(cwd, "dist", "maps", "index.mjs.map"),
+    JSON.stringify({
+      version: 3,
+      file: "../index.mjs",
+      sections: [
+        {
+          offset: { line: 0, column: 0 },
+          map: {
+            version: 3,
+            sourceRoot: "../../src",
+            sources: ["routes/z.ts", "routes/a.ts"],
+            mappings: "",
+          },
+        },
+        {
+          offset: { line: 10, column: 0 },
+          map: {
+            version: 3,
+            sourceRoot: "../../src",
+            sources: ["routes/a.ts", "routes/m.ts"],
+            mappings: "",
+          },
+        },
+      ],
+    }),
+  );
+
+  const ir = buildProgramIrFromArtifacts(
+    {
+      mode: "rust-engine-adapter",
+      manifestPath: "artifacts/manifests/manifest.json",
+      manifestIndexPath: "artifacts/manifests/index.json",
+      manifest: {
+        buildId: "aabbccddeeff0011",
+        entries: ["src/index.ts"],
+        bundles: [
+          {
+            file: "dist/index.mjs",
+            map: "dist/maps/index.mjs.map",
+            format: "esm",
+            exports: ["ok"],
+          },
+        ],
+        types: ["dist/index.d.ts"],
+      },
+      diagnostics: [],
+    },
+    "src/index.ts",
+    { cwd },
+  );
+
+  assert.deepEqual(
+    ir.modules.map((module) => module.sourcePath),
+    ["src/routes/a.ts", "src/routes/m.ts", "src/routes/z.ts"],
+  );
+  assert.deepEqual(ir.diagnostics, []);
+});
+
 test("buildProgramIrFromArtifacts emits deterministic diagnostics for missing/invalid typed mapping metadata", () => {
   const cwd = fs.mkdtempSync(
     path.join(os.tmpdir(), "tsgodown-artifact-ir-diag-"),


### PR DESCRIPTION
## Summary
- add TDD coverage for indexed sourcemap (`sections[].map`) source extraction in artifact-to-ir
- make sourcemap source collection handle both standard maps (`sources`) and indexed maps (`sections`)
- preserve deterministic normalization/sorting and deduplication of module source paths

## Why
Typed IR extraction should remain deterministic when tsdown emits indexed sourcemaps in edge cases. Previously, indexed maps fell back to manifest entries due to missing top-level `sources[]`.

## Testing
- pnpm format
- pnpm format:check
- pnpm lint
- pnpm build
- pnpm test
- pnpm gate:m1
