### PR TITLE
Go emitter: keep file-only diagnostic source locations from typed IR

### DIFF
--- a/packages/emitter-go/src/render/diagnostics-comment-rendering.ts
+++ b/packages/emitter-go/src/render/diagnostics-comment-rendering.ts
@@ -4,9 +4,19 @@ function formatDiagnosticSource(diagnostic: DiagnosticIR): string | undefined {
   const source = diagnostic.source;
   if (!source) return undefined;
 
-  const line = source.line ?? "?";
-  const column = source.column ?? "?";
-  return `${source.file}:${line}:${column}`;
+  if (source.line == null && source.column == null) {
+    return source.file;
+  }
+
+  if (source.line != null && source.column != null) {
+    return `${source.file}:${source.line}:${source.column}`;
+  }
+
+  if (source.line != null) {
+    return `${source.file}:${source.line}`;
+  }
+
+  return `${source.file}:?:${source.column}`;
 }
 
 function compareDiagnostics(a: DiagnosticIR, b: DiagnosticIR): number {

--- a/packages/emitter-go/test/emit-go.test.ts
+++ b/packages/emitter-go/test/emit-go.test.ts
@@ -444,6 +444,37 @@ test("emitGoProject unknown handler semantics use concrete JSON fallback without
   assert.doesNotMatch(goSource, /TODO implement handler/);
 });
 
+test("emitGoProject renders diagnostic source without placeholder coordinates when sourcemap omits line/column", () => {
+  const outDir = createOutDir();
+
+  emitGoProject(
+    {
+      modules: [],
+      handlers: [{ id: "h", params: [], async: false }],
+      diagnostics: [
+        {
+          level: "warn",
+          code: "SOURCEMAP_POSITION_PARTIAL",
+          message:
+            "sourcemap provided original file without stable generated coordinates",
+          source: { file: "src/generated/entry.js" },
+        },
+      ],
+      routes: [{ method: "GET", path: "/health", handlerRef: "h" }],
+    },
+    outDir,
+  );
+
+  const emitted = fs.readFileSync(path.join(outDir, "main.go"), "utf8");
+
+  assert.match(
+    emitted,
+    /\/\/\s+\[warn\] SOURCEMAP_POSITION_PARTIAL: sourcemap provided original file without stable generated coordinates/,
+  );
+  assert.match(emitted, /\/\/\s+at src\/generated\/entry\.js/);
+  assert.doesNotMatch(emitted, /src\/generated\/entry\.js:\?:\?/);
+});
+
 test("emitGoProject surfaces IR diagnostics as actionable comments without adding adapter policy", () => {
   const outDir = createOutDir();
 


### PR DESCRIPTION
## Summary
- add a Go emitter test asserting diagnostics with sourcemap-backed file-only sources render without `?:?` placeholders
- update diagnostic source formatter to preserve available coordinate fidelity:
  - file only -> `file`
  - file + line -> `file:line`
  - file + line + column -> `file:line:column`
  - file + column -> `file:?:column`

## Validation
- pnpm format
- pnpm format:check
- pnpm lint
- pnpm build
- pnpm test
- pnpm gate:m1