### PR TITLE
pipeline: stabilize sourceRoot mixed-segment path normalization

### DIFF
--- a/packages/emitter-go/test/emit-go.test.ts
+++ b/packages/emitter-go/test/emit-go.test.ts
@@ -475,6 +475,58 @@ test("emitGoProject renders diagnostic source without placeholder coordinates wh
   assert.doesNotMatch(emitted, /src\/generated\/entry\.js:\?:\?/);
 });
 
+test("emitGoProject keeps normalized repo-relative sourcemap diagnostic paths in comments and go-build flow", () => {
+  const outDir = createOutDir();
+
+  emitGoProject(
+    {
+      modules: [
+        {
+          id: "module_0",
+          sourcePath: "src/health.ts",
+          exports: ["health"],
+          imports: [],
+        },
+        {
+          id: "module_1",
+          sourcePath: "src/routes/list.ts",
+          exports: ["health"],
+          imports: [],
+        },
+      ],
+      handlers: [{ id: "h", params: [], async: false }],
+      diagnostics: [
+        {
+          level: "warn",
+          code: "SOURCEMAP_NORMALIZED_PATH",
+          message: "normalized sourcemap source path for stable module mapping",
+          source: { file: "src/routes/list.ts", line: 1, column: 1 },
+        },
+      ],
+      routes: [{ method: "GET", path: "/health", handlerRef: "h" }],
+    },
+    outDir,
+  );
+
+  const emitted = fs.readFileSync(path.join(outDir, "main.go"), "utf8");
+  assert.match(emitted, /\/\/\s+at src\/routes\/list\.ts:1:1/);
+
+  if (hasGoToolchain) {
+    const modulePath = "example.com/tsgodown-smoke/normalized-sourcemap-paths";
+    const modInit = spawnSync("go", ["mod", "init", modulePath], {
+      cwd: outDir,
+      encoding: "utf8",
+    });
+    assert.equal(modInit.status, 0, modInit.stderr || modInit.stdout);
+
+    const build = spawnSync("go", ["build", "./..."], {
+      cwd: outDir,
+      encoding: "utf8",
+    });
+    assert.equal(build.status, 0, build.stderr || build.stdout);
+  }
+});
+
 test("emitGoProject surfaces IR diagnostics as actionable comments without adding adapter policy", () => {
   const outDir = createOutDir();
 

--- a/packages/pipeline/src/internal/artifact-to-ir.ts
+++ b/packages/pipeline/src/internal/artifact-to-ir.ts
@@ -216,6 +216,7 @@ function collectSourceEntriesFromSourceMap(
   const normalized = new Set<string>();
   for (const entry of sourceEntries) {
     const normalizedSource = normalizeSourceMapSourcePath({
+      cwd,
       mapPath,
       sourceRoot: entry.sourceRoot,
       sourcePath: entry.sourcePath,
@@ -268,6 +269,7 @@ function collectSourceMapEntries(parsedMap: unknown): Array<{
 }
 
 function normalizeSourceMapSourcePath(params: {
+  cwd: string;
   mapPath: string;
   sourceRoot: string;
   sourcePath: unknown;
@@ -279,11 +281,23 @@ function normalizeSourceMapSourcePath(params: {
   const rootedPath = params.sourceRoot.trim()
     ? path.join(params.sourceRoot, params.sourcePath)
     : params.sourcePath;
-  const resolved = path
-    .normalize(path.join(path.dirname(params.mapPath), rootedPath))
-    .replaceAll("\\", "/");
-  const withoutDot = resolved.startsWith("./") ? resolved.slice(2) : resolved;
-  if (withoutDot.startsWith("../")) {
+
+  const resolved = path.isAbsolute(rootedPath)
+    ? path.normalize(rootedPath)
+    : path.normalize(path.join(path.dirname(params.mapPath), rootedPath));
+
+  const relativeToCwd = path.isAbsolute(resolved)
+    ? path.relative(params.cwd, resolved)
+    : resolved;
+  const normalized = relativeToCwd.replaceAll("\\", "/");
+  const withoutDot = normalized.startsWith("./")
+    ? normalized.slice(2)
+    : normalized;
+  if (
+    !withoutDot ||
+    withoutDot.startsWith("../") ||
+    path.isAbsolute(withoutDot)
+  ) {
     return undefined;
   }
   return withoutDot;

--- a/packages/pipeline/test/artifact-to-ir.test.ts
+++ b/packages/pipeline/test/artifact-to-ir.test.ts
@@ -203,6 +203,64 @@ test("buildProgramIrFromArtifacts resolves indexed sourcemap sections determinis
   assert.deepEqual(ir.diagnostics, []);
 });
 
+test("buildProgramIrFromArtifacts normalizes absolute sourceRoot with mixed relative segments into stable repo-relative module paths", () => {
+  const cwd = fs.mkdtempSync(
+    path.join(os.tmpdir(), "tsgodown-artifact-ir-abs-root-"),
+  );
+  fs.mkdirSync(path.join(cwd, "dist", "maps"), { recursive: true });
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "index.d.ts"),
+    "export declare const ok: true;\n",
+  );
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "maps", "index.mjs.map"),
+    JSON.stringify({
+      version: 3,
+      file: "../index.mjs",
+      sourceRoot: path.join(cwd, "src", "nested", ".."),
+      sources: [
+        "./routes/../health.ts",
+        "./routes/users/../list.ts",
+        "./routes/../health.ts",
+      ],
+      names: [],
+      mappings: "",
+    }),
+  );
+
+  const ir = buildProgramIrFromArtifacts(
+    {
+      mode: "rust-engine-adapter",
+      manifestPath: "artifacts/manifests/manifest.json",
+      manifestIndexPath: "artifacts/manifests/index.json",
+      manifest: {
+        buildId: "aabbccddeeff0011",
+        entries: ["src/index.ts"],
+        bundles: [
+          {
+            file: "dist/index.mjs",
+            map: "dist/maps/index.mjs.map",
+            format: "esm",
+            exports: ["ok"],
+          },
+        ],
+        types: ["dist/index.d.ts"],
+      },
+      diagnostics: [],
+    },
+    "src/index.ts",
+    { cwd },
+  );
+
+  assert.deepEqual(
+    ir.modules.map((module) => module.sourcePath),
+    ["src/health.ts", "src/routes/list.ts"],
+  );
+  assert.deepEqual(ir.diagnostics, []);
+});
+
 test("buildProgramIrFromArtifacts emits deterministic diagnostics for missing/invalid typed mapping metadata", () => {
   const cwd = fs.mkdtempSync(
     path.join(os.tmpdir(), "tsgodown-artifact-ir-diag-"),


### PR DESCRIPTION
## Summary
- add TDD coverage for sourcemap `sourceRoot` with mixed relative segments and deterministic `ProgramIR.modules[].sourcePath`
- normalize absolute sourcemap-rooted paths to repo-relative module paths for stable typed IR extraction
- add emitter-go test to assert normalized source paths remain present in generated diagnostic comments and still pass Go build flow

## Why
Real dist sourcemaps can carry absolute `sourceRoot` values plus mixed relative source segments. Without normalization to repo-relative paths, typed IR module paths become machine-specific/non-deterministic.

## Testing
- pnpm format
- pnpm format:check
- pnpm lint
- pnpm build
- pnpm test
- pnpm gate:m1
