### PR TITLE
test(pipeline): cover real artifact->typed IR->Go compile flow

### DIFF
--- a/packages/pipeline/src/internal/artifact-to-ir.ts
+++ b/packages/pipeline/src/internal/artifact-to-ir.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import type { DiagnosticIR, ProgramIR } from "@tsgodown/ir-core";
 import type { RunBuildResult } from "@tsgodown/tsdown-driver";
@@ -333,9 +334,11 @@ function normalizeSourceMapSourcePath(params: {
     return undefined;
   }
 
-  const rootedPath = params.sourceRoot.trim()
-    ? path.join(params.sourceRoot, params.sourcePath)
-    : params.sourcePath;
+  const sourceRootPath = toFileSystemPath(params.sourceRoot);
+  const sourcePath = toFileSystemPath(params.sourcePath);
+  const rootedPath = sourceRootPath.trim()
+    ? path.join(sourceRootPath, sourcePath)
+    : sourcePath;
 
   const resolved = path.isAbsolute(rootedPath)
     ? path.normalize(rootedPath)
@@ -356,4 +359,20 @@ function normalizeSourceMapSourcePath(params: {
     return undefined;
   }
   return withoutDot;
+}
+
+function toFileSystemPath(value: string): string {
+  if (!value.trim()) {
+    return "";
+  }
+
+  if (value.startsWith("file://")) {
+    try {
+      return fileURLToPath(value);
+    } catch {
+      return value;
+    }
+  }
+
+  return value;
 }

--- a/packages/pipeline/test/pipeline.e2e.test.ts
+++ b/packages/pipeline/test/pipeline.e2e.test.ts
@@ -6,7 +6,11 @@ import os from "node:os";
 import path from "node:path";
 import { after, test } from "node:test";
 
+import { emitGoProject } from "@tsgodown/emitter-go";
+import type { RunBuildResult } from "@tsgodown/tsdown-driver";
+
 import { runPipeline } from "../src/index.ts";
+import { buildProgramIrFromArtifacts } from "../src/internal/artifact-to-ir.ts";
 
 const tempDirs: string[] = [];
 
@@ -183,4 +187,95 @@ test("M1 regression: runPipeline fastify scaffold TS -> dist-go/main.go -> go bu
       process.env.TSGODOWN_RUST_ENGINE_BIN = prevRustBin;
     }
   }
+});
+
+test("M1 regression: real JS+d.ts+sourcemap artifact provenance (file:// sourceRoot) -> typed IR -> Go compile smoke", () => {
+  const cwd = fs.mkdtempSync(
+    path.join(os.tmpdir(), "tsgodown-pipeline-artifact-go-e2e-"),
+  );
+  tempDirs.push(cwd);
+
+  fs.mkdirSync(path.join(cwd, "src", "routes"), { recursive: true });
+  fs.mkdirSync(path.join(cwd, "dist"), { recursive: true });
+
+  fs.writeFileSync(
+    path.join(cwd, "src", "routes", "health.ts"),
+    "export const health = () => ({ ok: true });\n",
+  );
+  fs.writeFileSync(
+    path.join(cwd, "src", "routes", "users.ts"),
+    "export const listUsers = () => [{ id: 'u1' }];\n",
+  );
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "index.mjs"),
+    [
+      "const health = () => ({ ok: true });",
+      "const listUsers = () => [{ id: 'u1' }];",
+      "export { health, listUsers };",
+      "//# sourceMappingURL=index.mjs.map",
+      "",
+    ].join("\n"),
+  );
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "index.d.ts"),
+    [
+      "export declare const health: () => { ok: boolean };",
+      "export declare const listUsers: () => Array<{ id: string }>;",
+      "",
+    ].join("\n"),
+  );
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "index.mjs.map"),
+    JSON.stringify({
+      version: 3,
+      file: "index.mjs",
+      sourceRoot: new URL(`file://${path.join(cwd, "src")}/`).toString(),
+      sources: ["routes/health.ts", "routes/users.ts"],
+      names: [],
+      mappings: "",
+    }),
+  );
+
+  const buildResult: RunBuildResult = {
+    mode: "rust-engine-adapter",
+    manifestPath: "artifacts/manifests/manifest.json",
+    manifestIndexPath: "artifacts/manifests/index.json",
+    manifest: {
+      buildId: "0011223344556677",
+      entries: ["src/index.ts"],
+      bundles: [
+        {
+          file: "dist/index.mjs",
+          map: "dist/index.mjs.map",
+          format: "esm",
+          exports: ["health", "listUsers"],
+        },
+      ],
+      types: ["dist/index.d.ts"],
+    },
+    diagnostics: [],
+  };
+
+  const ir = buildProgramIrFromArtifacts(buildResult, "src/index.ts", { cwd });
+
+  assert.deepEqual(
+    ir.modules.map((module) => module.sourcePath),
+    ["src/routes/health.ts", "src/routes/users.ts"],
+  );
+  assert.deepEqual(ir.modules[0]?.exports, ["health", "listUsers"]);
+  assert.deepEqual(ir.diagnostics, []);
+
+  const goOutDir = path.join(cwd, "dist-go");
+  emitGoProject(ir, goOutDir);
+
+  const goMainPath = path.join(goOutDir, "main.go");
+  assert.equal(fs.existsSync(goMainPath), true);
+  const goSource = fs.readFileSync(goMainPath, "utf8");
+  assert.match(goSource, /^package main/m);
+  assert.match(goSource, /router\.handle\("GET", "\/health", route0\)/);
+
+  assertGoBuildSuccessIfToolchainAvailable(goOutDir);
 });


### PR DESCRIPTION
## Summary
- add a TDD-first pipeline e2e regression that creates real `dist/index.mjs` + `dist/index.d.ts` + `dist/index.mjs.map` artifacts, ingests them into typed IR, emits Go, and smoke-compiles via `go build` when toolchain is available
- cover real sourcemap provenance where `sourceRoot` is a `file://` URL
- minimally fix artifact-to-IR source normalization to decode `file://` source roots/sources into filesystem paths before repo-relative normalization

## TDD evidence
- New failing test first:
  - `M1 regression: real JS+d.ts+sourcemap artifact provenance (file:// sourceRoot) -> typed IR -> Go compile smoke`
- Red failure before fix:
  - actual module paths were `dist/file:/.../src/routes/*.ts`
  - expected deterministic repo-relative `src/routes/*.ts`
- Green after fix:
  - typed IR modules resolve to `src/routes/health.ts`, `src/routes/users.ts`
  - Go emission + compile smoke path succeeds (when Go is installed)

## Required checks
- `pnpm format`
- `pnpm format:check`
- `pnpm lint`
- `pnpm build`
- `pnpm test`
- `pnpm gate:m1`

All passed locally.
