### PR TITLE
test+fix: deterministic mixed indexed sourcemap typed IR diagnostics ordering

### DIFF
--- a/packages/emitter-go/src/render/diagnostics-comment-rendering.ts
+++ b/packages/emitter-go/src/render/diagnostics-comment-rendering.ts
@@ -31,14 +31,14 @@ function compareDiagnostics(a: DiagnosticIR, b: DiagnosticIR): number {
     return fileOrder;
   }
 
-  const lineA = sourceA?.line ?? -1;
-  const lineB = sourceB?.line ?? -1;
+  const lineA = sourceA?.line ?? Number.MAX_SAFE_INTEGER;
+  const lineB = sourceB?.line ?? Number.MAX_SAFE_INTEGER;
   if (lineA !== lineB) {
     return lineA - lineB;
   }
 
-  const columnA = sourceA?.column ?? -1;
-  const columnB = sourceB?.column ?? -1;
+  const columnA = sourceA?.column ?? Number.MAX_SAFE_INTEGER;
+  const columnB = sourceB?.column ?? Number.MAX_SAFE_INTEGER;
   if (columnA !== columnB) {
     return columnA - columnB;
   }

--- a/packages/pipeline/test/pipeline.e2e.test.ts
+++ b/packages/pipeline/test/pipeline.e2e.test.ts
@@ -368,3 +368,91 @@ test("M1 regression: indexed sourcemap inherited file:// sourceRoot keeps typed 
   assert.match(goMain, /\/\/\s+at src\/routes\/health\.ts:1:1/);
   assertGoBuildSuccessIfToolchainAvailable(goOutDir);
 });
+
+test("M1 regression: mixed indexed sourcemap JS+d.ts typed IR diagnostics keep source mapping and deterministic Go comment ordering", () => {
+  const cwd = fs.mkdtempSync(
+    path.join(os.tmpdir(), "tsgodown-pipeline-e2e-indexed-mixed-diag-"),
+  );
+  tempDirs.push(cwd);
+
+  fs.mkdirSync(path.join(cwd, "dist", "maps"), { recursive: true });
+  fs.mkdirSync(path.join(cwd, "src", "routes"), { recursive: true });
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "index.mjs"),
+    [
+      "export const health = () => ({ ok: true });",
+      "//# sourceMappingURL=maps/index.mjs.map",
+      "",
+    ].join("\n"),
+  );
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "index.d.ts"),
+    ["export declare const health: () => { ok: boolean };", ""].join("\n"),
+  );
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "maps", "index.mjs.map"),
+    JSON.stringify({
+      version: 3,
+      file: "../index.mjs",
+      sourceRoot: new URL(`file://${path.join(cwd, "src")}/`).toString(),
+      sections: [
+        {
+          offset: {},
+          map: {
+            version: 3,
+            sources: [null, "routes/health.ts"],
+            mappings: ";;;",
+          },
+        },
+        {
+          offset: { line: 4 },
+          map: {
+            version: 3,
+            names: [],
+            mappings: "",
+          },
+        },
+      ],
+    }),
+  );
+
+  const buildResult: RunBuildResult = {
+    mode: "rust-engine-adapter",
+    manifestPath: "artifacts/manifests/manifest.json",
+    manifestIndexPath: "artifacts/manifests/index.json",
+    manifest: {
+      buildId: "fedcba9876543210",
+      entries: ["src/index.ts"],
+      bundles: [
+        {
+          file: "dist/index.mjs",
+          map: "dist/maps/index.mjs.map",
+          format: "esm",
+          exports: ["health"],
+        },
+      ],
+      types: ["dist/index.d.ts"],
+    },
+    diagnostics: [],
+  };
+
+  const ir = buildProgramIrFromArtifacts(buildResult, "src/index.ts", { cwd });
+  assert.deepEqual(
+    ir.modules.map((module) => module.sourcePath),
+    ["src/routes/health.ts"],
+  );
+
+  const goOutDir = path.join(cwd, "dist-go");
+  emitGoProject(ir, goOutDir);
+
+  const goMain = fs.readFileSync(path.join(goOutDir, "main.go"), "utf8");
+  const lineScoped = goMain.indexOf("at dist/maps/index.mjs.map:5");
+  const fileOnly = goMain.indexOf("at dist/maps/index.mjs.map\n");
+  assert.ok(lineScoped >= 0 && fileOnly >= 0);
+  assert.ok(lineScoped < fileOnly);
+
+  assertGoBuildSuccessIfToolchainAvailable(goOutDir);
+});


### PR DESCRIPTION
## Summary\n- add failing-first pipeline e2e covering JS + d.ts + mixed indexed sourcemap sections\n- assert typed IR module mapping remains normalized and Go diagnostic comments are deterministic\n- fix diagnostic comment ordering to place line-scoped entries before file-only entries for stable numeric flow\n\n## Validation\n- pnpm install --frozen-lockfile\n- pnpm run lint\n- pnpm run format:check\n- pnpm run build\n- pnpm run examples:install-first:check\n- pnpm run test\n- cargo fmt --all --check\n- cargo clippy --workspace --all-targets -- -D warnings\n- cargo test --workspace --all-targets\n- pnpm run gate:differential\n- pnpm run gate:compliance\n- pnpm run test:guard:core-path