### PR TITLE
fix: deterministic mixed sourcemap diagnostic ordering in emitter-go

### DIFF
--- a/packages/emitter-go/src/render/diagnostics-comment-rendering.ts
+++ b/packages/emitter-go/src/render/diagnostics-comment-rendering.ts
@@ -1,49 +1,45 @@
 import type { DiagnosticIR } from "@tsgodown/ir-core";
 
+function normalizeDiagnosticPath(pathValue: string): string {
+  return pathValue.replaceAll("\\", "/");
+}
+
 function formatDiagnosticSource(diagnostic: DiagnosticIR): string | undefined {
   const source = diagnostic.source;
   if (!source) return undefined;
+
+  const normalizedFile = normalizeDiagnosticPath(source.file);
 
   if (
     diagnostic.code === "PIPELINE_SOURCEMAP_SPARSE_MAPPING" ||
     (source.line == null && source.column == null)
   ) {
-    return source.file;
+    return normalizedFile;
   }
 
   if (source.line != null && source.column != null) {
-    return `${source.file}:${source.line}:${source.column}`;
+    return `${normalizedFile}:${source.line}:${source.column}`;
   }
 
   if (source.line != null) {
-    return `${source.file}:${source.line}`;
+    return `${normalizedFile}:${source.line}`;
   }
 
-  return source.file;
+  return `${normalizedFile}:${source.column}`;
 }
 
 function compareDiagnostics(a: DiagnosticIR, b: DiagnosticIR): number {
-  const sourceA = a.source;
-  const sourceB = b.source;
-
-  const fileOrder = (sourceA?.file ?? "").localeCompare(sourceB?.file ?? "");
-  if (fileOrder !== 0) {
-    return fileOrder;
-  }
-
-  const lineA = sourceA?.line ?? Number.MAX_SAFE_INTEGER;
-  const lineB = sourceB?.line ?? Number.MAX_SAFE_INTEGER;
-  if (lineA !== lineB) {
-    return lineA - lineB;
-  }
-
-  const columnA = sourceA?.column ?? Number.MAX_SAFE_INTEGER;
-  const columnB = sourceB?.column ?? Number.MAX_SAFE_INTEGER;
-  if (columnA !== columnB) {
-    return columnA - columnB;
-  }
+  const fileA = normalizeDiagnosticPath(a.source?.file ?? "");
+  const fileB = normalizeDiagnosticPath(b.source?.file ?? "");
+  const lineA = a.source?.line ?? Number.MAX_SAFE_INTEGER;
+  const lineB = b.source?.line ?? Number.MAX_SAFE_INTEGER;
+  const columnA = a.source?.column ?? Number.MAX_SAFE_INTEGER;
+  const columnB = b.source?.column ?? Number.MAX_SAFE_INTEGER;
 
   return (
+    fileA.localeCompare(fileB) ||
+    lineA - lineB ||
+    columnA - columnB ||
     a.level.localeCompare(b.level) ||
     a.code.localeCompare(b.code) ||
     a.message.localeCompare(b.message)

--- a/packages/emitter-go/test/emit-go.test.ts
+++ b/packages/emitter-go/test/emit-go.test.ts
@@ -664,6 +664,96 @@ test("emitGoProject sorts same-file indexed missing-sources diagnostics by numer
   assert.ok(line4 < line21);
 });
 
+test("emitGoProject keeps deterministic ordering for mixed typed-IR sourcemap diagnostics across path styles", () => {
+  const firstOutDir = createOutDir();
+  const secondOutDir = createOutDir();
+
+  const baseDiagnostics: ProgramIR["diagnostics"] = [
+    {
+      level: "warn",
+      code: "PIPELINE_MISSING_SOURCEMAP_MAPPING",
+      message:
+        "missing sourcemap path required for deterministic source mapping",
+      source: {
+        file: "dist/index.mjs",
+        viaSourceMap: true,
+        line: 1,
+        column: 1,
+      },
+    },
+    {
+      level: "warn",
+      code: "PIPELINE_SOURCEMAP_POSITION_PARTIAL",
+      message:
+        "indexed sourcemap section offset is partial; diagnostics remain file-scoped for deterministic mapping",
+      source: { file: "dist/maps/index.mjs.map", viaSourceMap: true, line: 5 },
+    },
+    {
+      level: "warn",
+      code: "PIPELINE_INVALID_SOURCEMAP_MAPPING",
+      message:
+        "sourcemap metadata missing sources[] for artifact-to-ir mapping",
+      source: {
+        file: "dist/maps/index.mjs.map",
+        viaSourceMap: true,
+        line: 1,
+        column: 1,
+      },
+    },
+  ];
+
+  const firstIr: ProgramIR = {
+    modules: [],
+    handlers: [{ id: "h", params: [], async: false }],
+    diagnostics: [...baseDiagnostics].reverse(),
+    routes: [{ method: "GET", path: "/health", handlerRef: "h" }],
+  };
+
+  const secondIr: ProgramIR = {
+    ...firstIr,
+    diagnostics: [
+      {
+        ...baseDiagnostics[2],
+        source: {
+          ...baseDiagnostics[2].source,
+          file: "dist\\maps\\index.mjs.map",
+        },
+      },
+      {
+        ...baseDiagnostics[0],
+        source: { ...baseDiagnostics[0].source, file: "dist\\index.mjs" },
+      },
+      {
+        ...baseDiagnostics[1],
+        source: {
+          ...baseDiagnostics[1].source,
+          file: "dist\\maps\\index.mjs.map",
+        },
+      },
+    ],
+  };
+
+  emitGoProject(firstIr, firstOutDir);
+  emitGoProject(secondIr, secondOutDir);
+
+  const first = fs.readFileSync(path.join(firstOutDir, "main.go"), "utf8");
+  const second = fs.readFileSync(path.join(secondOutDir, "main.go"), "utf8");
+
+  assert.equal(first, second);
+  assert.ok(
+    second.indexOf("PIPELINE_MISSING_SOURCEMAP_MAPPING") <
+      second.indexOf("PIPELINE_INVALID_SOURCEMAP_MAPPING"),
+  );
+  assert.ok(
+    second.indexOf("PIPELINE_INVALID_SOURCEMAP_MAPPING") <
+      second.indexOf("PIPELINE_SOURCEMAP_POSITION_PARTIAL"),
+  );
+  assert.match(second, /\/\/\s+at dist\/maps\/index\.mjs\.map:1:1/);
+  assert.match(second, /\/\/\s+at dist\/index\.mjs:1:1/);
+  assert.match(second, /\/\/\s+at dist\/maps\/index\.mjs\.map:5/);
+  assert.doesNotMatch(second, /dist\\maps\\index\.mjs\.map/);
+});
+
 test("emitGoProject keeps normalized repo-relative sourcemap diagnostic paths in comments and go-build flow", () => {
   const outDir = createOutDir();
 


### PR DESCRIPTION
## Summary
- add a failing-first emitter-go test covering mixed typed-IR sourcemap diagnostics (missing map, sparse indexed section offsets, invalid sourcemap mappings)
- assert deterministic output is identical even when diagnostics arrive in different order and with mixed slash/backslash source file styles
- apply a minimal deterministic sort/key fix by normalizing source file separators and sorting by file/line/column before level/code/message
- normalize rendered diagnostic source paths to `/` to keep cross-platform output stable

## Validation
- pnpm install --frozen-lockfile
- pnpm lint
- pnpm format:check
- pnpm build
- pnpm examples:install-first:check
- pnpm test
- cargo fmt --check
- cargo clippy -- -D warnings
- cargo test
- pnpm guard:compiler-mode-only
- pnpm guard:core-path
- pnpm test:guard:core-path
- pnpm gate:differential
- pnpm gate:compliance
- pnpm gate:m1
