### PR TITLE
pipeline: support charset inline sourcemap fallback for typed IR

### DIFF
--- a/packages/pipeline/src/internal/artifact-to-ir.ts
+++ b/packages/pipeline/src/internal/artifact-to-ir.ts
@@ -166,13 +166,41 @@ function collectSourceEntriesFromSourceMap(
   diagnostics: DiagnosticIR[],
 ): string[] {
   const bundleFilePath = buildResult.manifest.bundles[0]?.file;
-  const mapPath =
+  let mapPath =
     buildResult.manifest.bundles[0]?.map ??
     discoverSourceMapPathFromBundle({
       cwd,
       bundlePath: bundleFilePath,
     });
-  if (!mapPath?.trim()) {
+
+  let parsedMap: unknown;
+  if (mapPath?.trim()) {
+    try {
+      parsedMap = JSON.parse(fs.readFileSync(path.join(cwd, mapPath), "utf8"));
+    } catch {
+      diagnostics.push({
+        level: "warn",
+        code: "PIPELINE_INVALID_SOURCEMAP_MAPPING",
+        message: `sourcemap metadata is missing or invalid JSON: ${mapPath}`,
+        source: {
+          file: mapPath,
+          viaSourceMap: true,
+          ...DETERMINISTIC_SOURCE_LOCATION,
+        },
+      });
+      return [];
+    }
+  } else {
+    parsedMap = readInlineSourceMapFromBundle({
+      cwd,
+      bundlePath: bundleFilePath,
+    });
+    if (parsedMap) {
+      mapPath = bundleFilePath ?? "manifest.bundles[0]";
+    }
+  }
+
+  if (!mapPath?.trim() || parsedMap === undefined) {
     diagnostics.push({
       level: "warn",
       code: "PIPELINE_MISSING_SOURCEMAP_MAPPING",
@@ -180,23 +208,6 @@ function collectSourceEntriesFromSourceMap(
         "missing sourcemap path required for deterministic source mapping",
       source: {
         file: bundleFilePath ?? "manifest.bundles[0]",
-        viaSourceMap: true,
-        ...DETERMINISTIC_SOURCE_LOCATION,
-      },
-    });
-    return [];
-  }
-
-  let parsedMap: unknown;
-  try {
-    parsedMap = JSON.parse(fs.readFileSync(path.join(cwd, mapPath), "utf8"));
-  } catch {
-    diagnostics.push({
-      level: "warn",
-      code: "PIPELINE_INVALID_SOURCEMAP_MAPPING",
-      message: `sourcemap metadata is missing or invalid JSON: ${mapPath}`,
-      source: {
-        file: mapPath,
         viaSourceMap: true,
         ...DETERMINISTIC_SOURCE_LOCATION,
       },
@@ -395,6 +406,67 @@ function discoverSourceMapPathFromBundle(params: {
   cwd: string;
   bundlePath: string | undefined;
 }): string | undefined {
+  const bundlePath = params.bundlePath;
+  if (!bundlePath?.trim()) {
+    return undefined;
+  }
+
+  const sourceMapUrl = readSourceMapUrlFromBundle(params);
+  if (!sourceMapUrl || sourceMapUrl.startsWith("data:")) {
+    return undefined;
+  }
+
+  const bundleDir = path.dirname(bundlePath);
+  const discoveredPath = path.isAbsolute(sourceMapUrl)
+    ? path.normalize(sourceMapUrl)
+    : path.normalize(path.join(bundleDir, sourceMapUrl));
+
+  const normalized = discoveredPath.replaceAll("\\", "/");
+  return normalized.startsWith("./") ? normalized.slice(2) : normalized;
+}
+
+function readInlineSourceMapFromBundle(params: {
+  cwd: string;
+  bundlePath: string | undefined;
+}): unknown | undefined {
+  const sourceMapUrl = readSourceMapUrlFromBundle(params);
+  if (!sourceMapUrl?.startsWith("data:")) {
+    return undefined;
+  }
+
+  const dataUrlMatch = sourceMapUrl.match(/^data:([^,]*),(.*)$/);
+  if (!dataUrlMatch) {
+    return undefined;
+  }
+
+  const mediaType = dataUrlMatch[1] ?? "";
+  const payload = dataUrlMatch[2] ?? "";
+  const mediaTypeParts = mediaType
+    .split(";")
+    .map((segment) => segment.trim().toLowerCase())
+    .filter(Boolean);
+
+  const mimeType = mediaTypeParts[0] ?? "";
+  if (mimeType && mimeType !== "application/json") {
+    return undefined;
+  }
+
+  const isBase64 = mediaTypeParts.includes("base64");
+
+  try {
+    const decoded = isBase64
+      ? Buffer.from(payload, "base64").toString("utf8")
+      : decodeURIComponent(payload);
+    return JSON.parse(decoded);
+  } catch {
+    return undefined;
+  }
+}
+
+function readSourceMapUrlFromBundle(params: {
+  cwd: string;
+  bundlePath: string | undefined;
+}): string | undefined {
   if (!params.bundlePath?.trim()) {
     return undefined;
   }
@@ -410,22 +482,7 @@ function discoverSourceMapPathFromBundle(params: {
   const sourceMapUrlMatch = bundleText.match(
     /\/\/\#\s*sourceMappingURL\s*=\s*(\S+)\s*$/m,
   );
-  const sourceMapUrl = sourceMapUrlMatch?.[1]?.trim();
-  if (!sourceMapUrl) {
-    return undefined;
-  }
-
-  if (sourceMapUrl.startsWith("data:")) {
-    return undefined;
-  }
-
-  const bundleDir = path.dirname(params.bundlePath);
-  const discoveredPath = path.isAbsolute(sourceMapUrl)
-    ? path.normalize(sourceMapUrl)
-    : path.normalize(path.join(bundleDir, sourceMapUrl));
-
-  const normalized = discoveredPath.replaceAll("\\", "/");
-  return normalized.startsWith("./") ? normalized.slice(2) : normalized;
+  return sourceMapUrlMatch?.[1]?.trim();
 }
 
 function normalizeSourceMapSourcePath(params: {

--- a/packages/pipeline/test/pipeline.e2e.test.ts
+++ b/packages/pipeline/test/pipeline.e2e.test.ts
@@ -365,6 +365,94 @@ test("M1 regression: JS sourcemap path discovered from bundle sourceMappingURL s
   assertGoBuildSuccessIfToolchainAvailable(goOutDir);
 });
 
+test("M1 regression: inline data URL sourcemap with charset metadata keeps typed IR provenance and Go diagnostic mapping deterministic", () => {
+  const cwd = fs.mkdtempSync(
+    path.join(os.tmpdir(), "tsgodown-pipeline-inline-map-charset-e2e-"),
+  );
+  tempDirs.push(cwd);
+
+  fs.mkdirSync(path.join(cwd, "src", "routes"), { recursive: true });
+  fs.mkdirSync(path.join(cwd, "dist"), { recursive: true });
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "index.d.ts"),
+    [
+      "export declare const health: () => { ok: boolean };",
+      "export declare const listUsers: () => Array<{ id: string }>;",
+      "",
+    ].join("\n"),
+  );
+
+  const inlineMapPayload = JSON.stringify({
+    version: 3,
+    file: "index.mjs",
+    sourceRoot: new URL(`file://${path.join(cwd, "src")}/`).toString(),
+    sources: ["routes/health.ts", "routes/users.ts"],
+    names: [],
+    mappings: "",
+  });
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "index.mjs"),
+    [
+      "const health = () => ({ ok: true });",
+      "const listUsers = () => [{ id: 'u1' }];",
+      "export { health, listUsers };",
+      `//# sourceMappingURL=data:application/json;charset=utf-8;base64,${Buffer.from(inlineMapPayload, "utf8").toString("base64")}`,
+      "",
+    ].join("\n"),
+  );
+
+  const buildResult: RunBuildResult = {
+    mode: "rust-engine-adapter",
+    manifestPath: "artifacts/manifests/manifest.json",
+    manifestIndexPath: "artifacts/manifests/index.json",
+    manifest: {
+      buildId: "2233445566778899",
+      entries: ["src/index.ts"],
+      bundles: [
+        {
+          file: "dist/index.mjs",
+          format: "esm",
+          exports: ["health", "listUsers"],
+        },
+      ],
+      types: ["dist/index.d.ts"],
+    },
+    diagnostics: [],
+  };
+
+  const ir = buildProgramIrFromArtifacts(buildResult, "src/index.ts", { cwd });
+  assert.deepEqual(
+    ir.modules.map((module) => module.sourcePath),
+    ["src/routes/health.ts", "src/routes/users.ts"],
+  );
+
+  const goOutDir = path.join(cwd, "dist-go");
+  emitGoProject(
+    {
+      ...ir,
+      diagnostics: [
+        {
+          level: "warn",
+          code: "PIPELINE_SOURCEMAP_PROVENANCE",
+          message: "typed IR provenance emitted from inline data URL sourcemap",
+          source: {
+            file: ir.modules[0]?.sourcePath ?? "src/index.ts",
+            line: 1,
+            column: 1,
+          },
+        },
+      ],
+    },
+    goOutDir,
+  );
+
+  const goMain = fs.readFileSync(path.join(goOutDir, "main.go"), "utf8");
+  assert.match(goMain, /\/\/\s+at src\/routes\/health\.ts:1:1/);
+  assertGoBuildSuccessIfToolchainAvailable(goOutDir);
+});
+
 test("M1 regression: indexed sourcemap inherited file:// sourceRoot keeps typed IR provenance deterministic and survives Go diagnostic emission", () => {
   const cwd = fs.mkdtempSync(
     path.join(os.tmpdir(), "tsgodown-pipeline-e2e-indexed-inherit-"),


### PR DESCRIPTION
## Summary
- add TDD regression for inline sourcemap data URLs with charset metadata (application/json;charset=utf-8;base64,...)
- ensure JS + external .d.ts + sourcemap provenance still maps to typed IR modules deterministically
- verify emitter-go diagnostic source mapping remains stable on this artifact path and Go compile smoke stays green

## Validation
- pnpm install --frozen-lockfile
- pnpm run lint
- pnpm run format:check
- pnpm run build
- pnpm run examples:install-first:check
- pnpm run test
- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace --all-targets
- pnpm run gate:differential
- pnpm run gate:compliance
- pnpm run test:guard:core-path
- pnpm run gate:m1
