### PR TITLE
fix(pipeline): fallback to inline sourcemap when declared map is missing

### DIFF
--- a/packages/pipeline/src/internal/artifact-to-ir.ts
+++ b/packages/pipeline/src/internal/artifact-to-ir.ts
@@ -260,6 +260,18 @@ function collectSourceMapEntriesFromArtifact(params: {
       if (parsedMap !== undefined) {
         resolvedMapPath = params.artifactPath;
       } else {
+        if (hasInlineSourceMapDataUrl(params)) {
+          params.diagnostics.push({
+            level: "warn",
+            code: "PIPELINE_INVALID_SOURCEMAP_MAPPING",
+            message: `inline sourcemap data URL is malformed or invalid JSON: ${params.artifactPath}`,
+            source: {
+              file: params.artifactPath,
+              viaSourceMap: true,
+              ...DETERMINISTIC_SOURCE_LOCATION,
+            },
+          });
+        }
         params.diagnostics.push({
           level: "warn",
           code: "PIPELINE_INVALID_SOURCEMAP_MAPPING",
@@ -536,6 +548,14 @@ function readInlineSourceMapFromArtifact(params: {
   } catch {
     return undefined;
   }
+}
+
+function hasInlineSourceMapDataUrl(params: {
+  cwd: string;
+  artifactPath: string | undefined;
+}): boolean {
+  const sourceMapUrl = readSourceMapUrlFromArtifact(params);
+  return sourceMapUrl?.startsWith("data:") ?? false;
 }
 
 function readSourceMapUrlFromArtifact(params: {

--- a/packages/pipeline/test/pipeline.e2e.test.ts
+++ b/packages/pipeline/test/pipeline.e2e.test.ts
@@ -599,6 +599,98 @@ test("M1 regression: declared external JS map missing falls back to inline data 
   assertGoBuildSuccessIfToolchainAvailable(goOutDir);
 });
 
+test("M1 regression: invalid declared JS map + malformed inline data URL keeps deterministic warnings and stable d.ts provenance ordering", () => {
+  const cwd = fs.mkdtempSync(
+    path.join(os.tmpdir(), "tsgodown-pipeline-inline-map-malformed-e2e-"),
+  );
+  tempDirs.push(cwd);
+
+  fs.mkdirSync(path.join(cwd, "dist", "maps"), { recursive: true });
+  fs.mkdirSync(path.join(cwd, "src", "contracts"), { recursive: true });
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "index.d.ts"),
+    [
+      "export declare const health: () => { ok: boolean };",
+      "//# sourceMappingURL=maps/index.d.ts.map",
+      "",
+    ].join("\n"),
+  );
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "maps", "index.d.ts.map"),
+    JSON.stringify({
+      version: 3,
+      file: "../index.d.ts",
+      sourceRoot: new URL(`file://${path.join(cwd, "src")}/`).toString(),
+      sources: ["contracts/zeta.ts", "contracts/alpha.ts"],
+      names: [],
+      mappings: "",
+    }),
+  );
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "index.mjs"),
+    [
+      "const health = () => ({ ok: true });",
+      "export { health };",
+      "//# sourceMappingURL=data:application/json;base64,this-is-not-base64-json",
+      "",
+    ].join("\n"),
+  );
+
+  const buildResult: RunBuildResult = {
+    mode: "rust-engine-adapter",
+    manifestPath: "artifacts/manifests/manifest.json",
+    manifestIndexPath: "artifacts/manifests/index.json",
+    manifest: {
+      buildId: "1029384756019283",
+      entries: ["src/index.ts"],
+      bundles: [
+        {
+          file: "dist/index.mjs",
+          map: "dist/maps/missing-index.mjs.map",
+          format: "esm",
+          exports: ["health"],
+        },
+      ],
+      types: ["dist/index.d.ts"],
+    },
+    diagnostics: [],
+  };
+
+  const ir = buildProgramIrFromArtifacts(buildResult, "src/index.ts", { cwd });
+  assert.deepEqual(
+    ir.modules.map((module) => module.sourcePath),
+    ["src/contracts/alpha.ts", "src/contracts/zeta.ts"],
+  );
+  assert.deepEqual(
+    ir.diagnostics.map((diagnostic) => ({
+      code: diagnostic.code,
+      message: diagnostic.message,
+      file: diagnostic.source?.file,
+    })),
+    [
+      {
+        code: "PIPELINE_INVALID_SOURCEMAP_MAPPING",
+        message:
+          "inline sourcemap data URL is malformed or invalid JSON: dist/index.mjs",
+        file: "dist/index.mjs",
+      },
+      {
+        code: "PIPELINE_INVALID_SOURCEMAP_MAPPING",
+        message:
+          "sourcemap metadata is missing or invalid JSON: dist/maps/missing-index.mjs.map",
+        file: "dist/maps/missing-index.mjs.map",
+      },
+    ],
+  );
+
+  const goOutDir = path.join(cwd, "dist-go");
+  emitGoProject(ir, goOutDir);
+  assertGoBuildSuccessIfToolchainAvailable(goOutDir);
+});
+
 test("M1 regression: indexed sourcemap inherited file:// sourceRoot keeps typed IR provenance deterministic and survives Go diagnostic emission", () => {
   const cwd = fs.mkdtempSync(
     path.join(os.tmpdir(), "tsgodown-pipeline-e2e-indexed-inherit-"),


### PR DESCRIPTION
## Summary\n- add M1 e2e regression for JS+d.ts typed-IR provenance when bundle declares missing external map but embeds inline data URL sourcemap\n- update artifact-to-ir sourcemap loading to fallback to inline map parsing if declared map file is unreadable\n- preserve deterministic module ordering and Go compile smoke path\n\n## Validation\n- pnpm install --frozen-lockfile\n- pnpm run lint\n- pnpm run format:check\n- pnpm run build\n- pnpm run examples:install-first:check\n- pnpm run test\n- cargo fmt --all --check\n- cargo clippy --workspace --all-targets -- -D warnings\n- cargo test --workspace --all-targets\n- pnpm run gate:differential\n- pnpm run gate:compliance\n- pnpm run test:guard:core-path\n- pnpm run gate:m1