### PR TITLE
fix: resolve d.ts sourcemap URLs with query/hash in artifact->IR path

### DIFF
--- a/packages/pipeline/src/internal/artifact-to-ir.ts
+++ b/packages/pipeline/src/internal/artifact-to-ir.ts
@@ -520,10 +520,15 @@ function discoverSourceMapPathFromArtifact(params: {
     return undefined;
   }
 
+  const sanitizedSourceMapPath = sourceMapUrl.replace(/[?#].*$/, "").trim();
+  if (!sanitizedSourceMapPath) {
+    return undefined;
+  }
+
   const artifactDir = path.dirname(artifactPath);
-  const discoveredPath = path.isAbsolute(sourceMapUrl)
-    ? path.normalize(sourceMapUrl)
-    : path.normalize(path.join(artifactDir, sourceMapUrl));
+  const discoveredPath = path.isAbsolute(sanitizedSourceMapPath)
+    ? path.normalize(sanitizedSourceMapPath)
+    : path.normalize(path.join(artifactDir, sanitizedSourceMapPath));
 
   const normalized = discoveredPath.replaceAll("\\", "/");
   return normalized.startsWith("./") ? normalized.slice(2) : normalized;

--- a/packages/pipeline/test/pipeline.e2e.test.ts
+++ b/packages/pipeline/test/pipeline.e2e.test.ts
@@ -1474,3 +1474,88 @@ test("M1 regression: multiple d.ts artifacts union typed exports while JS+d.ts s
   emitGoProject(ir, goOutDir);
   assertGoBuildSuccessIfToolchainAvailable(goOutDir);
 });
+
+test("M1 regression: d.ts sourceMappingURL query+hash still resolves map for JS+d.ts typed IR union and Go compile smoke", () => {
+  const cwd = fs.mkdtempSync(
+    path.join(os.tmpdir(), "tsgodown-pipeline-dts-map-query-hash-e2e-"),
+  );
+  tempDirs.push(cwd);
+
+  fs.mkdirSync(path.join(cwd, "dist", "maps"), { recursive: true });
+  fs.mkdirSync(path.join(cwd, "src", "routes"), { recursive: true });
+  fs.mkdirSync(path.join(cwd, "src", "contracts"), { recursive: true });
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "index.mjs"),
+    [
+      "const health = () => ({ ok: true });",
+      "export { health };",
+      "//# sourceMappingURL=maps/index.mjs.map",
+      "",
+    ].join("\n"),
+  );
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "maps", "index.mjs.map"),
+    JSON.stringify({
+      version: 3,
+      file: "../index.mjs",
+      sourceRoot: new URL(`file://${path.join(cwd, "src")}/`).toString(),
+      sources: ["routes/health.ts"],
+      names: [],
+      mappings: "",
+    }),
+  );
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "index.d.ts"),
+    [
+      "export declare const health: () => { ok: boolean };",
+      "export declare type User = { id: string };",
+      "//# sourceMappingURL=maps/index.d.ts.map?ts=20260219#types",
+      "",
+    ].join("\n"),
+  );
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "maps", "index.d.ts.map"),
+    JSON.stringify({
+      version: 3,
+      file: "../index.d.ts",
+      sourceRoot: new URL(`file://${path.join(cwd, "src")}/`).toString(),
+      sources: ["contracts/user.ts"],
+      names: [],
+      mappings: "",
+    }),
+  );
+
+  const buildResult: RunBuildResult = {
+    mode: "rust-engine-adapter",
+    manifestPath: "artifacts/manifests/manifest.json",
+    manifestIndexPath: "artifacts/manifests/index.json",
+    manifest: {
+      buildId: "1122334455667788",
+      entries: ["src/index.ts"],
+      bundles: [
+        {
+          file: "dist/index.mjs",
+          map: "dist/maps/index.mjs.map",
+          format: "esm",
+          exports: ["health"],
+        },
+      ],
+      types: ["dist/index.d.ts"],
+    },
+    diagnostics: [],
+  };
+
+  const ir = buildProgramIrFromArtifacts(buildResult, "src/index.ts", { cwd });
+  assert.deepEqual(
+    ir.modules.map((module) => module.sourcePath),
+    ["src/contracts/user.ts", "src/routes/health.ts"],
+  );
+
+  const goOutDir = path.join(cwd, "dist-go");
+  emitGoProject(ir, goOutDir);
+  assertGoBuildSuccessIfToolchainAvailable(goOutDir);
+});


### PR DESCRIPTION
## Summary
- add M1 pipeline e2e regression coverage for real JS + .d.ts + sourcemap where the .d.ts sourceMappingURL includes query/hash
- strip query/hash fragments when discovering non-data sourcemap paths from artifacts
- preserve typed IR provenance union so Go compile smoke path remains green

## Validation
- pnpm install --frozen-lockfile
- pnpm run lint
- pnpm run format:check
- pnpm run build
- pnpm run examples:install-first:check
- pnpm run test
- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace --all-targets
- pnpm run gate:differential
- pnpm run gate:compliance
- pnpm run test:guard:core-path
- pnpm run gate:m1