### PR TITLE
fix/cycle16 multi bundle provenance union

### DIFF
--- a/packages/pipeline/src/internal/artifact-to-ir.ts
+++ b/packages/pipeline/src/internal/artifact-to-ir.ts
@@ -91,8 +91,10 @@ function collectTypedExports(
   cwd: string,
   diagnostics: DiagnosticIR[],
 ): string[] {
-  const typePath = buildResult.manifest.types?.[0];
-  if (!typePath?.trim()) {
+  const typePaths = (buildResult.manifest.types ?? []).filter((typePath) =>
+    typePath?.trim(),
+  );
+  if (typePaths.length === 0) {
     diagnostics.push({
       level: "warn",
       code: "PIPELINE_MISSING_TYPES_METADATA",
@@ -105,42 +107,45 @@ function collectTypedExports(
     return [];
   }
 
-  const absoluteTypePath = path.join(cwd, typePath);
-  let sourceText = "";
-  try {
-    sourceText = fs.readFileSync(absoluteTypePath, "utf8");
-  } catch {
-    diagnostics.push({
-      level: "warn",
-      code: "PIPELINE_MISSING_TYPES_METADATA",
-      message: `declared types file is unreadable: ${typePath}`,
-      source: {
-        file: typePath,
-      },
-    });
-    return [];
-  }
-
   const exportedNames = new Set<string>();
-  for (const line of sourceText.split(/\r?\n/)) {
-    const trimmed = line.trim();
-    const match = trimmed.match(
-      /^export\s+(?:declare\s+)?(?:async\s+)?(?:function|const|let|var|class|type|interface|enum)\s+([A-Za-z_$][A-Za-z0-9_$]*)/,
-    );
-    if (match?.[1]) {
-      exportedNames.add(match[1]);
+
+  for (const typePath of typePaths) {
+    const absoluteTypePath = path.join(cwd, typePath);
+    let sourceText = "";
+    try {
+      sourceText = fs.readFileSync(absoluteTypePath, "utf8");
+    } catch {
+      diagnostics.push({
+        level: "warn",
+        code: "PIPELINE_MISSING_TYPES_METADATA",
+        message: `declared types file is unreadable: ${typePath}`,
+        source: {
+          file: typePath,
+        },
+      });
+      continue;
     }
 
-    const braceExportMatch = trimmed.match(/^export\s*\{([^}]+)\}/);
-    if (braceExportMatch?.[1]) {
-      for (const segment of braceExportMatch[1].split(",")) {
-        const symbol = segment
-          .trim()
-          .match(
-            /^(?:type\s+)?([A-Za-z_$][A-Za-z0-9_$]*)(?:\s+as\s+([A-Za-z_$][A-Za-z0-9_$]*))?$/,
-          );
-        if (symbol) {
-          exportedNames.add(symbol[2] ?? symbol[1]);
+    for (const line of sourceText.split(/\r?\n/)) {
+      const trimmed = line.trim();
+      const match = trimmed.match(
+        /^export\s+(?:declare\s+)?(?:async\s+)?(?:function|const|let|var|class|type|interface|enum)\s+([A-Za-z_$][A-Za-z0-9_$]*)/,
+      );
+      if (match?.[1]) {
+        exportedNames.add(match[1]);
+      }
+
+      const braceExportMatch = trimmed.match(/^export\s*\{([^}]+)\}/);
+      if (braceExportMatch?.[1]) {
+        for (const segment of braceExportMatch[1].split(",")) {
+          const symbol = segment
+            .trim()
+            .match(
+              /^(?:type\s+)?([A-Za-z_$][A-Za-z0-9_$]*)(?:\s+as\s+([A-Za-z_$][A-Za-z0-9_$]*))?$/,
+            );
+          if (symbol) {
+            exportedNames.add(symbol[2] ?? symbol[1]);
+          }
         }
       }
     }
@@ -152,7 +157,7 @@ function collectTypedExports(
       code: "PIPELINE_INVALID_TYPES_METADATA",
       message: "no named exports could be parsed from .d.ts metadata",
       source: {
-        file: typePath,
+        file: typePaths[0] ?? "manifest.types",
       },
     });
   }

--- a/packages/pipeline/test/pipeline.e2e.test.ts
+++ b/packages/pipeline/test/pipeline.e2e.test.ts
@@ -1359,3 +1359,106 @@ test("M1 regression: missing declared map file falls back to inline sourcemap fo
 
   assertGoBuildSuccessIfToolchainAvailable(goOutDir);
 });
+
+test("M1 regression: multiple d.ts artifacts union typed exports while JS+d.ts sourcemaps still drive provenance and Go compile path", () => {
+  const cwd = fs.mkdtempSync(
+    path.join(os.tmpdir(), "tsgodown-pipeline-e2e-multi-types-union-"),
+  );
+  tempDirs.push(cwd);
+
+  fs.mkdirSync(path.join(cwd, "dist", "maps"), { recursive: true });
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "index.mjs"),
+    [
+      "export const health = () => ({ ok: true });",
+      "//# sourceMappingURL=maps/index.mjs.map",
+      "",
+    ].join("\n"),
+  );
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "maps", "index.mjs.map"),
+    JSON.stringify({
+      version: 3,
+      file: "../index.mjs",
+      sourceRoot: new URL(`file://${path.join(cwd, "src")}/`).toString(),
+      sources: ["routes/health.ts"],
+      names: [],
+      mappings: "",
+    }),
+  );
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "index.d.ts"),
+    [
+      "export declare const health: () => { ok: boolean };",
+      "//# sourceMappingURL=maps/index.d.ts.map",
+      "",
+    ].join("\n"),
+  );
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "users.d.ts"),
+    [
+      "export declare const listUsers: () => Array<{ id: string }>;",
+      "//# sourceMappingURL=maps/users.d.ts.map",
+      "",
+    ].join("\n"),
+  );
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "maps", "index.d.ts.map"),
+    JSON.stringify({
+      version: 3,
+      file: "../index.d.ts",
+      sourceRoot: new URL(`file://${path.join(cwd, "src")}/`).toString(),
+      sources: ["types/http.ts"],
+      names: [],
+      mappings: "",
+    }),
+  );
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "maps", "users.d.ts.map"),
+    JSON.stringify({
+      version: 3,
+      file: "../users.d.ts",
+      sourceRoot: new URL(`file://${path.join(cwd, "src")}/`).toString(),
+      sources: ["types/users.ts"],
+      names: [],
+      mappings: "",
+    }),
+  );
+
+  const buildResult: RunBuildResult = {
+    mode: "rust-engine-adapter",
+    manifestPath: "artifacts/manifests/manifest.json",
+    manifestIndexPath: "artifacts/manifests/index.json",
+    manifest: {
+      buildId: "8899aabbccddeeff",
+      entries: ["src/index.ts"],
+      bundles: [
+        {
+          file: "dist/index.mjs",
+          map: "dist/maps/index.mjs.map",
+          format: "esm",
+          exports: ["health"],
+        },
+      ],
+      types: ["dist/index.d.ts", "dist/users.d.ts"],
+    },
+    diagnostics: [],
+  };
+
+  const ir = buildProgramIrFromArtifacts(buildResult, "src/index.ts", { cwd });
+  assert.deepEqual(
+    ir.modules.map((module) => module.sourcePath),
+    ["src/routes/health.ts", "src/types/http.ts", "src/types/users.ts"],
+  );
+  assert.deepEqual(ir.modules[0]?.exports, ["health", "listUsers"]);
+
+  const goOutDir = path.join(cwd, "dist-go");
+  emitGoProject(ir, goOutDir);
+  assertGoBuildSuccessIfToolchainAvailable(goOutDir);
+});


### PR DESCRIPTION
- **test(pipeline): cover multi-bundle sourcemap provenance union to typed IR**
- **pipeline: union sourcemap provenance across all manifest bundles**
- **test(pipeline): cover inline+external+indexed map provenance union**
- **test(pipeline): add mixed map-mode typed provenance regression**
- **pipeline: union exports across multiple declared d.ts artifacts**
