### PR TITLE
fix(pipeline): preserve d.ts declaration linkage with inline JS sourcemaps

### DIFF
--- a/packages/pipeline/src/internal/artifact-to-ir.ts
+++ b/packages/pipeline/src/internal/artifact-to-ir.ts
@@ -36,14 +36,24 @@ export function buildProgramIrFromArtifacts(
     sourceMappedEntries.length > 0 ? sourceMappedEntries : manifestEntries;
 
   const typedExports = collectTypedExports(buildResult, cwd, diagnostics);
+  const declarationLinkedSources = collectDeclarationLinkedSourceEntries(
+    buildResult,
+    cwd,
+    diagnostics,
+  );
 
   const modules = moduleEntries
-    .map((manifestEntry, index) => ({
-      id: `module_${index}`,
-      sourcePath: manifestEntry,
-      exports: typedExports,
-      imports: [],
-    }))
+    .map((manifestEntry, index) => {
+      const shouldAttachTypedExports =
+        declarationLinkedSources.size === 0 ||
+        declarationLinkedSources.has(manifestEntry);
+      return {
+        id: `module_${index}`,
+        sourcePath: manifestEntry,
+        exports: shouldAttachTypedExports ? typedExports : [],
+        imports: [],
+      };
+    })
     .sort((a, b) =>
       a.sourcePath === b.sourcePath
         ? a.id.localeCompare(b.id)
@@ -165,6 +175,31 @@ function collectTypedExports(
   }
 
   return [...exportedNames].sort((a, b) => a.localeCompare(b));
+}
+
+function collectDeclarationLinkedSourceEntries(
+  buildResult: RunBuildResult,
+  cwd: string,
+  diagnostics: DiagnosticIR[],
+): Set<string> {
+  const linkedSources = new Set<string>();
+
+  for (const typePath of buildResult.manifest.types ?? []) {
+    if (!typePath?.trim()) {
+      continue;
+    }
+
+    const sourceMapResult = collectSourceMapEntriesFromArtifact({
+      cwd,
+      artifactPath: typePath,
+      diagnostics,
+    });
+    for (const sourceEntry of sourceMapResult.entries) {
+      linkedSources.add(sourceEntry);
+    }
+  }
+
+  return linkedSources;
 }
 
 function collectSourceEntriesFromSourceMap(

--- a/packages/pipeline/test/artifact-to-ir.test.ts
+++ b/packages/pipeline/test/artifact-to-ir.test.ts
@@ -785,3 +785,81 @@ test("buildProgramIrFromArtifacts keeps indexed sourcemap source provenance dete
   );
   assert.deepEqual(ir.diagnostics, []);
 });
+
+test("buildProgramIrFromArtifacts preserves declaration linkage when JS sourcemap is inline and d.ts sourcemap uses sourceRoot with relative sources", () => {
+  const cwd = fs.mkdtempSync(
+    path.join(os.tmpdir(), "tsgodown-artifact-ir-inline-js-dts-linkage-"),
+  );
+  fs.mkdirSync(path.join(cwd, "dist", "maps"), { recursive: true });
+
+  const inlineJsMapPayload = JSON.stringify({
+    version: 3,
+    file: "index.mjs",
+    sourceRoot: "../src",
+    sources: ["routes/health.ts"],
+    names: [],
+    mappings: "",
+  });
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "index.mjs"),
+    [
+      "const health = () => ({ ok: true });",
+      "export { health };",
+      `//# sourceMappingURL=data:application/json;charset=utf-8;base64,${Buffer.from(inlineJsMapPayload, "utf8").toString("base64")}`,
+      "",
+    ].join("\n"),
+  );
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "index.d.ts"),
+    [
+      "declare const health: () => { ok: boolean };",
+      "declare interface HealthStatus { ok: boolean; }",
+      "export { health as healthHandler };",
+      "export type { HealthStatus as PublicHealthStatus };",
+      "//# sourceMappingURL=maps/index.d.ts.map",
+      "",
+    ].join("\n"),
+  );
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "maps", "index.d.ts.map"),
+    JSON.stringify({
+      version: 3,
+      file: "../index.d.ts",
+      sourceRoot: "../../src/nested/..",
+      sources: ["contracts/health.ts"],
+      names: [],
+      mappings: "",
+    }),
+  );
+
+  const ir = buildProgramIrFromArtifacts(
+    {
+      mode: "rust-engine-adapter",
+      manifestPath: "artifacts/manifests/manifest.json",
+      manifestIndexPath: "artifacts/manifests/index.json",
+      manifest: {
+        buildId: "aabbccddeeff0011",
+        entries: ["src/index.ts"],
+        bundles: [
+          { file: "dist/index.mjs", format: "esm", exports: ["health"] },
+        ],
+        types: ["dist/index.d.ts"],
+      },
+      diagnostics: [],
+    },
+    "src/index.ts",
+    { cwd },
+  );
+
+  assert.deepEqual(
+    ir.modules.map((module) => module.sourcePath),
+    ["src/contracts/health.ts", "src/routes/health.ts"],
+  );
+  assert.deepEqual(ir.modules[0]?.exports, [
+    "healthHandler",
+    "PublicHealthStatus",
+  ]);
+});

--- a/packages/pipeline/test/pipeline.e2e.test.ts
+++ b/packages/pipeline/test/pipeline.e2e.test.ts
@@ -1106,11 +1106,11 @@ test("M1 regression: inline+external+indexed sourcemaps with d.ts typing union t
       "src/types/http.ts",
     ],
   );
-  assert.deepEqual(ir.modules[0]?.exports, [
-    "adminPing",
-    "health",
-    "listUsers",
-  ]);
+  assert.deepEqual(
+    ir.modules.find((module) => module.sourcePath === "src/types/http.ts")
+      ?.exports,
+    ["adminPing", "health", "listUsers"],
+  );
   assert.deepEqual(
     ir.diagnostics.map((d) => ({
       code: d.code,
@@ -1646,7 +1646,11 @@ test("M1 regression: multiple d.ts artifacts union typed exports while JS+d.ts s
     ir.modules.map((module) => module.sourcePath),
     ["src/routes/health.ts", "src/types/http.ts", "src/types/users.ts"],
   );
-  assert.deepEqual(ir.modules[0]?.exports, ["health", "listUsers"]);
+  assert.deepEqual(
+    ir.modules.find((module) => module.sourcePath === "src/types/http.ts")
+      ?.exports,
+    ["health", "listUsers"],
+  );
 
   const goOutDir = path.join(cwd, "dist-go");
   emitGoProject(ir, goOutDir);
@@ -1728,7 +1732,11 @@ test("M1 regression: file:// sourceMappingURL on mjs+d.ts map comments resolves 
     ir.modules.map((module) => module.sourcePath),
     ["src/routes/health.ts", "src/types/health.ts"],
   );
-  assert.deepEqual(ir.modules[0]?.exports, ["health", "HealthPayload"]);
+  assert.deepEqual(
+    ir.modules.find((module) => module.sourcePath === "src/types/health.ts")
+      ?.exports,
+    ["health", "HealthPayload"],
+  );
   assert.deepEqual(ir.diagnostics, []);
 
   const goOutDir = path.join(cwd, "dist-go");


### PR DESCRIPTION
## Summary
- add a TDD regression for JS inline sourcemap + .d.ts.map (`sourceRoot` + relative `sources`) ensuring typed IR keeps declaration linkage
- attach parsed typed exports only to declaration-linked source modules when declaration sourcemap provenance is available
- update affected e2e expectations to assert exports on declaration-linked modules instead of relying on first-module position

## Validation
- pnpm lint
- pnpm format:check
- pnpm build
- pnpm examples:install-first:check
- pnpm test
- cargo test --workspace --all-targets
- pnpm gate:differential
- pnpm gate:compliance
