### PR TITLE
fix(pipeline): normalize Windows-style sourcemap paths in typed IR provenance

### DIFF
--- a/packages/pipeline/src/internal/artifact-to-ir.ts
+++ b/packages/pipeline/src/internal/artifact-to-ir.ts
@@ -727,15 +727,19 @@ function toFileSystemPath(value: unknown): string {
   const trimmed = value.trim();
   if (trimmed.startsWith("file://")) {
     try {
-      return fileURLToPath(trimmed);
+      return normalizePathSeparators(fileURLToPath(trimmed));
     } catch {
-      return trimmed;
+      return normalizePathSeparators(trimmed);
     }
   }
 
   try {
-    return decodeURIComponent(trimmed);
+    return normalizePathSeparators(decodeURIComponent(trimmed));
   } catch {
-    return trimmed;
+    return normalizePathSeparators(trimmed);
   }
+}
+
+function normalizePathSeparators(value: string): string {
+  return value.replaceAll("\\", "/");
 }

--- a/packages/pipeline/test/pipeline.e2e.test.ts
+++ b/packages/pipeline/test/pipeline.e2e.test.ts
@@ -2105,3 +2105,91 @@ test("M1 regression: JS+d.ts indexed sourcemap sections union deterministic type
   emitGoProject(ir, goOutDir);
   assertGoBuildSuccessIfToolchainAvailable(goOutDir);
 });
+
+test("M1 regression: Windows drive-letter/backslash sourcemap sourceRoot+sources normalize into deterministic typed IR provenance and Go compile smoke", () => {
+  const cwd = fs.mkdtempSync(
+    path.join(os.tmpdir(), "tsgodown-pipeline-windows-path-style-e2e-"),
+  );
+  tempDirs.push(cwd);
+
+  fs.mkdirSync(path.join(cwd, "dist", "maps"), { recursive: true });
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "index.mjs"),
+    [
+      "const health = () => ({ ok: true });",
+      "export { health };",
+      "//# sourceMappingURL=maps/index.mjs.map",
+      "",
+    ].join("\n"),
+  );
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "index.d.ts"),
+    [
+      "export declare const health: () => { ok: boolean };",
+      "export declare interface HealthResponse { ok: boolean }",
+      "//# sourceMappingURL=maps/index.d.ts.map",
+      "",
+    ].join("\n"),
+  );
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "maps", "index.mjs.map"),
+    JSON.stringify({
+      version: 3,
+      file: "..\\index.mjs",
+      sourceRoot: "..\\..\\src",
+      sources: ["routes\\health.ts"],
+      names: [],
+      mappings: "",
+    }),
+  );
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "maps", "index.d.ts.map"),
+    JSON.stringify({
+      version: 3,
+      file: "C:\\repo\\dist\\index.d.ts",
+      sourceRoot: "..\\..\\src\\nested\\..",
+      sources: ["types\\health-response.ts"],
+      names: [],
+      mappings: "",
+    }),
+  );
+
+  const buildResult: RunBuildResult = {
+    mode: "rust-engine-adapter",
+    manifestPath: "artifacts/manifests/manifest.json",
+    manifestIndexPath: "artifacts/manifests/index.json",
+    manifest: {
+      buildId: "19aa55cc77ee22ff",
+      entries: ["src/index.ts"],
+      bundles: [
+        {
+          file: "dist/index.mjs",
+          map: "dist/maps/index.mjs.map",
+          format: "esm",
+          exports: ["health"],
+        },
+      ],
+      types: ["dist/index.d.ts"],
+    },
+    diagnostics: [],
+  };
+
+  const ir = buildProgramIrFromArtifacts(buildResult, "src/index.ts", { cwd });
+  assert.deepEqual(
+    ir.modules.map((module) => module.sourcePath),
+    ["src/routes/health.ts", "src/types/health-response.ts"],
+  );
+  const typedModule = ir.modules.find(
+    (module) => module.sourcePath === "src/types/health-response.ts",
+  );
+  assert.deepEqual(typedModule?.exports, ["health", "HealthResponse"]);
+  assert.deepEqual(ir.diagnostics, []);
+
+  const goOutDir = path.join(cwd, "dist-go");
+  emitGoProject(ir, goOutDir);
+  assertGoBuildSuccessIfToolchainAvailable(goOutDir);
+});


### PR DESCRIPTION
## Summary
- add M1 pipeline e2e regression covering JS + d.ts sourcemaps that use Windows-style backslash paths and drive-letter-shaped metadata
- normalize decoded sourcemap paths to forward slashes before resolution so Windows-style relative segments map to deterministic repo-relative provenance
- verify typed IR provenance still compiles through Go smoke path

## Testing
- pnpm lint
- pnpm format:check
- pnpm build
- pnpm examples:install-first:check
- pnpm test
- cargo test --workspace --all-targets
- pnpm gate:differential
- pnpm gate:compliance