### PR TITLE
test(pipeline): cover quoted sourceMappingURL comments for JS+d.ts maps

### DIFF
--- a/packages/pipeline/src/internal/artifact-to-ir.ts
+++ b/packages/pipeline/src/internal/artifact-to-ir.ts
@@ -663,7 +663,25 @@ function readSourceMapUrlFromArtifact(params: {
     ...artifactText.matchAll(/\/\/\#\s*sourceMappingURL\s*=\s*(\S+)\s*$/gm),
   ];
   const sourceMapUrlMatch = sourceMapUrlMatches.at(-1);
-  return sourceMapUrlMatch?.[1]?.trim();
+  return unwrapQuotedValue(sourceMapUrlMatch?.[1]?.trim());
+}
+
+function unwrapQuotedValue(value: string | undefined): string | undefined {
+  if (!value) {
+    return value;
+  }
+
+  const singleQuoted = value.match(/^'([^']+)'$/);
+  if (singleQuoted?.[1]) {
+    return singleQuoted[1];
+  }
+
+  const doubleQuoted = value.match(/^"([^"]+)"$/);
+  if (doubleQuoted?.[1]) {
+    return doubleQuoted[1];
+  }
+
+  return value;
 }
 
 function normalizeSourceMapSourcePath(params: {


### PR DESCRIPTION
## Summary
- add a new TDD regression covering real JS + d.ts artifacts where `sourceMappingURL` values are quoted in trailing comments
- verify sourcemap provenance still resolves into typed IR module source paths and survives Go emission/compile smoke
- normalize parsed `sourceMappingURL` by unwrapping single/double-quoted values before map discovery

## Validation
- pnpm lint
- pnpm format:check
- pnpm build
- pnpm examples:install-first:check
- pnpm test
- cargo test --workspace --all-targets
- pnpm gate:differential
- pnpm gate:compliance
