### PR TITLE
test(pipeline): cover encoded-slash file URL sourcemap sources

### DIFF
--- a/packages/pipeline/src/internal/artifact-to-ir.ts
+++ b/packages/pipeline/src/internal/artifact-to-ir.ts
@@ -726,11 +726,18 @@ function toFileSystemPath(value: unknown): string {
 
   const trimmed = value.trim();
   if (/^file:\/\//i.test(trimmed)) {
+    const normalizedFileUrl = trimmed.replace(/^file:\/\//i, "file://");
     try {
-      const normalizedFileUrl = trimmed.replace(/^file:\/\//i, "file://");
       return normalizePathSeparators(fileURLToPath(normalizedFileUrl));
     } catch {
-      return normalizePathSeparators(trimmed);
+      try {
+        const parsedUrl = new URL(normalizedFileUrl);
+        const decodedPathname = decodeURIComponent(parsedUrl.pathname);
+        const hostPrefix = parsedUrl.host ? `//${parsedUrl.host}` : "";
+        return normalizePathSeparators(`${hostPrefix}${decodedPathname}`);
+      } catch {
+        return normalizePathSeparators(trimmed);
+      }
     }
   }
 

--- a/packages/pipeline/test/pipeline.e2e.test.ts
+++ b/packages/pipeline/test/pipeline.e2e.test.ts
@@ -2376,3 +2376,102 @@ test("M1 regression: Windows drive-letter/backslash sourcemap sourceRoot+sources
   emitGoProject(ir, goOutDir);
   assertGoBuildSuccessIfToolchainAvailable(goOutDir);
 });
+
+test("M1 regression: file URL sourcemap sources with percent-encoded slash stay deterministic across JS+d.ts typed IR and Go compile path", () => {
+  const cwd = fs.mkdtempSync(
+    path.join(os.tmpdir(), "tsgodown-pipeline-e2e-file-url-encoded-slash-"),
+  );
+  tempDirs.push(cwd);
+
+  fs.mkdirSync(path.join(cwd, "dist", "maps"), { recursive: true });
+  fs.mkdirSync(path.join(cwd, "src", "routes"), { recursive: true });
+  fs.mkdirSync(path.join(cwd, "src", "types"), { recursive: true });
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "index.mjs"),
+    [
+      "export const health = () => ({ ok: true });",
+      "//# sourceMappingURL=maps/index.mjs.map",
+      "",
+    ].join("\n"),
+  );
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "index.d.ts"),
+    [
+      "export declare const health: () => { ok: boolean };",
+      "export declare interface HealthContract { ok: boolean }",
+      "//# sourceMappingURL=maps/index.d.ts.map",
+      "",
+    ].join("\n"),
+  );
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "maps", "index.mjs.map"),
+    JSON.stringify({
+      version: 3,
+      file: "../index.mjs",
+      sources: [
+        new URL(`file://${path.join(cwd, "src", "routes", "health.ts")}`)
+          .toString()
+          .replace("/routes/health.ts", "/routes%2Fhealth.ts"),
+      ],
+      names: [],
+      mappings: "",
+    }),
+  );
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "maps", "index.d.ts.map"),
+    JSON.stringify({
+      version: 3,
+      file: "../index.d.ts",
+      sources: [
+        new URL(
+          `file://${path.join(cwd, "src", "types", "health-contract.ts")}`,
+        )
+          .toString()
+          .replace("/types/health-contract.ts", "/types%2Fhealth-contract.ts"),
+      ],
+      names: [],
+      mappings: "",
+    }),
+  );
+
+  const buildResult: RunBuildResult = {
+    mode: "rust-engine-adapter",
+    manifestPath: "artifacts/manifests/manifest.json",
+    manifestIndexPath: "artifacts/manifests/index.json",
+    manifest: {
+      buildId: "3fa9b1d2478c60ef",
+      entries: ["src/index.ts"],
+      bundles: [
+        {
+          file: "dist/index.mjs",
+          map: "dist/maps/index.mjs.map",
+          format: "esm",
+          exports: ["health"],
+        },
+      ],
+      types: ["dist/index.d.ts"],
+    },
+    diagnostics: [],
+  };
+
+  const ir = buildProgramIrFromArtifacts(buildResult, "src/index.ts", { cwd });
+  assert.deepEqual(
+    ir.modules.map((module) => module.sourcePath),
+    ["src/routes/health.ts", "src/types/health-contract.ts"],
+  );
+  assert.deepEqual(
+    ir.modules.find(
+      (module) => module.sourcePath === "src/types/health-contract.ts",
+    )?.exports,
+    ["health", "HealthContract"],
+  );
+  assert.deepEqual(ir.diagnostics, []);
+
+  const goOutDir = path.join(cwd, "dist-go");
+  emitGoProject(ir, goOutDir);
+  assertGoBuildSuccessIfToolchainAvailable(goOutDir);
+});


### PR DESCRIPTION
## Summary
- add a pipeline regression covering real `.mjs + .d.ts + sourcemap` inputs where sourcemap `sources[]` are absolute `file://` URLs containing percent-encoded slashes (`%2F`)
- assert deterministic typed IR provenance and export linkage survive this path-encoding edge case
- make file URL sourcemap path normalization lenient when `fileURLToPath` rejects encoded slashes, so encoded file URLs still normalize to deterministic repo-relative paths

## Validation
- pnpm lint
- pnpm format:check
- pnpm build
- pnpm examples:install-first:check
- pnpm test
- cargo test --workspace --all-targets
- pnpm gate:differential
- pnpm gate:compliance
