### PR TITLE
fix(pipeline): harden Windows drive-letter file URL sourcemap provenance

### DIFF
--- a/packages/pipeline/src/internal/artifact-to-ir.ts
+++ b/packages/pipeline/src/internal/artifact-to-ir.ts
@@ -699,17 +699,17 @@ function normalizeSourceMapSourcePath(params: {
   if (!sourcePath.trim()) {
     return undefined;
   }
-  const rootedPath = path.isAbsolute(sourcePath)
+  const rootedPath = isAbsoluteFileSystemPathLike(sourcePath)
     ? sourcePath
     : sourceRootPath.trim()
       ? path.join(sourceRootPath, sourcePath)
       : sourcePath;
 
-  const resolved = path.isAbsolute(rootedPath)
+  const resolved = isAbsoluteFileSystemPathLike(rootedPath)
     ? path.normalize(rootedPath)
     : path.normalize(path.join(path.dirname(params.mapPath), rootedPath));
 
-  const relativeToCwd = path.isAbsolute(resolved)
+  const relativeToCwd = isAbsoluteFileSystemPathLike(resolved)
     ? path.relative(params.cwd, resolved)
     : resolved;
   const normalized = relativeToCwd.replaceAll("\\", "/");
@@ -768,5 +768,22 @@ function toFileSystemPath(value: unknown): string {
 }
 
 function normalizePathSeparators(value: string): string {
-  return value.replaceAll("\\", "/");
+  const normalized = value.replaceAll("\\", "/");
+  return normalizeWindowsDrivePathToPortableAbsolute(normalized);
+}
+
+function normalizeWindowsDrivePathToPortableAbsolute(value: string): string {
+  const withDrive = value.match(/^\/?[A-Za-z]:(\/.*)$/);
+  if (!withDrive) {
+    return value;
+  }
+  return withDrive[1] ?? value;
+}
+
+function isAbsoluteFileSystemPathLike(value: string): boolean {
+  return (
+    path.isAbsolute(value) ||
+    /^[A-Za-z]:\//.test(value) ||
+    /^\/\/[A-Za-z0-9._-]+\//.test(value)
+  );
 }

--- a/packages/pipeline/test/pipeline.e2e.test.ts
+++ b/packages/pipeline/test/pipeline.e2e.test.ts
@@ -2542,6 +2542,98 @@ test("M1 regression: Windows drive-letter/backslash sourcemap sourceRoot+sources
   assertGoBuildSuccessIfToolchainAvailable(goOutDir);
 });
 
+test("M1 regression: Windows drive-letter file:// sourceRoot mixed with backslash sources keeps deterministic JS+d.ts typed provenance and Go compile smoke", () => {
+  const cwd = fs.mkdtempSync(
+    path.join(os.tmpdir(), "tsgodown-pipeline-windows-drive-file-url-e2e-"),
+  );
+  tempDirs.push(cwd);
+
+  fs.mkdirSync(path.join(cwd, "dist", "maps"), { recursive: true });
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "index.mjs"),
+    [
+      "const health = () => ({ ok: true });",
+      "export { health };",
+      "//# sourceMappingURL=maps/index.mjs.map",
+      "",
+    ].join("\n"),
+  );
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "index.d.ts"),
+    [
+      "export declare const health: () => { ok: boolean };",
+      "export declare interface HealthResponse { ok: boolean }",
+      "//# sourceMappingURL=maps/index.d.ts.map",
+      "",
+    ].join("\n"),
+  );
+
+  const windowsDriveFileRoot = `file:///C:${cwd.replaceAll("\\", "/")}/src/`;
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "maps", "index.mjs.map"),
+    JSON.stringify({
+      version: 3,
+      file: "..\\index.mjs",
+      sourceRoot: windowsDriveFileRoot,
+      sources: ["routes\\health.ts"],
+      names: [],
+      mappings: "",
+    }),
+  );
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "maps", "index.d.ts.map"),
+    JSON.stringify({
+      version: 3,
+      file: "..\\index.d.ts",
+      sourceRoot: windowsDriveFileRoot,
+      sources: [
+        `file:///C:${cwd.replaceAll("\\", "/")}/src/types\\health-response.ts`,
+      ],
+      names: [],
+      mappings: "",
+    }),
+  );
+
+  const buildResult: RunBuildResult = {
+    mode: "rust-engine-adapter",
+    manifestPath: "artifacts/manifests/manifest.json",
+    manifestIndexPath: "artifacts/manifests/index.json",
+    manifest: {
+      buildId: "19aa55ff88ee33aa",
+      entries: ["src/index.ts"],
+      bundles: [
+        {
+          file: "dist/index.mjs",
+          map: "dist/maps/index.mjs.map",
+          format: "esm",
+          exports: ["health"],
+        },
+      ],
+      types: ["dist/index.d.ts"],
+    },
+    diagnostics: [],
+  };
+
+  const ir = buildProgramIrFromArtifacts(buildResult, "src/index.ts", { cwd });
+  assert.deepEqual(
+    ir.modules.map((module) => module.sourcePath),
+    ["src/routes/health.ts", "src/types/health-response.ts"],
+  );
+  const typedModule = ir.modules.find(
+    (module) => module.sourcePath === "src/types/health-response.ts",
+  );
+  assert.deepEqual(typedModule?.exports, ["health", "HealthResponse"]);
+  assert.deepEqual(ir.diagnostics, []);
+
+  const goOutDir = path.join(cwd, "dist-go");
+  emitGoProject(ir, goOutDir);
+  assertGoBuildSuccessIfToolchainAvailable(goOutDir);
+});
+
 test("M1 regression: file URL sourcemap sources with percent-encoded slash stay deterministic across JS+d.ts typed IR and Go compile path", () => {
   const cwd = fs.mkdtempSync(
     path.join(os.tmpdir(), "tsgodown-pipeline-e2e-file-url-encoded-slash-"),


### PR DESCRIPTION
## Summary\n- add a regression e2e covering mixed Windows drive-letter + backslash sourcemap paths with file:// sourceRoot/sources across JS + d.ts artifacts\n- normalize Windows drive-letter path forms from sourcemap metadata into portable absolute paths before resolution/deduplication\n- treat Windows absolute/UNC-style paths as absolute during source mapping so deterministic typed provenance remains stable\n\n## Validation\n- pnpm lint\n- pnpm format:check\n- pnpm build\n- pnpm examples:install-first:check\n- pnpm test\n- cargo test --workspace --all-targets\n- pnpm gate:differential\n- pnpm gate:compliance