### PR TITLE
fix(pipeline): normalize encoded query/hash source variants in mixed inline/external sourcemaps

### DIFF
--- a/packages/pipeline/src/internal/artifact-to-ir.ts
+++ b/packages/pipeline/src/internal/artifact-to-ir.ts
@@ -694,8 +694,10 @@ function normalizeSourceMapSourcePath(params: {
     return undefined;
   }
 
-  const sourceRootPath = toFileSystemPath(stripQueryAndHash(params.sourceRoot));
-  const sourcePath = toFileSystemPath(stripQueryAndHash(params.sourcePath));
+  const sourceRootPath = normalizeDecodedSourceMapPathSegment(
+    params.sourceRoot,
+  );
+  const sourcePath = normalizeDecodedSourceMapPathSegment(params.sourcePath);
   if (!sourcePath.trim()) {
     return undefined;
   }
@@ -724,6 +726,17 @@ function normalizeSourceMapSourcePath(params: {
     return undefined;
   }
   return withoutDot;
+}
+
+function normalizeDecodedSourceMapPathSegment(value: unknown): string {
+  const strippedValue = stripQueryAndHash(value);
+  const normalizedPath = toFileSystemPath(strippedValue);
+
+  if (typeof strippedValue === "string" && /^file:\/\//i.test(strippedValue)) {
+    return normalizedPath;
+  }
+
+  return String(stripQueryAndHash(normalizedPath));
 }
 
 function stripQueryAndHash(value: unknown): unknown {

--- a/packages/pipeline/test/pipeline.e2e.test.ts
+++ b/packages/pipeline/test/pipeline.e2e.test.ts
@@ -2177,6 +2177,98 @@ test("M1 regression: inline JS data URL sourcemap + external d.ts sourcemap keep
   assertGoBuildSuccessIfToolchainAvailable(goOutDir);
 });
 
+test("M1 regression: inline JS data URL sourcemap + external d.ts map dedupe duplicate logical sources when query/hash are raw vs percent-encoded", async () => {
+  const cwd = fs.mkdtempSync(
+    path.join(
+      os.tmpdir(),
+      "tsgodown-pipeline-inline-external-encoded-queryhash-e2e-",
+    ),
+  );
+  tempDirs.push(cwd);
+
+  fs.mkdirSync(path.join(cwd, "dist", "maps"), { recursive: true });
+  fs.mkdirSync(path.join(cwd, "src", "routes"), { recursive: true });
+  fs.mkdirSync(path.join(cwd, "src", "types"), { recursive: true });
+
+  const inlineJsMapPayload = JSON.stringify({
+    version: 3,
+    file: "index.mjs",
+    sourceRoot: "../src",
+    sources: ["routes/health.ts?from=inline#frag"],
+    names: [],
+    mappings: "",
+  });
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "index.mjs"),
+    [
+      "const health = () => ({ ok: true });",
+      "export { health };",
+      `//# sourceMappingURL=data:application/json;charset=utf-8;base64,${Buffer.from(inlineJsMapPayload, "utf8").toString("base64")}`,
+      "",
+    ].join("\n"),
+  );
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "index.d.ts"),
+    [
+      "declare const health: () => { ok: boolean };",
+      "declare interface HealthStatus { ok: boolean; }",
+      "export { health as healthHandler };",
+      "export type { HealthStatus as PublicHealthStatus };",
+      "//# sourceMappingURL=maps/index.d.ts.map?rev=19#types",
+      "",
+    ].join("\n"),
+  );
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "maps", "index.d.ts.map"),
+    JSON.stringify({
+      version: 3,
+      file: "../index.d.ts",
+      sourceRoot: "../../src",
+      sources: ["routes/health.ts%3Ffrom%3Dtypes%23decl", "types/http.ts"],
+      names: [],
+      mappings: "",
+    }),
+  );
+
+  const buildResult: RunBuildResult = {
+    mode: "rust-engine-adapter",
+    manifestPath: "artifacts/manifests/manifest.json",
+    manifestIndexPath: "artifacts/manifests/index.json",
+    manifest: {
+      buildId: "1919191919191919",
+      entries: ["src/index.ts"],
+      bundles: [
+        {
+          file: "dist/index.mjs",
+          format: "esm",
+          exports: ["health"],
+        },
+      ],
+      types: ["dist/index.d.ts"],
+    },
+    diagnostics: [],
+  };
+
+  const ir = buildProgramIrFromArtifacts(buildResult, "src/index.ts", { cwd });
+  assert.deepEqual(
+    ir.modules.map((module) => module.sourcePath),
+    ["src/routes/health.ts", "src/types/http.ts"],
+  );
+  assert.deepEqual(ir.modules[0]?.exports, [
+    "healthHandler",
+    "PublicHealthStatus",
+  ]);
+  assert.deepEqual(ir.diagnostics, []);
+
+  const goOutDir = path.join(cwd, "dist-go");
+  emitGoProject(ir, goOutDir);
+  assertGoBuildSuccessIfToolchainAvailable(goOutDir);
+  await assertGoHealthRuntimeReady(goOutDir);
+});
+
 test("M1 regression: real JS+d.ts+sourcemap keeps stable symbol/type linkage for export type braces with query/hash map URL", () => {
   const cwd = fs.mkdtempSync(
     path.join(os.tmpdir(), "tsgodown-pipeline-dts-export-type-linkage-e2e-"),


### PR DESCRIPTION
## Summary
- add a regression e2e for mixed inline JS data URL sourcemap + external d.ts sourcemap where duplicate logical sources appear with raw vs percent-encoded query/hash suffixes
- normalize decoded non-file sourcemap source paths by stripping query/hash delimiters after percent-decoding
- preserve file:// URL path semantics so encoded path segments like  remain stable literal path content

## Validation
- pnpm lint
- pnpm format:check
- pnpm build
- pnpm examples:install-first:check
- pnpm test
- cargo test --workspace --all-targets
- pnpm gate:differential
- pnpm gate:compliance