### PR TITLE
fix(pipeline): dedupe mixed double-encoded JS and d.ts sourcemap roots

### DIFF
--- a/packages/pipeline/src/internal/artifact-to-ir.ts
+++ b/packages/pipeline/src/internal/artifact-to-ir.ts
@@ -718,7 +718,9 @@ function normalizeSourceMapSourcePath(params: {
   );
   const sourcePath = String(
     stripQueryAndHash(normalizeDecodedSourceMapPathSegment(params.sourcePath)),
-  );
+  )
+    .replace(/%2f/gi, "/")
+    .replace(/%5c/gi, "/");
   if (!sourcePath.trim()) {
     return undefined;
   }
@@ -820,8 +822,13 @@ function toFileSystemPath(value: unknown): string {
   }
 
   const trimmed = value.trim();
-  if (/^file:\/\//i.test(trimmed)) {
-    const normalizedFileUrl = trimmed.replace(/^file:\/\//i, "file://");
+
+  if (/^file:/i.test(trimmed)) {
+    const normalizedFileUrl = normalizeDoubleEncodedFileUrlPathSeparators(
+      /^file:\/\//i.test(trimmed)
+        ? trimmed.replace(/^file:\/\//i, "file://")
+        : trimmed.replace(/^file:/i, "file://"),
+    );
     try {
       return normalizePathSeparators(fileURLToPath(normalizedFileUrl));
     } catch {
@@ -841,6 +848,22 @@ function toFileSystemPath(value: unknown): string {
   } catch {
     return normalizePathSeparators(trimmed);
   }
+}
+
+function normalizeDoubleEncodedFileUrlPathSeparators(value: string): string {
+  let normalized = value;
+  for (let i = 0; i < 2; i += 1) {
+    const next = normalized.replace(/%252f/gi, "%2F").replace(/%255c/gi, "%5C");
+    if (next === normalized) {
+      break;
+    }
+    normalized = next;
+  }
+  if (/^file:\/\/%2f/i.test(normalized)) {
+    normalized = normalized.replace(/^file:\/\/%2f/i, "file:///");
+  }
+
+  return normalized;
 }
 
 function normalizePathSeparators(value: string): string {

--- a/packages/pipeline/test/pipeline.e2e.test.ts
+++ b/packages/pipeline/test/pipeline.e2e.test.ts
@@ -3013,6 +3013,99 @@ test("M1 regression: inline JS map + external d.ts map with encoded sourceRoot q
   assertGoBuildSuccessIfToolchainAvailable(goOutDir);
 });
 
+test("M1 regression: mixed JS double-encoded sourceRoot + d.ts encoded sourceRoot dedupe to stable canonical typed IR provenance", () => {
+  const cwd = fs.mkdtempSync(
+    path.join(os.tmpdir(), "tsgodown-pipeline-double-encoded-mixed-e2e-"),
+  );
+  tempDirs.push(cwd);
+
+  fs.mkdirSync(path.join(cwd, "dist", "maps"), { recursive: true });
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "index.mjs"),
+    [
+      "const health = () => ({ ok: true });",
+      "export { health };",
+      "//# sourceMappingURL=maps/index.mjs.map",
+      "",
+    ].join("\n"),
+  );
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "index.d.ts"),
+    [
+      "export declare const health: () => { ok: boolean };",
+      "export declare interface HealthResponse { ok: boolean }",
+      "//# sourceMappingURL=maps/index.d.ts.map",
+      "",
+    ].join("\n"),
+  );
+
+  const jsDoubleEncodedRoot = `file://${path
+    .join(cwd, "src")
+    .replaceAll("\\", "/")
+    .replaceAll("/", "%252F")}%252F`;
+  const dtsEncodedRoot = `file://${path
+    .join(cwd, "src")
+    .replaceAll("\\", "/")
+    .replaceAll("/", "%2F")}%2F`;
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "maps", "index.mjs.map"),
+    JSON.stringify({
+      version: 3,
+      file: "../index.mjs",
+      sourceRoot: jsDoubleEncodedRoot,
+      sources: ["routes%252Fhealth.ts"],
+      names: [],
+      mappings: "",
+    }),
+  );
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "maps", "index.d.ts.map"),
+    JSON.stringify({
+      version: 3,
+      file: "../index.d.ts",
+      sourceRoot: dtsEncodedRoot,
+      sources: ["routes/health.ts", "types/health-response.ts"],
+      names: [],
+      mappings: "",
+    }),
+  );
+
+  const buildResult: RunBuildResult = {
+    mode: "rust-engine-adapter",
+    manifestPath: "artifacts/manifests/manifest.json",
+    manifestIndexPath: "artifacts/manifests/index.json",
+    manifest: {
+      buildId: "d0aa11bb22cc33ee",
+      entries: ["src/index.ts"],
+      bundles: [
+        {
+          file: "dist/index.mjs",
+          map: "dist/maps/index.mjs.map",
+          format: "esm",
+          exports: ["health"],
+        },
+      ],
+      types: ["dist/index.d.ts"],
+    },
+    diagnostics: [],
+  };
+
+  const ir = buildProgramIrFromArtifacts(buildResult, "src/index.ts", { cwd });
+  assert.deepEqual(
+    ir.modules.map((module) => module.sourcePath),
+    ["src/routes/health.ts", "src/types/health-response.ts"],
+  );
+  assert.deepEqual(ir.diagnostics, []);
+
+  const goOutDir = path.join(cwd, "dist-go");
+  emitGoProject(ir, goOutDir);
+  assertGoBuildSuccessIfToolchainAvailable(goOutDir);
+});
+
 test("M1 regression: file URL sourcemap sources with percent-encoded slash stay deterministic across JS+d.ts typed IR and Go compile path", () => {
   const cwd = fs.mkdtempSync(
     path.join(os.tmpdir(), "tsgodown-pipeline-e2e-file-url-encoded-slash-"),


### PR DESCRIPTION
## Summary\n- add failing-first pipeline e2e regression for mixed sourcemap provenance where JS uses double-encoded sourceRoot/source paths (%252F) and d.ts uses standard encoded segments\n- normalize file URL path separators with double-encoding-aware handling and canonicalize mixed JS+d.ts provenance dedupe\n- keep typed IR provenance deterministic and preserve Go compile/run health-path regression behavior\n\n## Validation\n- pnpm lint\n- pnpm format:check\n- pnpm build\n- pnpm examples:install-first:check\n- pnpm test\n- cargo test --workspace --all-targets\n- pnpm gate:differential\n- pnpm gate:compliance