### PR TITLE
test(pipeline): cover JS+d.ts sourceRoot relative canonical resolution

### DIFF
--- a/packages/pipeline/test/pipeline.e2e.test.ts
+++ b/packages/pipeline/test/pipeline.e2e.test.ts
@@ -3293,6 +3293,95 @@ test("M1 regression: chained JS external sourcemap + inline d.ts sourcemap keep 
   assertGoBuildSuccessIfToolchainAvailable(goOutDir);
 });
 
+test("M1 regression: JS+d.ts sourcemap sourceRoot relative resolution canonicalizes shared logical source path", () => {
+  const cwd = fs.mkdtempSync(
+    path.join(
+      os.tmpdir(),
+      "tsgodown-pipeline-sourceroot-relative-resolution-canonical-",
+    ),
+  );
+  tempDirs.push(cwd);
+
+  fs.mkdirSync(path.join(cwd, "dist", "maps"), { recursive: true });
+  fs.mkdirSync(path.join(cwd, "src", "contracts"), { recursive: true });
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "index.mjs"),
+    [
+      "const health = () => ({ ok: true });",
+      "export { health };",
+      "//# sourceMappingURL=maps/index.mjs.map",
+      "",
+    ].join("\n"),
+  );
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "index.d.ts"),
+    [
+      "export declare const health: () => { ok: boolean };",
+      "export declare interface HealthContract { ok: boolean }",
+      "//# sourceMappingURL=maps/index.d.ts.map",
+      "",
+    ].join("\n"),
+  );
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "maps", "index.mjs.map"),
+    JSON.stringify({
+      version: 3,
+      file: "../index.mjs",
+      sourceRoot: new URL(`file://${path.join(cwd, "src")}/`).toString(),
+      sources: ["contracts/health.ts"],
+      names: [],
+      mappings: "",
+    }),
+  );
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "maps", "index.d.ts.map"),
+    JSON.stringify({
+      version: 3,
+      file: "../index.d.ts",
+      sourceRoot: new URL(`file://${path.join(cwd, "%73rc%2F")}`).toString(),
+      sources: ["./contracts/%68ealth.ts?from=dts#frag"],
+      names: [],
+      mappings: "",
+    }),
+  );
+
+  const buildResult: RunBuildResult = {
+    mode: "rust-engine-adapter",
+    manifestPath: "artifacts/manifests/manifest.json",
+    manifestIndexPath: "artifacts/manifests/index.json",
+    manifest: {
+      buildId: "88a40f5af7ec21d9",
+      entries: ["src/index.ts"],
+      bundles: [
+        {
+          file: "dist/index.mjs",
+          format: "esm",
+          exports: ["health"],
+        },
+      ],
+      types: ["dist/index.d.ts"],
+    },
+    diagnostics: [],
+  };
+
+  const ir = buildProgramIrFromArtifacts(buildResult, "src/index.ts", { cwd });
+
+  assert.deepEqual(
+    ir.modules.map((module) => module.sourcePath),
+    ["src/contracts/health.ts"],
+  );
+  assert.deepEqual(ir.modules[0]?.exports, ["health", "HealthContract"]);
+  assert.deepEqual(ir.diagnostics, []);
+
+  const goOutDir = path.join(cwd, "dist-go");
+  emitGoProject(ir, goOutDir);
+  assertGoBuildSuccessIfToolchainAvailable(goOutDir);
+});
+
 test("M1 regression: legacy //@ sourceMappingURL directives in JS+d.ts are discovered for typed IR provenance and Go compile path", () => {
   const cwd = fs.mkdtempSync(
     path.join(os.tmpdir(), "tsgodown-pipeline-legacy-at-sourcemap-directive-"),


### PR DESCRIPTION
## Summary
- add regression covering JS map sourceRoot+relative sources with d.ts map sourceRoot encoded/trailing variants
- assert both sourcemaps resolve to same logical source path in typed IR
- keep Go compilation smoke green for the resolved typed IR path

## Validation
- pnpm lint
- pnpm format:check
- pnpm build
- pnpm examples:install-first:check
- pnpm test
- cargo test --workspace --all-targets
- pnpm gate:differential
- pnpm gate:compliance