### PR TITLE
fix: dedupe inline JS + external d.ts.map sourceRoot query-encoded equivalents

### DIFF
--- a/packages/pipeline/src/internal/artifact-to-ir.ts
+++ b/packages/pipeline/src/internal/artifact-to-ir.ts
@@ -713,9 +713,14 @@ function normalizeSourceMapSourcePath(params: {
     return undefined;
   }
 
-  const sourceRootPath = normalizeDecodedSourceMapPathSegment(
+  const decodedSourceRootPath = normalizeDecodedSourceMapPathSegment(
     params.sourceRoot,
   );
+  const sourceRootQueryIndex = decodedSourceRootPath.indexOf("?");
+  const sourceRootPath =
+    sourceRootQueryIndex >= 0
+      ? decodedSourceRootPath.slice(0, sourceRootQueryIndex)
+      : decodedSourceRootPath;
   const sourcePath = String(
     stripQueryAndHash(normalizeDecodedSourceMapPathSegment(params.sourcePath)),
   )

--- a/packages/pipeline/test/pipeline.e2e.test.ts
+++ b/packages/pipeline/test/pipeline.e2e.test.ts
@@ -2369,6 +2369,97 @@ test("M1 regression: inline JS data URL sourcemap + external d.ts map dedupe dup
   await assertGoHealthRuntimeReady(goOutDir);
 });
 
+test("M1 regression: inline JS sourcemap + external d.ts.map dedupe canonical source when sourceRoot query markers are raw vs percent-encoded", async () => {
+  const cwd = fs.mkdtempSync(
+    path.join(
+      os.tmpdir(),
+      "tsgodown-pipeline-inline-external-sourceroot-fragment-canonical-e2e-",
+    ),
+  );
+  tempDirs.push(cwd);
+
+  fs.mkdirSync(path.join(cwd, "dist", "maps"), { recursive: true });
+  fs.mkdirSync(path.join(cwd, "src", "routes"), { recursive: true });
+
+  const inlineJsMapPayload = JSON.stringify({
+    version: 3,
+    file: "index.mjs",
+    sourceRoot: "../src?types=inline",
+    sources: ["routes/health.ts?from=inline#js"],
+    names: [],
+    mappings: "",
+  });
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "index.mjs"),
+    [
+      "const health = () => ({ ok: true });",
+      "export { health };",
+      `//# sourceMappingURL=data:application/json;base64,${Buffer.from(inlineJsMapPayload, "utf8").toString("base64")}`,
+      "",
+    ].join("\n"),
+  );
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "index.d.ts"),
+    [
+      "declare const health: () => { ok: boolean };",
+      "declare interface HealthStatus { ok: boolean; }",
+      "export { health as healthHandler };",
+      "export type { HealthStatus as PublicHealthStatus };",
+      "//# sourceMappingURL=maps/index.d.ts.map?rev=22#types",
+      "",
+    ].join("\n"),
+  );
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "maps", "index.d.ts.map"),
+    JSON.stringify({
+      version: 3,
+      file: "../index.d.ts",
+      sourceRoot: "..%2F..%2Fsrc%3Ftypes%3Dinline",
+      sources: ["routes/./health.ts%3Ffrom%3Dtypes%23decl"],
+      names: [],
+      mappings: "",
+    }),
+  );
+
+  const buildResult: RunBuildResult = {
+    mode: "rust-engine-adapter",
+    manifestPath: "artifacts/manifests/manifest.json",
+    manifestIndexPath: "artifacts/manifests/index.json",
+    manifest: {
+      buildId: "2222222222222222",
+      entries: ["src/index.ts"],
+      bundles: [
+        {
+          file: "dist/index.mjs",
+          format: "esm",
+          exports: ["health"],
+        },
+      ],
+      types: ["dist/index.d.ts"],
+    },
+    diagnostics: [],
+  };
+
+  const ir = buildProgramIrFromArtifacts(buildResult, "src/index.ts", { cwd });
+  assert.deepEqual(
+    ir.modules.map((module) => module.sourcePath),
+    ["src/routes/health.ts"],
+  );
+  assert.deepEqual(ir.modules[0]?.exports, [
+    "healthHandler",
+    "PublicHealthStatus",
+  ]);
+  assert.deepEqual(ir.diagnostics, []);
+
+  const goOutDir = path.join(cwd, "dist-go");
+  emitGoProject(ir, goOutDir);
+  assertGoBuildSuccessIfToolchainAvailable(goOutDir);
+  await assertGoHealthRuntimeReady(goOutDir);
+});
+
 test("M1 regression: real JS+d.ts+sourcemap keeps stable symbol/type linkage for export type braces with query/hash map URL", () => {
   const cwd = fs.mkdtempSync(
     path.join(os.tmpdir(), "tsgodown-pipeline-dts-export-type-linkage-e2e-"),


### PR DESCRIPTION
## Summary\n- add M1 regression covering inline JS sourcemap + external d.ts.map where equivalent source roots differ by raw vs percent-encoded query markers\n- assert typed IR canonical dedupe, typed export linkage, and Go compile/runtime health path\n- normalize decoded sourcemap sourceRoot by stripping decoded query suffixes for canonical path identity\n\n## Validation\n- pnpm lint\n- pnpm format:check\n- pnpm build\n- pnpm examples:install-first:check\n- pnpm test\n- cargo test --workspace --all-targets\n- pnpm gate:differential\n- pnpm gate:compliance