### PR TITLE
fix(pipeline): dedupe dist/src aliases in chained JS+d.ts sourcemaps

### DIFF
--- a/packages/pipeline/src/internal/artifact-to-ir.ts
+++ b/packages/pipeline/src/internal/artifact-to-ir.ts
@@ -264,12 +264,19 @@ function canonicalizeDeclarationCompanionPaths(entries: string[]): string[] {
   const entrySet = new Set(entries);
 
   for (const entry of entries) {
-    if (!entry.endsWith(".d.ts")) {
+    if (entry.endsWith(".d.ts")) {
+      const tsCandidate = `${entry.slice(0, -".d.ts".length)}.ts`;
+      if (entrySet.has(tsCandidate)) {
+        entrySet.delete(entry);
+      }
+    }
+
+    if (!entry.startsWith("dist/src/")) {
       continue;
     }
 
-    const tsCandidate = `${entry.slice(0, -".d.ts".length)}.ts`;
-    if (entrySet.has(tsCandidate)) {
+    const sourceCandidate = entry.slice("dist/".length);
+    if (entrySet.has(sourceCandidate)) {
       entrySet.delete(entry);
     }
   }

--- a/packages/pipeline/test/pipeline.e2e.test.ts
+++ b/packages/pipeline/test/pipeline.e2e.test.ts
@@ -3200,6 +3200,184 @@ test("M1 regression: chained JS external sourcemap + inline d.ts sourcemap keep 
   assertGoBuildSuccessIfToolchainAvailable(goOutDir);
 });
 
+test("M1 regression: JS+d.ts sourcemap sourceRoot relative resolution canonicalizes shared logical source path", () => {
+  const cwd = fs.mkdtempSync(
+    path.join(
+      os.tmpdir(),
+      "tsgodown-pipeline-sourceroot-relative-resolution-canonical-",
+    ),
+  );
+  tempDirs.push(cwd);
+
+  fs.mkdirSync(path.join(cwd, "dist", "maps"), { recursive: true });
+  fs.mkdirSync(path.join(cwd, "src", "contracts"), { recursive: true });
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "index.mjs"),
+    [
+      "const health = () => ({ ok: true });",
+      "export { health };",
+      "//# sourceMappingURL=maps/index.mjs.map",
+      "",
+    ].join("\n"),
+  );
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "index.d.ts"),
+    [
+      "export declare const health: () => { ok: boolean };",
+      "export declare interface HealthContract { ok: boolean }",
+      "//# sourceMappingURL=maps/index.d.ts.map",
+      "",
+    ].join("\n"),
+  );
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "maps", "index.mjs.map"),
+    JSON.stringify({
+      version: 3,
+      file: "../index.mjs",
+      sourceRoot: new URL(`file://${path.join(cwd, "src")}/`).toString(),
+      sources: ["contracts/health.ts"],
+      names: [],
+      mappings: "",
+    }),
+  );
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "maps", "index.d.ts.map"),
+    JSON.stringify({
+      version: 3,
+      file: "../index.d.ts",
+      sourceRoot: new URL(`file://${path.join(cwd, "%73rc%2F")}`).toString(),
+      sources: ["./contracts/%68ealth.ts?from=dts#frag"],
+      names: [],
+      mappings: "",
+    }),
+  );
+
+  const buildResult: RunBuildResult = {
+    mode: "rust-engine-adapter",
+    manifestPath: "artifacts/manifests/manifest.json",
+    manifestIndexPath: "artifacts/manifests/index.json",
+    manifest: {
+      buildId: "88a40f5af7ec21d9",
+      entries: ["src/index.ts"],
+      bundles: [
+        {
+          file: "dist/index.mjs",
+          format: "esm",
+          exports: ["health"],
+        },
+      ],
+      types: ["dist/index.d.ts"],
+    },
+    diagnostics: [],
+  };
+
+  const ir = buildProgramIrFromArtifacts(buildResult, "src/index.ts", { cwd });
+
+  assert.deepEqual(
+    ir.modules.map((module) => module.sourcePath),
+    ["src/contracts/health.ts"],
+  );
+  assert.deepEqual(ir.modules[0]?.exports, ["health", "HealthContract"]);
+  assert.deepEqual(ir.diagnostics, []);
+
+  const goOutDir = path.join(cwd, "dist-go");
+  emitGoProject(ir, goOutDir);
+  assertGoBuildSuccessIfToolchainAvailable(goOutDir);
+});
+
+test("M1 regression: chained JS+d.ts sourcemaps with mixed encoded URL/path forms keep one logical TS source + healthy Go runtime", async () => {
+  const cwd = fs.mkdtempSync(
+    path.join(
+      os.tmpdir(),
+      "tsgodown-pipeline-chained-encoded-logical-source-health-",
+    ),
+  );
+  tempDirs.push(cwd);
+
+  fs.mkdirSync(path.join(cwd, "dist", "maps"), { recursive: true });
+  fs.mkdirSync(path.join(cwd, "src", "routes"), { recursive: true });
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "index.mjs"),
+    [
+      "const health = () => ({ ok: true });",
+      "export { health };",
+      "//# sourceMappingURL=maps/index.mjs.map",
+      "",
+    ].join("\n"),
+  );
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "index.d.ts"),
+    [
+      "export declare const health: () => { ok: boolean };",
+      "export declare interface HealthContract { ok: boolean }",
+      "//# sourceMappingURL=maps/index.d.ts.map",
+      "",
+    ].join("\n"),
+  );
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "maps", "index.mjs.map"),
+    JSON.stringify({
+      version: 3,
+      file: "../index.mjs",
+      sourceRoot: new URL(`file://${path.join(cwd, "%73rc%2F")}`).toString(),
+      sources: ["routes/%68ealth.ts?from=js#bundle"],
+      names: [],
+      mappings: "",
+    }),
+  );
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "maps", "index.d.ts.map"),
+    JSON.stringify({
+      version: 3,
+      file: "../index.d.ts",
+      sourceRoot: "../%73rc/",
+      sources: ["./routes/health.ts%3Ffrom%3Ddts%23decl"],
+      names: [],
+      mappings: "",
+    }),
+  );
+
+  const buildResult: RunBuildResult = {
+    mode: "rust-engine-adapter",
+    manifestPath: "artifacts/manifests/manifest.json",
+    manifestIndexPath: "artifacts/manifests/index.json",
+    manifest: {
+      buildId: "a0ed4c86ddaa72f1",
+      entries: ["src/index.ts"],
+      bundles: [
+        {
+          file: "dist/index.mjs",
+          format: "esm",
+          exports: ["health"],
+        },
+      ],
+      types: ["dist/index.d.ts"],
+    },
+    diagnostics: [],
+  };
+
+  const ir = buildProgramIrFromArtifacts(buildResult, "src/index.ts", { cwd });
+  assert.deepEqual(
+    ir.modules.map((module) => module.sourcePath),
+    ["src/routes/health.ts"],
+  );
+  assert.deepEqual(ir.modules[0]?.exports, ["health", "HealthContract"]);
+  assert.deepEqual(ir.diagnostics, []);
+
+  const goOutDir = path.join(cwd, "dist-go");
+  emitGoProject(ir, goOutDir);
+  assertGoBuildSuccessIfToolchainAvailable(goOutDir);
+  await assertGoHealthRuntimeReady(goOutDir);
+});
+
 test("M1 regression: legacy //@ sourceMappingURL directives in JS+d.ts are discovered for typed IR provenance and Go compile path", () => {
   const cwd = fs.mkdtempSync(
     path.join(os.tmpdir(), "tsgodown-pipeline-legacy-at-sourcemap-directive-"),


### PR DESCRIPTION
## Summary
- add e2e regression for chained JS+d.ts sourcemaps that resolve one logical TS source via mixed encoded URL/path forms
- assert deterministic typed IR source identity and Go /health runtime smoke
- dedupe dist/src alias paths when canonical src path is also present

## Validation
- pnpm lint
- pnpm format:check
- pnpm build
- pnpm examples:install-first:check
- pnpm test
- cargo test --workspace --all-targets
- pnpm gate:differential
- pnpm gate:compliance