### PR TITLE
fix: stabilize d.ts sourcemap decode dedupe and typed provenance

### DIFF
--- a/packages/pipeline/src/internal/artifact-to-ir.ts
+++ b/packages/pipeline/src/internal/artifact-to-ir.ts
@@ -804,10 +804,11 @@ function stripQueryAndHash(value: unknown): unknown {
   }
 
   const afterHash = withoutQuery.slice(hashIndex + 1);
+  const decodedAfterHash = decodePathSegmentIfPossible(afterHash);
   if (
-    afterHash.includes("/") ||
-    afterHash.includes("\\") ||
-    /^[^/\\]+\.[A-Za-z0-9]+$/.test(afterHash)
+    decodedAfterHash.includes("/") ||
+    decodedAfterHash.includes("\\") ||
+    /^[^/\\]+\.[A-Za-z0-9]+$/.test(decodedAfterHash)
   ) {
     return withoutQuery;
   }
@@ -849,14 +850,23 @@ function toFileSystemPath(value: unknown): string {
         : trimmed.replace(/^file:/i, "file://"),
     );
     try {
-      return normalizePathSeparators(fileURLToPath(normalizedFileUrl));
+      const parsedUrl = new URL(normalizedFileUrl);
+      let normalizedFsPath = normalizePathSeparators(
+        fileURLToPath(normalizedFileUrl),
+      );
+      const decodedHashPayload = decodePathRepeatedly(parsedUrl.hash.slice(1));
+      if (decodedHashPayload && /[./\\]/.test(decodedHashPayload)) {
+        normalizedFsPath = `${normalizedFsPath.replace(/\/?$/, "/")}${decodedHashPayload}`;
+      }
+      return normalizePathSeparators(normalizedFsPath);
     } catch {
       try {
         const parsedUrl = new URL(normalizedFileUrl);
         let decodedPathname = decodePathRepeatedly(parsedUrl.pathname);
         const hashPayload = parsedUrl.hash.slice(1);
-        if (hashPayload && /[./\\]/.test(hashPayload)) {
-          decodedPathname = `${decodedPathname.replace(/\/?$/, "/")}${decodePathRepeatedly(hashPayload)}`;
+        const decodedHashPayload = decodePathRepeatedly(hashPayload);
+        if (decodedHashPayload && /[./\\]/.test(decodedHashPayload)) {
+          decodedPathname = `${decodedPathname.replace(/\/?$/, "/")}${decodedHashPayload}`;
         }
         const hostPrefix =
           parsedUrl.host && parsedUrl.hostname.toLowerCase() !== "localhost"

--- a/packages/pipeline/test/pipeline.e2e.test.ts
+++ b/packages/pipeline/test/pipeline.e2e.test.ts
@@ -3962,3 +3962,92 @@ test("M1 regression: JS+d.ts sourcemap provenance normalizes file://localhost au
   emitGoProject(ir, goOutDir);
   assertGoBuildSuccessIfToolchainAvailable(goOutDir);
 });
+
+test("M1 regression: file URL sourceRoot hash with percent-encoded path separators in d.ts map keeps typed IR provenance deterministic and deduped with JS map", () => {
+  const cwd = fs.mkdtempSync(
+    path.join(os.tmpdir(), "tsgodown-pipeline-fileurl-hash-encoded-sep-"),
+  );
+  tempDirs.push(cwd);
+
+  fs.mkdirSync(path.join(cwd, "dist", "maps"), { recursive: true });
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "index.mjs"),
+    [
+      "const health = () => ({ ok: true });",
+      "export { health };",
+      "//# sourceMappingURL=maps/index.mjs.map",
+      "",
+    ].join("\n"),
+  );
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "index.d.ts"),
+    [
+      "export declare const health: () => { ok: boolean };",
+      "export declare interface HealthPayload { ok: boolean }",
+      "//# sourceMappingURL=maps/index.d.ts.map",
+      "",
+    ].join("\n"),
+  );
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "maps", "index.mjs.map"),
+    JSON.stringify({
+      version: 3,
+      file: "../index.mjs",
+      sourceRoot: new URL(`file://${path.join(cwd, "src")}/`).toString(),
+      sources: ["routes/health.ts"],
+      names: [],
+      mappings: "",
+    }),
+  );
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "maps", "index.d.ts.map"),
+    JSON.stringify({
+      version: 3,
+      file: "../index.d.ts",
+      sourceRoot: `${new URL(`file://${path.join(cwd, "src")}`).toString()}#types%2F`,
+      sources: ["health.ts"],
+      names: [],
+      mappings: "",
+    }),
+  );
+
+  const buildResult: RunBuildResult = {
+    mode: "rust-engine-adapter",
+    manifestPath: "artifacts/manifests/manifest.json",
+    manifestIndexPath: "artifacts/manifests/index.json",
+    manifest: {
+      buildId: "24bb11cc22dd33ee",
+      entries: ["src/index.ts"],
+      bundles: [
+        {
+          file: "dist/index.mjs",
+          map: "dist/maps/index.mjs.map",
+          format: "esm",
+          exports: ["health"],
+        },
+      ],
+      types: ["dist/index.d.ts"],
+    },
+    diagnostics: [],
+  };
+
+  const ir = buildProgramIrFromArtifacts(buildResult, "src/index.ts", { cwd });
+  assert.deepEqual(
+    ir.modules.map((module) => module.sourcePath),
+    ["src/routes/health.ts", "src/types/health.ts"],
+  );
+
+  const typedModule = ir.modules.find(
+    (module) => module.sourcePath === "src/types/health.ts",
+  );
+  assert.deepEqual(typedModule?.exports, ["health", "HealthPayload"]);
+  assert.deepEqual(ir.diagnostics, []);
+
+  const goOutDir = path.join(cwd, "dist-go");
+  emitGoProject(ir, goOutDir);
+  assertGoBuildSuccessIfToolchainAvailable(goOutDir);
+});


### PR DESCRIPTION
## Summary
- add TDD regression for mixed single/double-decoded d.ts sourcemap source paths with JS sourceRoot trailing slash/dot variants
- ensure typed IR provenance dedupes deterministically and preserves typed exports through Go compile path
- normalize absolute-path-to-cwd mapping for drive-letter casing variance and separator style differences
- minimally harden sourcemap path decoding by bounded repeated decode to collapse encoded separator variants

## Validation
- pnpm lint
- pnpm format:check
- pnpm build
- pnpm examples:install-first:check
- pnpm test
- cargo test --workspace --all-targets
- pnpm gate:differential
- pnpm gate:compliance