### PR TITLE
fix: stabilize typed IR provenance for over-encoded sourcemap paths

### DIFF
--- a/packages/pipeline/src/internal/artifact-to-ir.ts
+++ b/packages/pipeline/src/internal/artifact-to-ir.ts
@@ -816,11 +816,25 @@ function stripQueryAndHash(value: unknown): unknown {
 }
 
 function decodePathSegmentIfPossible(value: string): string {
-  try {
-    return decodeURIComponent(value);
-  } catch {
-    return value;
+  return decodePathRepeatedly(value);
+}
+
+function decodePathRepeatedly(value: string, maxIterations = 4): string {
+  let decoded = value;
+
+  for (let i = 0; i < maxIterations; i += 1) {
+    try {
+      const next = decodeURIComponent(decoded);
+      if (next === decoded) {
+        return next;
+      }
+      decoded = next;
+    } catch {
+      return decoded;
+    }
   }
+
+  return decoded;
 }
 
 function decodeSourceMapUrlPath(sourceMapUrl: string): string {
@@ -853,10 +867,10 @@ function toFileSystemPath(value: unknown): string {
     } catch {
       try {
         const parsedUrl = new URL(normalizedFileUrl);
-        let decodedPathname = decodeURIComponent(parsedUrl.pathname);
+        let decodedPathname = decodePathRepeatedly(parsedUrl.pathname);
         const hashPayload = parsedUrl.hash.slice(1);
         if (hashPayload && /[./\\]/.test(hashPayload)) {
-          decodedPathname = `${decodedPathname.replace(/\/?$/, "/")}${decodeURIComponent(hashPayload)}`;
+          decodedPathname = `${decodedPathname.replace(/\/?$/, "/")}${decodePathRepeatedly(hashPayload)}`;
         }
         const hostPrefix =
           parsedUrl.host && parsedUrl.hostname.toLowerCase() !== "localhost"
@@ -869,11 +883,7 @@ function toFileSystemPath(value: unknown): string {
     }
   }
 
-  try {
-    return normalizePathSeparators(decodeURIComponent(trimmed));
-  } catch {
-    return normalizePathSeparators(trimmed);
-  }
+  return normalizePathSeparators(decodePathRepeatedly(trimmed));
 }
 
 function normalizeDoubleEncodedFileUrlPathSeparators(value: string): string {

--- a/packages/pipeline/test/pipeline.e2e.test.ts
+++ b/packages/pipeline/test/pipeline.e2e.test.ts
@@ -3962,3 +3962,91 @@ test("M1 regression: JS+d.ts sourcemap provenance normalizes file://localhost au
   emitGoProject(ir, goOutDir);
   assertGoBuildSuccessIfToolchainAvailable(goOutDir);
 });
+
+test("M1 regression: over-encoded d.ts sourcemap source separators still dedupe with JS sourcemap provenance and keep typed IR deterministic", () => {
+  const cwd = fs.mkdtempSync(
+    path.join(os.tmpdir(), "tsgodown-pipeline-overencoded-separator-e2e-"),
+  );
+  tempDirs.push(cwd);
+
+  fs.mkdirSync(path.join(cwd, "dist", "maps"), { recursive: true });
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "index.mjs"),
+    [
+      "const health = () => ({ ok: true });",
+      "export { health };",
+      "//# sourceMappingURL=maps/index.mjs.map",
+      "",
+    ].join("\n"),
+  );
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "index.d.ts"),
+    [
+      "export declare const health: () => { ok: boolean };",
+      "export declare interface HealthPayload { ok: boolean }",
+      "//# sourceMappingURL=maps/index.d.ts.map",
+      "",
+    ].join("\n"),
+  );
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "maps", "index.mjs.map"),
+    JSON.stringify({
+      version: 3,
+      file: "../index.mjs",
+      sourceRoot: "../../src/routes/../",
+      sources: ["routes/health.ts"],
+      names: [],
+      mappings: "",
+    }),
+  );
+
+  fs.writeFileSync(
+    path.join(cwd, "dist", "maps", "index.d.ts.map"),
+    JSON.stringify({
+      version: 3,
+      file: "../index.d.ts",
+      sourceRoot: "../../src",
+      sources: ["types%252525252Fhealth-payload.ts", "routes%2Fhealth.ts"],
+      names: [],
+      mappings: "",
+    }),
+  );
+
+  const buildResult: RunBuildResult = {
+    mode: "rust-engine-adapter",
+    manifestPath: "artifacts/manifests/manifest.json",
+    manifestIndexPath: "artifacts/manifests/index.json",
+    manifest: {
+      buildId: "55aa66bb77cc88dd",
+      entries: ["src/index.ts"],
+      bundles: [
+        {
+          file: "dist/index.mjs",
+          map: "dist/maps/index.mjs.map",
+          format: "esm",
+          exports: ["health"],
+        },
+      ],
+      types: ["dist/index.d.ts"],
+    },
+    diagnostics: [],
+  };
+
+  const ir = buildProgramIrFromArtifacts(buildResult, "src/index.ts", { cwd });
+  assert.deepEqual(
+    ir.modules.map((module) => module.sourcePath),
+    ["src/routes/health.ts", "src/types/health-payload.ts"],
+  );
+  const typedModule = ir.modules.find(
+    (module) => module.sourcePath === "src/types/health-payload.ts",
+  );
+  assert.deepEqual(typedModule?.exports, ["health", "HealthPayload"]);
+  assert.deepEqual(ir.diagnostics, []);
+
+  const goOutDir = path.join(cwd, "dist-go");
+  emitGoProject(ir, goOutDir);
+  assertGoBuildSuccessIfToolchainAvailable(goOutDir);
+});


### PR DESCRIPTION
## Summary
- add TDD regression for combined JS + d.ts + sourcemap artifacts where d.ts source paths contain over-encoded separators
- keep typed IR module provenance deterministic and deduped across JS/d.ts sourcemaps
- apply minimal bounded repeated path decoding to canonicalize over-encoded sourcemap path segments

## Checks
- pnpm lint
- pnpm format:check
- pnpm build
- pnpm examples:install-first:check
- pnpm test
- cargo test --workspace --all-targets
- pnpm gate:differential
- pnpm gate:compliance