### PR TITLE
pipeline: stabilize deterministic module IDs in artifact->IR mapping

### DIFF
--- a/packages/pipeline/src/internal/artifact-to-ir.ts
+++ b/packages/pipeline/src/internal/artifact-to-ir.ts
@@ -37,18 +37,16 @@ export function buildProgramIrFromArtifacts(
 
   const typedExports = collectTypedExports(buildResult, cwd, diagnostics);
 
-  const modules = moduleEntries
-    .map((manifestEntry, index) => ({
-      id: `module_${index}`,
-      sourcePath: manifestEntry,
-      exports: typedExports,
-      imports: [],
-    }))
-    .sort((a, b) =>
-      a.sourcePath === b.sourcePath
-        ? a.id.localeCompare(b.id)
-        : a.sourcePath.localeCompare(b.sourcePath),
-    );
+  const sortedModuleEntries = [...moduleEntries].sort((a, b) =>
+    a.localeCompare(b),
+  );
+
+  const modules = sortedModuleEntries.map((manifestEntry, index) => ({
+    id: `module_${index}`,
+    sourcePath: manifestEntry,
+    exports: typedExports,
+    imports: [],
+  }));
 
   const primaryHandlerId = "health";
 


### PR DESCRIPTION
## Summary\n- sort normalized module source entries before assigning module IDs\n- ensure module id/index assignment is stable for equivalent JS + d.ts + sourcemap provenance sets\n- keep Rust as analysis source-of-truth while TS stays deterministic orchestration\n\n## Validation\n- pnpm run lint\n- pnpm run typecheck\n- pnpm run test