### PR TITLE
pipeline: preserve default d.ts export in typed IR exports

### DIFF
--- a/packages/pipeline/src/internal/artifact-to-ir.ts
+++ b/packages/pipeline/src/internal/artifact-to-ir.ts
@@ -140,6 +140,14 @@ function collectTypedExports(
 
     for (const line of sourceText.split(/\r?\n/)) {
       const trimmed = line.trim();
+
+      const defaultExportMatch = trimmed.match(
+        /^export\s+default\s+(?:declare\s+)?(?:async\s+)?(?:function|class)\b/,
+      );
+      if (defaultExportMatch) {
+        exportedNames.add("default");
+      }
+
       const match = trimmed.match(
         /^export\s+(?:declare\s+)?(?:async\s+)?(?:function|const|let|var|class|type|interface|enum)\s+([A-Za-z_$][A-Za-z0-9_$]*)/,
       );


### PR DESCRIPTION
## Summary
- detect export default function/class declarations while parsing .d.ts typed export metadata
- keep named export parsing unchanged and deterministic
- ensure typed IR export list can include default for Go compile path parity

## Testing
- pnpm install --frozen-lockfile
- pnpm run lint
- pnpm run format:check
- pnpm run build
- pnpm run examples:install-first:check
- pnpm run test
- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace --all-targets
- node scripts/guard-compiler-mode-only.mjs
- node scripts/guard-core-path-no-framework-branching.mjs
- node --test scripts/guard-core-path-no-framework-branching.test.mjs
- pnpm run gate:differential
- pnpm run gate:compliance
- ./scripts/smoke-m1.sh